### PR TITLE
Add DSA units to spook and anomaly spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Every mutant type can establish a nest which spawns defenders when players are n
 * **Acid Smasher** – Corrosive variant that spews acid while smashing through targets.
 
 ## Spooks and Other Anomalies
-Drongo’s system adds creepy events such as ghostly whispers or sudden darkening of the sky. These spook zones appear mostly at night and vanish after a short time, keeping players uneasy as they travel.
+Drongo’s system adds creepy events such as ghostly whispers or sudden darkening of the sky. These spook zones appear mostly at night and vanish after a short time, keeping players uneasy as they travel. When a zone spawns the mod now creates one of the DSA creature classes (for example `DSA_Wendigo` or `DSA_Shadowman`) at the location and cleans it up once the zone expires.
 
 Common spook types include:
 * **Wendigo** – Deer-like humanoid that leaps at nearby prey.

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -25,7 +25,7 @@ STALKER_anomalyMarkers pushBack _marker;
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
-    private _anom = [_pos] call diwako_anomalies_main_fnc_createLaunchpad;
+    private _anom = createVehicle ["DSA_Launchpad", _pos, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -25,7 +25,7 @@ STALKER_anomalyMarkers pushBack _marker;
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
-    private _anom = [_pos] call diwako_anomalies_main_fnc_createLeech;
+    private _anom = createVehicle ["DSA_Leech", _pos, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -25,7 +25,7 @@ STALKER_anomalyMarkers pushBack _marker;
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
-    private _anom = [_pos] call diwako_anomalies_main_fnc_createTrapdoor;
+    private _anom = createVehicle ["DSA_Trapdoor", _pos, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -25,7 +25,7 @@ STALKER_anomalyMarkers pushBack _marker;
 private _spawned = [];
 for "_i" from 1 to _count do {
     private _pos = _site getPos [random 10, random 360];
-    private _anom = [_pos] call diwako_anomalies_main_fnc_createZapper;
+    private _anom = createVehicle ["DSA_Zapper", _pos, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf
@@ -27,6 +27,7 @@ private _duration = missionNamespace getVariable ["STALKER_SpookDuration",15];
 if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
 
 if (isNil "drg_activeSpookZones") then { drg_activeSpookZones = []; };
+if (isNil "STALKER_activeSpooks") then { STALKER_activeSpooks = []; };
 
 for "_i" from 1 to _count do {
     if (random 100 >= _weight) then { continue };
@@ -35,6 +36,25 @@ for "_i" from 1 to _count do {
         private _zone = createTrigger ["EmptyDetector", _pos];
         _zone setTriggerArea [25,25,0,false];
         _zone setVariable ["isSpookZone", true];
+
+        // Spawn a random spook from Drongo's mod
+        private _spookTypes = [
+            "DSA_Wendigo",
+            "DSA_Vampire",
+            "DSA_Shadowman",
+            "DSA_Hatman",
+            "DSA_Mindflayer",
+            "DSA_411",
+            "DSA_Rake",
+            "DSA_Abomination",
+            "DSA_Snatcher",
+            "DSA_Crazy",
+            "DSA_ActiveIdol"
+        ];
+
+        private _spook = createVehicle [selectRandom _spookTypes, _pos, [], 0, "NONE"];
+        _zone setVariable ["spawnedSpook", _spook];
+        STALKER_activeSpooks pushBack _spook;
 
         // Create a map marker so the zone is visible for debugging or admin use
         private _markerName = format ["spook_%1", diag_tickTime];
@@ -48,9 +68,15 @@ for "_i" from 1 to _count do {
         _zone setVariable ["zoneMarker", _marker];
 
         drg_activeSpookZones pushBack _zone;
-        [_zone, _duration] spawn {
-            params ["_zone","_dur"];
+        [_zone, _spook, _duration] spawn {
+            params ["_zone","_spook","_dur"];
             sleep (_dur * 60);
+            if (!isNull _spook) then {
+                deleteVehicle _spook;
+                if (!isNil "STALKER_activeSpooks") then {
+                    STALKER_activeSpooks = STALKER_activeSpooks - [_spook];
+                };
+            };
             if (!isNull _zone) then {
                 private _m = _zone getVariable ["zoneMarker", ""];
                 if (_m isNotEqualTo "") then { deleteMarker _m; };

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -9,6 +9,7 @@ STALKER_SpookDuration  = 15;     // minutes zones remain active
 STALKER_AnomalyFieldDuration = 30; // minutes anomaly fields persist
 
 drg_activeSpookZones = [];
+STALKER_activeSpooks = [];
 
 // Global tracking arrays for spawned groups
 STALKER_activeHerds = [];


### PR DESCRIPTION
## Summary
- spawn actual Drongo's Spooks units when creating spook zones
- remove spawned spooks when their zone expires
- spawn DSA anomaly objects for launchpad, leech, zapper and trapdoor fields
- track spawned spooks on init
- document DSA creature spawns in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68495bb08388832fb8281f38fb8a24f6