### PR TITLE
Ensure CBA settings wait for initialization

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -8,6 +8,7 @@
 private _root = "\Viceroys-STALKER-ALife";
 private _settings = _root + "\cba_settings.sqf";
 if (fileExists _settings) then {
+    waitUntil {!isNil "CBA_fnc_addSetting"};
     call compile preprocessFileLineNumbers _settings;
 };
 


### PR DESCRIPTION
## Summary
- wait for `CBA_fnc_addSetting` to be defined before processing settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68497406fb44832f8f6823899ba5d562