### PR TITLE
Configure line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Enforce LF line endings for specific file types
+*.sqf text eol=lf
+*.cpp text eol=lf
+*.txt text eol=lf
+*.md text eol=lf


### PR DESCRIPTION
## Summary
- enforce LF line endings for `.sqf`, `.cpp`, and common text files via `.gitattributes`
- renormalize repository content

## Testing
- `git add --renormalize .`


------
https://chatgpt.com/codex/tasks/task_e_68486e53bcec832faa30d67a31b78dc1