### PR TITLE
Invoke storm scheduling on postInit

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -53,6 +53,7 @@ VIC_fnc_setupDebugActions        = compile preprocessFileLineNumbers "\Viceroys-
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
     [] call VIC_fnc_registerEmissionHooks;
+    [] call VIC_fnc_schedulePsyStorms;
     [] call VIC_fnc_setupMutantHabitats;
     if (["VSA_debugMode", false] call CBA_fnc_getSetting) then {
         [] call VIC_fnc_setupDebugActions;


### PR DESCRIPTION
## Summary
- start periodic psy-storm scheduling once ALife initializes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848608f3684832f91e49d0d7f77b214