### PR TITLE
Fix player proximity check

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -20,7 +20,7 @@ private _nightOnly   = ["VSA_anomalyNightOnly", false] call VIC_fnc_getSetting;
 
 if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
 
-if (![_center, 1500] call VIC_fnc_hasPlayersNearby) exitWith {};
+if (!([_center, 1500] call VIC_fnc_hasPlayersNearby)) exitWith {};
 
 private _types = [
     VIC_fnc_createField_burner,


### PR DESCRIPTION
## Summary
- fix the logic used to determine if players are nearby in anomaly field spawner

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684a0512d41c832f8117b590654fdf51