### PR TITLE
Assign distinct colors to anomaly markers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_clicker_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Clicker fields get a pink marker
+_marker setMarkerColor "ColorPink";
 _marker setMarkerText "Clicker 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_electra_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Use blue for electra fields
+_marker setMarkerColor "ColorBlue";
 _marker setMarkerText "Electra 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_fruitpunch_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Use green to distinguish fruit punch fields
+_marker setMarkerColor "ColorGreen";
 _marker setMarkerText "Fruitpunch 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_gravi_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Brown marker helps identify gravi fields
+_marker setMarkerColor "ColorBrown";
 _marker setMarkerText "Gravi 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_meatgrinder_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Meatgrinder zones use a red marker
+_marker setMarkerColor "ColorRed";
 _marker setMarkerText "Meatgrinder 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_springboard_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Springboard markers use khaki for visibility
+_marker setMarkerColor "ColorKhaki";
 _marker setMarkerText "Springboard 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -18,7 +18,8 @@ private _markerName = format ["anom_whirligig_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorOrange";
+// Whirligig fields are marked with white
+_marker setMarkerColor "ColorWhite";
 _marker setMarkerText "Whirligig 10m";
 STALKER_anomalyMarkers pushBack _marker;
 


### PR DESCRIPTION
## Summary
- give each anomaly field a unique color marker
  - burners remain orange
  - fruitpunch is green
  - electra is blue
  - clicker is pink
  - gravi is brown
  - meatgrinder is red
  - springboard is khaki
  - whirligig is white

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684842927d90832f83b4576df6a05750