### PR TITLE
Add AI anomaly avoidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 ### AI Panic
 * AI groups react to nearby emissions or scary events by fleeing to cover positions.
 * Uses **fn_triggerAIPanic.sqf** and **fn_resetAIBehavior.sqf** to manage behavior states.
+* Optional avoidance of nearby anomalies controlled by **VSA_aiAnomalyAvoidChance**.
 
 ### Anomalies
 * Procedurally spawns anomaly fields using scripts in `functions/anomalies`.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -336,6 +336,22 @@ true
     false
 ] call CBA_fnc_addSetting;
 
+[
+    "VSA_aiAnomalyAvoidChance",
+    "SLIDER",
+    ["Anomaly Avoid Chance", "Chance AI moves away from nearby anomalies"],
+    "Viceroy's STALKER ALife - AI",
+    [50, 0, 100, 0]
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_aiAnomalyAvoidRange",
+    "SLIDER",
+    ["Anomaly Avoid Range", "Distance to check for anomalies around AI"],
+    "Viceroy's STALKER ALife - AI",
+    [20, 5, 50, 0]
+] call CBA_fnc_addSetting;
+
 
 // Hostile mutant spawns
 [

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -33,6 +33,7 @@ class CfgFunctions
             file = "Viceroys-STALKER-ALife\functions\ai";
             class resetAIBehavior{};
             class triggerAIPanic{};
+            class avoidAnomalies{};
         };
 
         class Panic

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalies.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalies.sqf
@@ -1,0 +1,40 @@
+/*
+    File: fn_avoidAnomalies.sqf
+    Author: Viceroy's STALKER ALife
+    Description:
+        Causes nearby AI to move away from active anomalies based on a chance.
+    Parameter(s): none
+*/
+
+["fn_avoidAnomalies"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (["VSA_enableAIBehaviour", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_aiNightOnly", false] call VIC_fnc_getSetting && { daytime > 5 && daytime < 20 }) exitWith {};
+if (isNil "STALKER_anomalyFields") exitWith {};
+
+private _chance = ["VSA_aiAnomalyAvoidChance", 50] call VIC_fnc_getSetting;
+private _range  = ["VSA_aiAnomalyAvoidRange", 20] call VIC_fnc_getSetting;
+
+private _anoms = [];
+{ _x params [,,,,"_objs"]; _anoms append _objs; } forEach STALKER_anomalyFields;
+if (_anoms isEqualTo []) exitWith {};
+
+{
+    if (random 100 >= _chance) then { continue; };
+    private _unit = _x;
+    if (!alive _unit || {isPlayer _unit}) then { continue; };
+
+    private _near = objNull;
+    {
+        if (_unit distance _x < _range) exitWith { _near = _x; };
+    } forEach _anoms;
+
+    if (!isNull _near) then {
+        private _dir = _unit getDir _near;
+        private _dest = [getPosATL _unit, _range * 2, _dir + 180] call BIS_fnc_relPos;
+        _unit doMove _dest;
+    };
+} forEach allUnits;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -19,6 +19,7 @@ if (isServer) then {
 // --- Function Registration -------------------------------------------------
 VIC_fnc_resetAIBehavior          = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_resetAIBehavior.sqf");
 VIC_fnc_triggerAIPanic           = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_triggerAIPanic.sqf");
+VIC_fnc_avoidAnomalies           = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_avoidAnomalies.sqf");
 VIC_fnc_cleanupChemicalZones    = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_cleanupChemicalZones.sqf");
 VIC_fnc_spawnChemicalZone       = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_spawnChemicalZone.sqf");
 VIC_fnc_spawnRandomChemicalZones = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_spawnRandomChemicalZones.sqf");
@@ -130,6 +131,15 @@ VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\f
                 sleep 60;
             };
         }, [], 15
+    ] call CBA_fnc_waitAndExecute;
+
+    [
+        {
+            while {true} do {
+                [] call VIC_fnc_avoidAnomalies;
+                sleep 30;
+            };
+        }, [], 16
     ] call CBA_fnc_waitAndExecute;
 
     [


### PR DESCRIPTION
## Summary
- create `fn_avoidAnomalies` to move AI away from anomaly fields
- register the new function and schedule periodic execution
- expose `VSA_aiAnomalyAvoidChance` and `VSA_aiAnomalyAvoidRange` settings
- mention avoidance feature in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684a29e127c0832f8a76b50a42e7e852