### PR TITLE
Add radiation cleanup at emission end

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -7,9 +7,13 @@
     "VSA_AIPanicEnabled",
     "CHECKBOX",
     ["Enable AI Emission Panic", "AI units will attempt to find cover indoors or in trenches when an emission is building up."],
-    "VSA - Emission",
+"VSA - Emission",
     true
 ] call CBA_fnc_addSetting;
+
+
+
+
 
 /*
     cba_settings.sqf
@@ -92,8 +96,24 @@
     "VSA_radiationNightOnly",
     "CHECKBOX",
     ["Night Time Only", "Radiation zones only appear at night"],
-    "VSA - Radiation",
+"VSA - Radiation",
     false
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_emissionRadiationCount",
+    "SLIDER",
+    ["Zones After Emission", "Radiation zones spawned after an emission"],
+    "VSA - Radiation",
+    [2, 0, 10, 0]
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_emissionRadiationRadius",
+    "SLIDER",
+    ["Emission Radiation Radius", "Search radius around players for emission zones"],
+    "VSA - Radiation",
+    [300, 50, 2000, 0]
 ] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_registerEmissionHooks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_registerEmissionHooks.sqf
@@ -53,6 +53,15 @@ missionNamespace setVariable ["emission_active", false];
         [] call mutants_fnc_onEmissionEnd;
         [] call radiation_fnc_onEmissionEnd;
         [] call zombification_fnc_onEmissionEnd;
+
+        // remove old radiation zones and spawn new ones
+        [true] call VIC_fnc_cleanupRadiationZones;
+
+        private _radius = ["VSA_emissionRadiationRadius", 300] call CBA_fnc_getSetting;
+        private _count  = ["VSA_emissionRadiationCount", 2] call CBA_fnc_getSetting;
+        {
+            [_x, _radius, _count, -1] call VIC_fnc_spawnRandomRadiationZones;
+        } forEach allPlayers;
     }
 ] call CBA_fnc_addEventHandler;
 

--- a/addons/Viceroys-STALKER-ALife/functions/radiation/fn_cleanupRadiationZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/radiation/fn_cleanupRadiationZones.sqf
@@ -7,6 +7,9 @@
     that runs after emissions.
 */
 
+
+params [["_force", false]];
+
 ["cleanupRadiationZones"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_radiationZones") exitWith {};
@@ -19,7 +22,7 @@ for [{_i = (count STALKER_radiationZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
     private _marker = _entry select 1;
     private _expires = _entry select 2;
 
-    if (_now > _expires) then {
+    if (_force || { _expires >= 0 && _now > _expires }) then {
         // Delete the zone using the Chemical Warfare Plus function
         [_zoneHandle] call CWP_fnc_removeZone;
 

--- a/addons/Viceroys-STALKER-ALife/functions/radiation/fn_spawnRadiationZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/radiation/fn_spawnRadiationZone.sqf
@@ -13,7 +13,8 @@
 
 params [
     ["_position", [0,0,0]],
-    ["_radius", 50]
+    ["_radius", 50],
+    ["_duration", -1]
 ];
 
 ["spawnRadiationZone"] call VIC_fnc_debugLog;
@@ -23,11 +24,13 @@ if (isNil "STALKER_radiationZones") then {
     STALKER_radiationZones = [];
 };
 
-// Fallback to fifteen minutes if the mission maker has not set a value
-private _duration = missionNamespace getVariable [
-    "STALKER_radiationZoneDuration",
-    900
-];
+if (_duration < 0) then {
+    // Fallback to fifteen minutes if the mission maker has not set a value
+    _duration = missionNamespace getVariable [
+        "STALKER_radiationZoneDuration",
+        900
+    ];
+};
 
 // Spawn the zone using Chemical Warfare Plus. The mod is expected to
 // provide `CWP_fnc_createZone` which returns a zone handle that can be
@@ -49,7 +52,7 @@ _marker setMarkerText format ["Radiation %1m", _radius];
 STALKER_radiationZones pushBack [
     _zoneHandle,
     _marker,
-    diag_tickTime + _duration
+    (_duration >= 0) ? (diag_tickTime + _duration) : -1
 ];
 
 _zoneHandle

--- a/addons/Viceroys-STALKER-ALife/functions/radiation/fn_spawnRandomRadiationZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/radiation/fn_spawnRandomRadiationZones.sqf
@@ -3,14 +3,18 @@
     Params:
         0: POSITION - center of the area
         1: NUMBER   - search radius
+        2: NUMBER   - number of zones to spawn (optional)
+        3: NUMBER   - zone duration in seconds (optional, -1 = until cleaned)
 */
-params ["_center","_radius"];
+params ["_center","_radius", ["_count", -1], ["_duration", -1]];
 
 ["spawnRandomRadiationZones"] call VIC_fnc_debugLog;
 
 if (["VSA_enableRadiation", true] call CBA_fnc_getSetting isEqualTo false) exitWith {};
 
-private _count  = ["VSA_radiationZoneCount", 2] call CBA_fnc_getSetting;
+if (_count < 0) then {
+    _count = ["VSA_radiationZoneCount", 2] call CBA_fnc_getSetting;
+};
 private _weight = ["VSA_radiationSpawnWeight", 50] call CBA_fnc_getSetting;
 private _nightOnly = ["VSA_radiationNightOnly", false] call CBA_fnc_getSetting;
 
@@ -19,6 +23,6 @@ if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
 for "_i" from 1 to _count do {
     if (random 100 >= _weight) then { continue };
     private _pos = _center getPos [random _radius, random 360];
-    [_pos, 50] call VIC_fnc_spawnRadiationZone;
+    [_pos, 50, _duration] call VIC_fnc_spawnRadiationZone;
 };
 


### PR DESCRIPTION
## Summary
- remove expired radiation zones after emissions end
- spawn new radiation zones that last until the next emission
- allow emission-related radiation count and radius via CBA settings

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684860e7c8d0832fa843ae5498a99c92