### PR TITLE
Implement spook zone spawning

### DIFF
--- a/functions/spooks/fn_setupSpookZones.sqf
+++ b/functions/spooks/fn_setupSpookZones.sqf
@@ -1,1 +1,23 @@
-// functions/spooks/fn_setupSpookZones.sqf stub
+/*
+    Author: STALKER ALife Script
+    Description:
+        Finds potential positions for Drongo's spook zones near buildings such as
+        graveyards, churches and ruins.
+
+    Returns:
+        ARRAY - list of positions suitable for spook zones.
+*/
+
+private _candidates = [];
+
+{
+    private _type = toLower (typeOf _x);
+    if (
+        {_type find _x > -1} count ["church","chapel","grave","cemetery","ruin"] > 0
+    ) then {
+        _candidates pushBack (getPosATL _x);
+    };
+} forEach (allMissionObjects "building");
+
+drg_spook_zone_positions = _candidates;
+_candidates

--- a/functions/spooks/fn_spawnSpookZone.sqf
+++ b/functions/spooks/fn_spawnSpookZone.sqf
@@ -1,1 +1,38 @@
-// functions/spooks/fn_spawnSpookZone.sqf stub
+/*
+    Author: STALKER ALife Script
+    Description:
+        Spawns a set of Drongo's spook zones using locations gathered by
+        fn_setupSpookZones.sqf. The number of zones spawned is controlled by
+        STALKER_MinSpookFields and STALKER_MaxSpookFields. Each zone persists
+        for STALKER_SpookDuration minutes.
+*/
+
+if (isNil "drg_spook_zone_positions") then {
+    [] call compile preprocessFileLineNumbers "functions/spooks/fn_setupSpookZones.sqf";
+};
+
+private _min = missionNamespace getVariable ["STALKER_MinSpookFields",1];
+private _max = missionNamespace getVariable ["STALKER_MaxSpookFields",3];
+private _duration = missionNamespace getVariable ["STALKER_SpookDuration",15];
+
+private _count = round random [_min, _max, _max];
+if (_count < _min) then { _count = _min; };
+
+if (isNil "drg_activeSpookZones") then { drg_activeSpookZones = []; };
+
+for "_i" from 1 to _count do {
+    private _pos = selectRandom drg_spook_zone_positions;
+    if (!isNil "_pos") then {
+        private _zone = createTrigger ["EmptyDetector", _pos];
+        _zone setTriggerArea [25,25,0,false];
+        _zone setVariable ["isSpookZone", true];
+        drg_activeSpookZones pushBack _zone;
+        [_zone, _duration] spawn {
+            params ["_zone","_dur"];
+            sleep (_dur * 60);
+            if (!isNull _zone) then {
+                deleteVehicle _zone;
+            };
+        };
+    };
+};

--- a/initServer.sqf
+++ b/initServer.sqf
@@ -1,1 +1,12 @@
-// initServer.sqf placeholder
+// Server initialization for STALKER ALife
+
+// Spook zone configuration
+STALKER_MinSpookFields = 2;      // minimum zones spawned per emission
+STALKER_MaxSpookFields = 5;      // maximum zones spawned per emission
+STALKER_SpookDuration  = 15;     // minutes zones remain active
+
+drg_activeSpookZones = [];
+
+// Prepare spook zone locations
+[] call compile preprocessFileLineNumbers "functions/spooks/fn_setupSpookZones.sqf";
+


### PR DESCRIPTION
## Summary
- set up Drongo's spook zone locations on server start
- spawn configurable spook fields from those locations
- allow setting field count and duration

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684798166548832f81c4fb78b4fc48a2