### PR TITLE
Allow debug toggle at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ Common spook types include:
    * [Chemical Warfare Plus](https://steamcommunity.com/sharedfiles/filedetails/?id=3295358796)
 3. Review `cba_settings.sqf` for adjustable options.
 4. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
+   This option can now be toggled while a mission is running and the debug
+   actions will appear automatically.
+5. When debug mode is active, your scroll menu includes options to trigger storms, spawn anomaly fields or spook zones, generate habitats, spawn ambient herds and other test helpers.
 
 ## Usage
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -130,7 +130,7 @@ VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\f
 ["EntityKilled", {
     params ["_unit"];
     [_unit] call VIC_fnc_trackDeadForZombify;
-}] call CBA_fnc_addEventHandler;
+  }] call CBA_fnc_addEventHandler;
 } else {
     ["postInit", {
         if (hasInterface && ["VSA_debugMode", false] call CBA_fnc_getSetting) then {
@@ -139,3 +139,12 @@ VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\f
         };
     }] call CBA_fnc_addEventHandler;
 };
+
+// Allow toggling debug mode mid-mission
+["CBA_SettingChanged", {
+    params ["_setting", "_value"];
+    if (hasInterface && {_setting isEqualTo "VSA_debugMode" && {_value}}) then {
+        [] call VIC_fnc_setupDebugActions;
+        [] call VIC_fnc_markAllBuildings;
+    };
+}] call CBA_fnc_addEventHandler;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -14,6 +14,8 @@ player addAction ["Spawn Anomaly Fields", { [getPos player, 200] call VIC_fnc_sp
 player addAction ["Spawn Mutant Group", { [getPos player] call VIC_fnc_spawnMutantGroup }];
 player addAction ["Spawn Spook Zone", { [] call VIC_fnc_spawnSpookZone }];
 player addAction ["Spawn Zombies From Queue", { [] call VIC_fnc_spawnZombiesFromQueue }];
+player addAction ["Spawn Ambient Herds", { [] call VIC_fnc_spawnAmbientHerds }];
+player addAction ["Generate Mutant Habitats", { [] call VIC_fnc_setupMutantHabitats }];
 
 ["Debug actions added"] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- add setting change handler so debug actions appear when `VSA_debugMode` is toggled mid-mission
- add debug menu options for ambient herds and mutant habitats
- update README with debug action list

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68493472e380832f8dcb9af467752410