### PR TITLE
Remove dark green markers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -17,8 +17,9 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_trapdoor_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
-_marker setMarkerColor "ColorDarkGreen";
+    _marker setMarkerSize [10,10];
+    // Replace dark green with standard green for clarity
+    _marker setMarkerColor "ColorGreen";
 _marker setMarkerText "Trapdoor 10m";
 STALKER_anomalyMarkers pushBack _marker;
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -14,7 +14,8 @@ private _createMarker = {
     private _name = format ["hab_%1_%2", toLower _type, diag_tickTime + random 1000];
     private _marker = createMarker [_name, _pos];
     _marker setMarkerShape "ELLIPSE";
-    _marker setMarkerColor "ColorDarkGreen";
+    // Dark green markers caused confusion with players, use standard green instead
+    _marker setMarkerColor "ColorGreen";
     _marker setMarkerSize [150,150];
     _marker setMarkerText format ["Habitat: %1", toUpper _type];
     STALKER_mutantHabitats pushBack [_marker, _type];


### PR DESCRIPTION
## Summary
- avoid using dark green for markers

## Testing
- `grep -R "ColorDarkGreen" -n || true`

------
https://chatgpt.com/codex/tasks/task_e_68495e220664832f8715d2512600eaa4