### PR TITLE
Fix AI loop early exits

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_resetAIBehavior.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_resetAIBehavior.sqf
@@ -19,7 +19,9 @@ if (["VSA_aiNightOnly", false] call CBA_fnc_getSetting && {daytime > 5 && daytim
 
 {
     private _unit = _x;
-    if (!alive _unit) exitWith {};
+    if (!alive _unit) then {
+        continue;
+    };
 
     // Restore saved behaviour and combat mode
     if (!isNil { _unit getVariable "vsa_savedBehaviour" }) then {

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_triggerAIPanic.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_triggerAIPanic.sqf
@@ -20,9 +20,13 @@ if (["VSA_aiNightOnly", false] call CBA_fnc_getSetting && {daytime > 5 && daytim
 private _threshold = ["VSA_panicThreshold", 50] call CBA_fnc_getSetting;
 
 {
-    if (random 100 >= _threshold) exitWith {};
+    if (random 100 >= _threshold) then {
+        continue;
+    };
     private _unit = _x;
-    if (!alive _unit) exitWith {};
+    if (!alive _unit) then {
+        continue;
+    };
 
     // Remember original behaviour so it can be restored later
     _unit setVariable ["vsa_savedBehaviour", behaviour _unit];


### PR DESCRIPTION
## Summary
- prevent `exitWith` in loops from skipping units in panic handler
- allow behavior reset loop to process all units

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684860870aec832f85646065aa7c4d7a