### PR TITLE
Add warning for missing settings

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -9,6 +9,10 @@ private _root = "\Viceroys-STALKER-ALife";
 private _settings = _root + "\cba_settings.sqf";
 if (fileExists _settings) then {
     call compile preprocessFileLineNumbers _settings;
+} else {
+    private _msg = format ["[VIC] WARNING: cba_settings.sqf not found at %1", _settings];
+    diag_log _msg;
+    [_msg] call VIC_fnc_debugLog;
 };
 
 


### PR DESCRIPTION
## Summary
- add check for `cba_settings.sqf`
- log warning when the settings file is missing using `VIC_fnc_debugLog`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6848e49d6d7c832f93108f3a0e29b605