### PR TITLE
Add limit for anomaly fields

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -38,6 +38,14 @@
 ] call CBA_fnc_addSetting;
 
 [
+    "VSA_maxAnomalyFields",
+    "SLIDER",
+    ["Max Active Fields", "Maximum number of anomaly fields present at once"],
+    "VSA - Anomalies",
+    [20, 0, 100, 0]
+] call CBA_fnc_addSetting;
+
+[
     "VSA_anomalySpawnWeight",
     "SLIDER",
     ["Anomaly Spawn Weight", "Relative spawn chance of anomaly types"],

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -10,6 +10,10 @@ params ["_center","_radius"];
 
 if (["VSA_enableAnomalies", true] call CBA_fnc_getSetting isEqualTo false) exitWith {};
 
+// Prepare anomaly marker tracking
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _maxFields = ["VSA_maxAnomalyFields", 20] call CBA_fnc_getSetting;
+
 private _fieldCount = ["VSA_anomalyFieldCount", 3] call CBA_fnc_getSetting;
 private _spawnWeight = ["VSA_anomalySpawnWeight", 50] call CBA_fnc_getSetting;
 private _nightOnly   = ["VSA_anomalyNightOnly", false] call CBA_fnc_getSetting;
@@ -30,6 +34,7 @@ private _types = [
 ];
 
 for "_i" from 1 to _fieldCount do {
+    if ((count STALKER_anomalyMarkers) >= _maxFields) exitWith {};
     if (random 100 >= _spawnWeight) then { continue };
     private _fn = selectRandom _types;
     [_center, _radius] call _fn;


### PR DESCRIPTION
## Summary
- add `VSA_maxAnomalyFields` CBA setting to cap total anomaly fields
- stop spawning new anomaly fields when the marker count hits the limit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684856f098e4832fa98fa7f5876594af