### PR TITLE
Add psy storm scheduling and trigger functions

### DIFF
--- a/functions/storms/fn_schedulePsyStorms.sqf
+++ b/functions/storms/fn_schedulePsyStorms.sqf
@@ -1,1 +1,40 @@
-// functions/storms/fn_schedulePsyStorms.sqf stub
+/*
+    Author: Codex
+    Description:
+        Periodically schedules psy storms or listens for a manual trigger.
+        If a variable name is provided as third parameter the storm will
+        also trigger whenever that variable is set to true in the mission
+        namespace.
+
+    Params:
+        0: NUMBER - minimum delay between storms in seconds (default 1800)
+        1: NUMBER - maximum delay between storms in seconds (default 3600)
+        2: STRING - missionNamespace variable used for manual trigger (optional)
+*/
+
+params [
+    ["_minDelay", 1800],
+    ["_maxDelay", 3600],
+    ["_manualVar", ""]
+];
+
+if (_minDelay < 0) then { _minDelay = 0; };
+if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
+
+[_minDelay, _maxDelay, _manualVar] spawn {
+    params ["_min", "_max", "_var"];
+    private _nextStorm = time + (_min + random (_max - _min));
+    while {true} do {
+        if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
+            missionNamespace setVariable [_var, false, true];
+            [] call AL_fnc_triggerPsyStorm;
+            _nextStorm = time + (_min + random (_max - _min));
+        };
+
+        if (time >= _nextStorm) then {
+            [] call AL_fnc_triggerPsyStorm;
+            _nextStorm = time + (_min + random (_max - _min));
+        };
+        sleep 5;
+    };
+};

--- a/functions/storms/fn_triggerPsyStorm.sqf
+++ b/functions/storms/fn_triggerPsyStorm.sqf
@@ -1,1 +1,60 @@
-// functions/storms/fn_triggerPsyStorm.sqf stub
+/*
+    Author: Codex
+    Description:
+        Applies screen effects and optional hallucinations, damages exposed units
+        and can spawn spooks or zombies.
+
+    Params:
+        0: NUMBER - duration of the storm in seconds (default 60)
+        1: NUMBER - damage applied to exposed units per tick (default 0.03)
+        2: BOOL   - enable hallucination effects (default true)
+        3: BOOL   - spawn spook zone when finished (default false)
+        4: BOOL   - spawn zombies when finished (default false)
+*/
+
+params [
+    ["_duration", 60],
+    ["_damage", 0.03],
+    ["_hallucinations", true],
+    ["_spawnSpooks", false],
+    ["_spawnZombies", false]
+];
+
+private _effect = ppEffectCreate ["ColorCorrections", 1500];
+_effect ppEffectEnable true;
+_effect ppEffectAdjust [0.2, 1, 0, [1,0.2,1,0.2], [0,0,0,1], [1,1,1,0]];
+_effect ppEffectCommit 0;
+
+private _ticks = floor _duration;
+for "_i" from 1 to _ticks do {
+    {
+        if (alive _x) then {
+            private _from = eyePos _x;
+            private _to = _from vectorAdd [0,0,50];
+            if (lineIntersectsSurfaces [_from, _to, _x, objNull, true] isEqualTo []) then {
+                _x setDamage ((damage _x) + _damage);
+            };
+        };
+    } forEach allUnits;
+
+    if (_hallucinations && {random 1 < 0.15}) then {
+        private _sounds = [
+            "a3\sounds_f\characters\human-sfx\personality\tired-breathing-02.wss",
+            "a3\sounds_f\sfx\alarm_independent.wss"
+        ];
+        playSound3D [selectRandom _sounds, player];
+    };
+
+    sleep 1;
+};
+
+_effect ppEffectEnable false;
+ppEffectDestroy _effect;
+
+if (_spawnSpooks) then {
+    [] call AL_fnc_spawnSpookZone;
+};
+
+if (_spawnZombies) then {
+    [] call AL_fnc_spawnZombiesFromQueue;
+};


### PR DESCRIPTION
## Summary
- implement `fn_schedulePsyStorms` to periodically start psy storms and react to manual variable triggers
- implement `fn_triggerPsyStorm` to apply screen effects, damage units and optionally spawn spooks or zombies

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684798131df4832f8dc331af7327446a