### PR TITLE
Fix radiation zone expiry logic

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/radiation/fn_spawnRadiationZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/radiation/fn_spawnRadiationZone.sqf
@@ -49,7 +49,10 @@ _marker setMarkerColor "ColorYellow";
 _marker setMarkerText format ["Radiation %1m", _radius];
 
 // Record the zone and when it should be removed
-private _expires = (_duration >= 0) ? (diag_tickTime + _duration) : -1;
+private _expires = -1;
+if (_duration >= 0) then {
+    _expires = diag_tickTime + _duration;
+};
 
 STALKER_radiationZones pushBack [
     _zoneHandle,


### PR DESCRIPTION
## Summary
- fix error in `fn_spawnRadiationZone.sqf` by computing `_expires` with an if block instead of a ternary operator

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68486a2ba3b0832f9df0412f51580cfa