### PR TITLE
Add zombie tracking for killed units

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -59,3 +59,9 @@ VIC_fnc_setupDebugActions        = compile preprocessFileLineNumbers "\Viceroys-
     };
 }] call CBA_fnc_addEventHandler;
 
+// Track units killed during emissions for later zombification
+["EntityKilled", {
+    params ["_unit"];
+    [_unit] call VIC_fnc_trackDeadForZombify;
+}] call CBA_fnc_addEventHandler;
+


### PR DESCRIPTION
## Summary
- hook into `EntityKilled` to queue corpses for zombification

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486234b338832fad4d4fa9ac556f87