### PR TITLE
Add zombie emission functions

### DIFF
--- a/functions/zombification/fn_spawnZombiesFromQueue.sqf
+++ b/functions/zombification/fn_spawnZombiesFromQueue.sqf
@@ -1,1 +1,26 @@
-// functions/zombification/fn_spawnZombiesFromQueue.sqf stub
+// Spawn zombies from the tracked corpse queue once the emission ends
+
+// read and clear the queue
+private _queue = missionNamespace getVariable ["ALF_zombieQueue", []];
+missionNamespace setVariable ["ALF_zombieQueue", []];
+
+// list of WebKnight zombie classes
+private _zClasses = [
+    "WBK_Zombie1",
+    "WBK_Zombie2",
+    "WBK_Zombie3"
+];
+
+{
+    private _corpse = _x;
+    if (!isNull _corpse) then {
+        private _pos = getPosATL _corpse;
+        private _dir = getDir _corpse;
+        deleteVehicle _corpse;
+
+        private _class = selectRandom _zClasses;
+        private _zombie = createVehicle [_class, _pos, [], 0, "NONE"];
+        _zombie setDir _dir;
+    };
+} forEach _queue;
+

--- a/functions/zombification/fn_trackDeadForZombify.sqf
+++ b/functions/zombification/fn_trackDeadForZombify.sqf
@@ -1,1 +1,16 @@
-// functions/zombification/fn_trackDeadForZombify.sqf stub
+// Collect units that die during an emission so they can be turned into zombies
+
+params ["_unit"];
+
+// only track during an active emission
+if !(missionNamespace getVariable ["ALF_emissionActive", false]) exitWith {};
+
+// ensure queue exists
+private _queue = missionNamespace getVariable ["ALF_zombieQueue", []];
+
+if (!isNull _unit) then {
+    _queue pushBack _unit;
+};
+
+missionNamespace setVariable ["ALF_zombieQueue", _queue];
+


### PR DESCRIPTION
## Summary
- implement tracking of deaths during emissions
- spawn WebKnight zombies from tracked corpses

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68479811f870832fa454a465b9e5d9ee