### PR TITLE
Show population labels on habitat markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Dedicated nest spawns for every mutant type keep their territories dangerous.
 
 ### Mutant Habitats
-* Defines simple territory markers via **fn_setupMutantHabitats.sqf**.
+* Defines territory areas via **fn_setupMutantHabitats.sqf**.
+* Each habitat now uses an ellipse marker to show its bounds and a labeled icon displaying the current population (e.g. `Bloodsucker Habitat: 4/12`).
 * Systems rely on **fn_hasPlayersNearby.sqf** so activity sleeps when players are far away.
 * CBA settings allow mission makers to customize these behaviors.
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -1,7 +1,7 @@
 /*
     Manages mutant habitats. Spawns units when players approach and
     replenishes cleared habitats over time.
-    STALKER_mutantHabitats entries: [marker, group, position, type, max]
+    STALKER_mutantHabitats entries: [areaMarker, labelMarker, group, position, type, max]
 */
 
 ["manageHabitats"] call VIC_fnc_debugLog;
@@ -28,7 +28,7 @@ private _getClass = {
 private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
 
 {
-    _x params ["_marker","_grp","_pos","_type","_max"];
+    _x params ["_area","_label","_grp","_pos","_type","_max"];
     private _near = [_pos,1500] call VIC_fnc_hasPlayersNearby;
 
     if (_near && {isNull _grp}) then {
@@ -57,9 +57,10 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
         };
     };
 
-    _marker setMarkerColor (if (_grp isEqualTo grpNull) then {"ColorGreen"} else {"ColorRed"});
-    _marker setMarkerText format ["%1 Habitat: %2/%3", _type, _alive, _max];
+    _area setMarkerColor (if (_grp isEqualTo grpNull) then {"ColorGreen"} else {"ColorRed"});
+    _label setMarkerColor (if (_grp isEqualTo grpNull) then {"ColorGreen"} else {"ColorRed"});
+    _label setMarkerText format ["%1 Habitat: %2/%3", _type, _alive, _max];
 
-    STALKER_mutantHabitats set [_forEachIndex, [_marker,_grp,_pos,_type,_max]];
+    STALKER_mutantHabitats set [_forEachIndex, [_area,_label,_grp,_pos,_type,_max]];
 } forEach STALKER_mutantHabitats;
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -11,11 +11,17 @@ if (isNil "STALKER_mutantHabitats") then { STALKER_mutantHabitats = []; };
 
 private _createMarker = {
     params ["_type", "_pos"];
-    private _name = format ["hab_%1_%2", toLower _type, diag_tickTime + random 1000];
-    private _marker = createMarker [_name, _pos];
-    _marker setMarkerShape "ELLIPSE";
-    _marker setMarkerColor "ColorGreen";
-    _marker setMarkerSize [150,150];
+    private _base = format ["hab_%1_%2", toLower _type, diag_tickTime + random 1000];
+
+    private _area = createMarker [_base + "_area", _pos];
+    _area setMarkerShape "ELLIPSE";
+    _area setMarkerColor "ColorGreen";
+    _area setMarkerSize [150,150];
+
+    private _label = createMarker [_base + "_label", _pos];
+    _label setMarkerShape "ICON";
+    _label setMarkerType "mil_dot";
+    _label setMarkerColor "ColorGreen";
     private _max = switch (_type) do {
         case "Bloodsucker": { ["VSA_habitatSize_Bloodsucker",12] call VIC_fnc_getSetting };
         case "Blind Dog": { ["VSA_habitatSize_Dog",50] call VIC_fnc_getSetting };
@@ -28,8 +34,8 @@ private _createMarker = {
         case "Izlom": { ["VSA_habitatSize_Izlom",10] call VIC_fnc_getSetting };
         default {10};
     };
-    _marker setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
-    STALKER_mutantHabitats pushBack [_marker, grpNull, _pos, _type, _max];
+    _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
+    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max];
 };
 
 private _center = [worldSize/2, worldSize/2, 0];


### PR DESCRIPTION
## Summary
- add a labelled icon marker alongside each habitat ellipse
- keep area and label markers updated in `manageHabitats`
- document labelled habitat markers in README

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a194abcf0832faac7b7e802110c3e