### PR TITLE
Implement radiation zone creation and cleanup

### DIFF
--- a/functions/radiation/fn_cleanupRadiationZones.sqf
+++ b/functions/radiation/fn_cleanupRadiationZones.sqf
@@ -1,1 +1,27 @@
-// functions/radiation/fn_cleanupRadiationZones.sqf stub
+/*
+    Removes expired Chemical Warfare Plus contamination zones.
+    The zones are stored in `STALKER_radiationZones` with their
+    expiration time as returned by `fn_spawnRadiationZone`.
+
+    This function should be called periodically, e.g. from a scheduler
+    that runs after emissions.
+*/
+
+if (isNil "STALKER_radiationZones") exitWith {};
+
+private _now = diag_tickTime;
+
+for [{_i = (count STALKER_radiationZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
+    private _entry = STALKER_radiationZones select _i;
+    private _zoneHandle = _entry select 0;
+    private _expires = _entry select 1;
+
+    if (_now > _expires) then {
+        // Delete the zone using the Chemical Warfare Plus function
+        [_zoneHandle] call CWP_fnc_removeZone;
+
+        STALKER_radiationZones deleteAt _i;
+    };
+};
+
+true

--- a/functions/radiation/fn_spawnRadiationZone.sqf
+++ b/functions/radiation/fn_spawnRadiationZone.sqf
@@ -1,1 +1,44 @@
-// functions/radiation/fn_spawnRadiationZone.sqf stub
+/*
+    Spawns a Chemical Warfare Plus contamination zone at the given
+    position. The created zone will be automatically removed after the
+    duration configured by `STALKER_radiationZoneDuration` (in seconds).
+
+    Params:
+        0: POSITION - center of the contamination area.
+        1: NUMBER   - radius of the zone in meters (default: 50).
+
+    Returns:
+        ANY - handle returned by the CWP creation function.
+*/
+
+params [
+    ["_position", [0,0,0]],
+    ["_radius", 50]
+];
+
+// Array to keep track of active zones and their expiration times
+if (isNil "STALKER_radiationZones") then {
+    STALKER_radiationZones = [];
+};
+
+// Fallback to fifteen minutes if the mission maker has not set a value
+private _duration = missionNamespace getVariable [
+    "STALKER_radiationZoneDuration",
+    900
+];
+
+// Spawn the zone using Chemical Warfare Plus. The mod is expected to
+// provide `CWP_fnc_createZone` which returns a zone handle that can be
+// later passed to `CWP_fnc_removeZone` for cleanup.
+private _zoneHandle = [
+    _position,
+    _radius
+] call CWP_fnc_createZone;
+
+// Record the zone and when it should be removed
+STALKER_radiationZones pushBack [
+    _zoneHandle,
+    diag_tickTime + _duration
+];
+
+_zoneHandle


### PR DESCRIPTION
## Summary
- implement `fn_spawnRadiationZone` to spawn Chemical Warfare Plus contamination zones
- implement `fn_cleanupRadiationZones` to delete zones after they expire

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684798153788832fb0b0ade020c29fdb