### PR TITLE
Implement mutant spawns

### DIFF
--- a/cba_settings.sqf
+++ b/cba_settings.sqf
@@ -1,1 +1,11 @@
-// cba_settings.sqf placeholder
+/* Default CBA settings for ALife systems */
+
+// Hostile mutant spawns
+["ALF_mutantGroupCount", "SLIDER", [1, 5, 1], 1, "Number of mutant groups after an emission"] call CBA_fnc_addSetting;
+["ALF_mutantThreat", "SLIDER", [1, 10, 1], 3, "Units per hostile group"] call CBA_fnc_addSetting;
+["ALF_mutantNightOnly", "CHECKBOX", false, "Spawn hostile groups only at night"] call CBA_fnc_addSetting;
+
+// Ambient herds
+["ALF_ambientHerdCount", "SLIDER", [0, 5, 1], 2, "Number of roaming herds"] call CBA_fnc_addSetting;
+["ALF_ambientHerdSize", "SLIDER", [1, 8, 1], 4, "Units per roaming herd"] call CBA_fnc_addSetting;
+["ALF_ambientNightOnly", "CHECKBOX", false, "Spawn herds only at night"] call CBA_fnc_addSetting;

--- a/functions/mutants/fn_spawnAmbientHerds.sqf
+++ b/functions/mutants/fn_spawnAmbientHerds.sqf
@@ -1,1 +1,26 @@
-// functions/mutants/fn_spawnAmbientHerds.sqf stub
+/*
+    Spawns passive mutant herds roaming the world.
+    Settings via CBA:
+      - ALF_ambientHerdCount: number of herds to spawn (default 2)
+      - ALF_ambientHerdSize:  units per herd (default 4)
+      - ALF_ambientNightOnly: spawn only at night if true (default false)
+*/
+
+if (!isServer) exitWith {};
+
+private _herdCount = ["ALF_ambientHerdCount", 2] call CBA_fnc_getSetting;
+private _herdSize  = ["ALF_ambientHerdSize", 4]  call CBA_fnc_getSetting;
+private _nightOnly = ["ALF_ambientNightOnly", false] call CBA_fnc_getSetting;
+
+if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
+
+for "_i" from 1 to _herdCount do {
+    private _pos = [random worldSize, random worldSize, 0];
+    private _grp = createGroup civilian;
+    for "_j" from 1 to _herdSize do {
+        private _unit = _grp createUnit ["C_ALF_Mutant", _pos, [], 0, "FORM"];
+        _unit disableAI "TARGET";
+        _unit disableAI "AUTOTARGET";
+    };
+    [_grp, _pos] call BIS_fnc_taskPatrol;
+};

--- a/functions/mutants/fn_spawnMutantGroup.sqf
+++ b/functions/mutants/fn_spawnMutantGroup.sqf
@@ -1,1 +1,27 @@
-// functions/mutants/fn_spawnMutantGroup.sqf stub
+/*
+    Spawns hostile mutant groups after an emission.
+    Settings are retrieved via CBA:
+      - ALF_mutantGroupCount: how many groups to spawn (default 1)
+      - ALF_mutantThreat:    how many units per group (default 3)
+      - ALF_mutantNightOnly: only spawn at night if true (default false)
+
+    _centerPos - position around which groups will appear
+*/
+params ["_centerPos"];
+
+if (!isServer) exitWith {};
+
+private _groupCount = ["ALF_mutantGroupCount", 1] call CBA_fnc_getSetting;
+private _threat     = ["ALF_mutantThreat", 3]     call CBA_fnc_getSetting;
+private _nightOnly  = ["ALF_mutantNightOnly", false] call CBA_fnc_getSetting;
+
+if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
+
+for "_i" from 1 to _groupCount do {
+    private _spawnPos = _centerPos getPos [100 + random 100, random 360];
+    private _grp = createGroup east;
+    for "_j" from 1 to _threat do {
+        _grp createUnit ["O_ALF_Mutant", _spawnPos, [], 0, "FORM"];
+    };
+    [_grp, _spawnPos] call BIS_fnc_taskPatrol;
+};


### PR DESCRIPTION
## Summary
- add CBA settings for ALife mutant behaviour
- spawn hostile mutant groups during emissions
- spawn roaming ambient herds

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684798148f38832fb3776605db22a231