### PR TITLE
Add visual markers for spawned zones

### DIFF
--- a/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/functions/anomalies/fields/fn_createField_burner.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_burner;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_burner_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Burner 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "burner"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_clicker;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_clicker_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Clicker 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "clicker"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/functions/anomalies/fields/fn_createField_electra.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_electra;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_electra_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Electra 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "electra"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_fruitpunch;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_fruitpunch_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Fruitpunch 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "fruitpunch"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_gravi;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_gravi_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Gravi 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "gravi"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_meatgrinder;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_meatgrinder_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Meatgrinder 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "meatgrinder"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_springboard;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_springboard_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Springboard 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "springboard"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -11,10 +11,21 @@ params ["_center","_radius", ["_count",5]];
 private _site = [_center,_radius] call VIC_fnc_findSite_whirligig;
 if (_site isEqualTo []) exitWith { [] };
 
+// Create a marker for this anomaly field
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_whirligig_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [10,10];
+_marker setMarkerColor "ColorOrange";
+_marker setMarkerText "Whirligig 10m";
+STALKER_anomalyMarkers pushBack _marker;
+
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
     private _anom = [_pos, "whirligig"] call diwako_anomalies_fnc_spawnAnomaly;
+    _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };
 _spawned

--- a/functions/radiation/fn_cleanupRadiationZones.sqf
+++ b/functions/radiation/fn_cleanupRadiationZones.sqf
@@ -14,11 +14,14 @@ private _now = diag_tickTime;
 for [{_i = (count STALKER_radiationZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
     private _entry = STALKER_radiationZones select _i;
     private _zoneHandle = _entry select 0;
-    private _expires = _entry select 1;
+    private _marker = _entry select 1;
+    private _expires = _entry select 2;
 
     if (_now > _expires) then {
         // Delete the zone using the Chemical Warfare Plus function
         [_zoneHandle] call CWP_fnc_removeZone;
+
+        if (!isNil {_marker}) then { deleteMarker _marker; };
 
         STALKER_radiationZones deleteAt _i;
     };

--- a/functions/radiation/fn_spawnRadiationZone.sqf
+++ b/functions/radiation/fn_spawnRadiationZone.sqf
@@ -35,9 +35,18 @@ private _zoneHandle = [
     _radius
 ] call CWP_fnc_createZone;
 
+// Create and configure a map marker for this radiation zone
+private _markerName = format ["rad_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _position];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [_radius, _radius];
+_marker setMarkerColor "ColorYellow";
+_marker setMarkerText format ["Radiation %1m", _radius];
+
 // Record the zone and when it should be removed
 STALKER_radiationZones pushBack [
     _zoneHandle,
+    _marker,
     diag_tickTime + _duration
 ];
 

--- a/functions/spooks/fn_spawnSpookZone.sqf
+++ b/functions/spooks/fn_spawnSpookZone.sqf
@@ -33,11 +33,25 @@ for "_i" from 1 to _count do {
         private _zone = createTrigger ["EmptyDetector", _pos];
         _zone setTriggerArea [25,25,0,false];
         _zone setVariable ["isSpookZone", true];
+
+        // Create a map marker so the zone is visible for debugging or admin use
+        private _markerName = format ["spook_%1", diag_tickTime];
+        private _marker = createMarker [_markerName, _pos];
+        _marker setMarkerShape "ELLIPSE";
+        _marker setMarkerSize [25,25];
+        _marker setMarkerColor "ColorBlack";
+        _marker setMarkerText "Spook 25m";
+
+        // Store the marker reference on the zone for later cleanup
+        _zone setVariable ["zoneMarker", _marker];
+
         drg_activeSpookZones pushBack _zone;
         [_zone, _duration] spawn {
             params ["_zone","_dur"];
             sleep (_dur * 60);
             if (!isNull _zone) then {
+                private _m = _zone getVariable ["zoneMarker", ""];
+                if (_m isNotEqualTo "") then { deleteMarker _m; };
                 deleteVehicle _zone;
             };
         };


### PR DESCRIPTION
## Summary
- show map markers when spook zones spawn
- create radiation zone markers and track them for removal
- clean up radiation markers once zones expire
- visualize anomaly field centers with markers

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68482110bf04832fa3d7feee4611fe48