### PR TITLE
Add debug menu for building markers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -16,6 +16,7 @@ player addAction ["Spawn Spook Zone", { [] call VIC_fnc_spawnSpookZone }];
 player addAction ["Spawn Zombies From Queue", { [] call VIC_fnc_spawnZombiesFromQueue }];
 player addAction ["Spawn Ambient Herds", { [] call VIC_fnc_spawnAmbientHerds }];
 player addAction ["Generate Mutant Habitats", { [] call VIC_fnc_setupMutantHabitats }];
+player addAction ["Mark All Buildings", { [] call VIC_fnc_markAllBuildings }];
 
 ["Debug actions added"] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- add a mouse-scroll debug action called `Mark All Buildings`
- ensure markers for anomaly zones and other areas display their labels

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_6849549e8b84832f901ab9876c2bb361