### PR TITLE
Add branding assets to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Mission makers can tweak or remove individual systems as needed. Most features a
 
 These mods must be loaded for the scripts in this repository to function correctly.
 
+## Branding
+
+The repository ships with `logo.paa` as the main logo and `Icon.paa` for smaller
+launcher displays. These images are referenced in `config.cpp` so that Arma 3
+shows the mod's branding in the launcher and in-game menus.
+
 ## License
 
 This project is licensed under the **Arma Public License Share Alike (APL-SA)**.

--- a/config.cpp
+++ b/config.cpp
@@ -100,3 +100,22 @@ class CfgFunctions
     };
 };
 
+class CfgMods
+{
+    class VIC_StalkerALife
+    {
+        dir = "Viceroys-STALKER-ALife";
+        picture = "logo.paa";
+        logo = "logo.paa";
+        logoOver = "logo.paa";
+        logoSmall = "Icon.paa";
+        tooltip = "VIC STALKER ALife";
+        name = "Viceroy's STALKER ALife";
+        actionName = "Website";
+        action = "https://github.com/Viceroyman";
+        description = "Dynamic ALife system for S.T.A.L.K.E.R.-style missions.";
+        hideName = 0;
+        hidePicture = 0;
+    };
+};
+


### PR DESCRIPTION
## Summary
- reference mod icon and logo in `config.cpp`
- document bundled branding assets in README

## Testing
- `grep -n logo.paa config.cpp`

------
https://chatgpt.com/codex/tasks/task_e_68482c5f7ca8832fa196ba9e1c1bd6c8