### PR TITLE
Adjust ranges and bugfix

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -19,7 +19,7 @@
     "SLIDER",
     ["Player Nearby Range", "Distance used to check if players are near"],
     "Viceroy's STALKER ALife - Core",
-    [1500, 500, 3000, 0]
+    [1500, 0, 7500, 0]
 ] call CBA_fnc_addSetting;
 
 
@@ -50,7 +50,7 @@
     "SLIDER",
     ["Anomaly Fields per Area", "Number of fields spawned per area"],
     "Viceroy's STALKER ALife - Anomalies",
-    [3, 0, 10, 0]
+    [3, 0, 50, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -58,7 +58,7 @@
     "SLIDER",
     ["Max Active Fields", "Maximum number of anomaly fields present at once"],
     "Viceroy's STALKER ALife - Anomalies",
-    [20, 0, 100, 0]
+    [20, 0, 200, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -101,7 +101,7 @@
     "SLIDER",
     ["Chemical Zones per Area", "Number of chemical zones created"],
     "Viceroy's STALKER ALife - Chemical",
-    [2, 0, 10, 0]
+    [2, 0, 20, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -125,7 +125,7 @@
     "SLIDER",
     ["Chemical Zone Radius", "Radius of each chemical zone"],
     "Viceroy's STALKER ALife - Chemical",
-    [50, 10, 200, 0]
+    [50, 0, 250, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -133,7 +133,7 @@
     "SLIDER",
     ["Zones After Emission", "Chemical zones spawned after an emission"],
     "VSA - Chemical",
-    [2, 0, 10, 0]
+    [2, 0, 50, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -160,7 +160,7 @@
     "SLIDER",
     ["Mutant Groups per Area", "Number of mutant groups"],
     "Viceroy's STALKER ALife - Mutants",
-    [3, 0, 20, 0]
+    [3, 0, 50, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -255,7 +255,7 @@ true
     "SLIDER",
     ["Storm Interval (min)", "Minutes between possible storms"],
     "Viceroy's STALKER ALife - Storms",
-    [30, 5, 120, 0]
+    [30, 0, 150, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -349,7 +349,7 @@ true
     "SLIDER",
     ["Anomaly Avoid Range", "Distance to check for anomalies around AI"],
     "Viceroy's STALKER ALife - AI",
-    [20, 5, 50, 0]
+    [20, 0, 100, 0]
 ] call CBA_fnc_addSetting;
 
 
@@ -359,7 +359,7 @@ true
     "SLIDER",
     ["Post-Emission Groups", "Number of mutant groups after an emission"],
     "Viceroy's STALKER ALife - Mutants",
-    [1, 1, 5, 0]
+    [1, 0, 25, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -367,7 +367,7 @@ true
     "SLIDER",
     ["Units per Hostile Group", "Units spawned in each hostile group"],
     "Viceroy's STALKER ALife - Mutants",
-    [3, 1, 10, 0]
+    [3, 0, 30, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -384,7 +384,7 @@ true
     "SLIDER",
     ["Roaming Herds", "Number of roaming herds"],
     "Viceroy's STALKER ALife - Mutants",
-    [2, 0, 5, 0]
+    [2, 0, 10, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -392,7 +392,7 @@ true
     "SLIDER",
     ["Herd Size", "Units per roaming herd"],
     "Viceroy's STALKER ALife - Mutants",
-    [4, 1, 8, 0]
+    [4, 0, 50, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -404,7 +404,7 @@ true
 ] call CBA_fnc_addSetting;
 
 ["VSA_predatorAttackChance","SLIDER",["Predator Attack Chance","Chance each check to spawn an ambush"],"Viceroy's STALKER ALife - Mutants",[5,0,100,0]] call CBA_fnc_addSetting;
-["VSA_predatorRange","SLIDER",["Predator Range","Distance from players to spawn predators"],"Viceroy's STALKER ALife - Mutants",[1500,500,3000,0]] call CBA_fnc_addSetting;
+["VSA_predatorRange","SLIDER",["Predator Range","Distance from players to spawn predators"],"Viceroy's STALKER ALife - Mutants",[1500,0,7500,0]] call CBA_fnc_addSetting;
 ["VSA_predatorCheckInterval","SLIDER",["Predator Check Interval","Seconds between predator attack checks"],"Viceroy's STALKER ALife - Mutants",[300,60,900,0]] call CBA_fnc_addSetting;
 ["VSA_proximityCheckInterval","SLIDER",["Proximity Check Interval","Seconds between player distance checks"],"Viceroy's STALKER ALife - Mutants",[30,10,300,0]] call CBA_fnc_addSetting;
 ["VSA_predatorNightOnly","CHECKBOX",["Night Time Attacks","Predators only attack at night"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
@@ -414,7 +414,7 @@ true
     "SLIDER",
     ["Max Active Herds", "Maximum number of roaming herds"],
     "Viceroy's STALKER ALife - Mutants",
-    [5, 0, 20, 0]
+    [5, 0, 100, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -422,7 +422,7 @@ true
     "SLIDER",
     ["Max Hostile Groups", "Maximum active hostile mutant groups"],
     "Viceroy's STALKER ALife - Mutants",
-    [5, 0, 20, 0]
+    [5, 0, 50, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -430,7 +430,7 @@ true
     "SLIDER",
     ["Max Mutant Nests", "Maximum active bloodsucker nests"],
     "Viceroy's STALKER ALife - Mutants",
-    [3, 0, 10, 0]
+    [3, 0, 30, 0]
 ] call CBA_fnc_addSetting;
 
 [
@@ -441,15 +441,15 @@ true
     true
 ] call CBA_fnc_addSetting;
 
-["VSA_habitatSize_Bloodsucker","SLIDER",["Bloodsucker Habitat Size","Max bloodsuckers per habitat"],"Viceroy's STALKER ALife - Mutants",[12,1,50,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Dog","SLIDER",["Dog Habitat Size","Max dogs per habitat"],"Viceroy's STALKER ALife - Mutants",[50,1,100,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Boar","SLIDER",["Boar Habitat Size","Max boars per habitat"],"Viceroy's STALKER ALife - Mutants",[10,1,50,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Cat","SLIDER",["Cat Habitat Size","Max cats per habitat"],"Viceroy's STALKER ALife - Mutants",[10,1,50,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Flesh","SLIDER",["Flesh Habitat Size","Max flesh per habitat"],"Viceroy's STALKER ALife - Mutants",[10,1,50,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Pseudodog","SLIDER",["Pseudodog Habitat Size","Max pseudodogs per habitat"],"Viceroy's STALKER ALife - Mutants",[20,1,50,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Controller","SLIDER",["Controller Habitat Size","Max controllers per habitat"],"Viceroy's STALKER ALife - Mutants",[8,1,20,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Pseudogiant","SLIDER",["Pseudogiant Habitat Size","Max pseudogiants per habitat"],"Viceroy's STALKER ALife - Mutants",[6,1,20,0]] call CBA_fnc_addSetting;
-["VSA_habitatSize_Izlom","SLIDER",["Izlom Habitat Size","Max izlom per habitat"],"Viceroy's STALKER ALife - Mutants",[10,1,50,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Bloodsucker","SLIDER",["Bloodsucker Habitat Size","Max bloodsuckers per habitat"],"Viceroy's STALKER ALife - Mutants",[12,0,60,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Dog","SLIDER",["Dog Habitat Size","Max dogs per habitat"],"Viceroy's STALKER ALife - Mutants",[50,0,250,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Boar","SLIDER",["Boar Habitat Size","Max boars per habitat"],"Viceroy's STALKER ALife - Mutants",[10,0,50,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Cat","SLIDER",["Cat Habitat Size","Max cats per habitat"],"Viceroy's STALKER ALife - Mutants",[10,0,50,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Flesh","SLIDER",["Flesh Habitat Size","Max flesh per habitat"],"Viceroy's STALKER ALife - Mutants",[10,0,50,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Pseudodog","SLIDER",["Pseudodog Habitat Size","Max pseudodogs per habitat"],"Viceroy's STALKER ALife - Mutants",[20,0,100,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Controller","SLIDER",["Controller Habitat Size","Max controllers per habitat"],"Viceroy's STALKER ALife - Mutants",[8,0,40,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Pseudogiant","SLIDER",["Pseudogiant Habitat Size","Max pseudogiants per habitat"],"Viceroy's STALKER ALife - Mutants",[6,0,30,0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Izlom","SLIDER",["Izlom Habitat Size","Max izlom per habitat"],"Viceroy's STALKER ALife - Mutants",[10,0,50,0]] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
 // Debug

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -20,14 +20,14 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_burner_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 _marker setMarkerColor "ColorOrange";
-_marker setMarkerText "Burner 10m";
+_marker setMarkerText "Burner 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createBurner;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_clicker_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Clicker fields get a pink marker
 _marker setMarkerColor "ColorPink";
-_marker setMarkerText "Clicker 10m";
+_marker setMarkerText "Clicker 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createClicker;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_electra_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Use blue for electra fields
 _marker setMarkerColor "ColorBlue";
-_marker setMarkerText "Electra 10m";
+_marker setMarkerText "Electra 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createElectra;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_fruitpunch_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Use green to distinguish fruit punch fields
 _marker setMarkerColor "ColorGreen";
-_marker setMarkerText "Fruitpunch 10m";
+_marker setMarkerText "Fruitpunch 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createFruitPunch;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_gravi_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Brown marker helps identify gravi fields
 _marker setMarkerColor "ColorBrown";
-_marker setMarkerText "Gravi 10m";
+_marker setMarkerText "Gravi 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createGravi;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -19,14 +19,14 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_launchpad_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 _marker setMarkerColor "ColorYellow";
-_marker setMarkerText "Launchpad 10m";
+_marker setMarkerText "Launchpad 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = createVehicle ["DSA_Launchpad", ASLToATL _surf, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -19,14 +19,14 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_leech_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 _marker setMarkerColor "ColorBlack";
-_marker setMarkerText "Leech 10m";
+_marker setMarkerText "Leech 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = createVehicle ["DSA_Leech", ASLToATL _surf, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_meatgrinder_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Meatgrinder zones use a red marker
 _marker setMarkerColor "ColorRed";
-_marker setMarkerText "Meatgrinder 10m";
+_marker setMarkerText "Meatgrinder 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createMeatgrinder;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_springboard_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Springboard markers use khaki for visibility
 _marker setMarkerColor "ColorKhaki";
-_marker setMarkerText "Springboard 10m";
+_marker setMarkerText "Springboard 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createSpringboard;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_trapdoor_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-    _marker setMarkerSize [10,10];
+    _marker setMarkerSize [15,15];
     // Replace dark green with standard green for clarity
     _marker setMarkerColor "ColorGreen";
-_marker setMarkerText "Trapdoor 10m";
+_marker setMarkerText "Trapdoor 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = createVehicle ["DSA_Trapdoor", ASLToATL _surf, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -19,15 +19,15 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_whirligig_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 // Whirligig fields are marked with white
 _marker setMarkerColor "ColorWhite";
-_marker setMarkerText "Whirligig 10m";
+_marker setMarkerText "Whirligig 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = [_surf] call diwako_anomalies_main_fnc_createWhirligig;
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -19,14 +19,14 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_zapper_%1", diag_tickTime];
 private _marker = createMarker [_markerName, _site];
 _marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [10,10];
+_marker setMarkerSize [15,15];
 _marker setMarkerColor "ColorEAST";
-_marker setMarkerText "Zapper 10m";
+_marker setMarkerText "Zapper 15m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 10, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
     private _anom = createVehicle ["DSA_Zapper", ASLToATL _surf, [], 0, "NONE"];
     _anom setVariable ["zoneMarker", _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
@@ -1,6 +1,6 @@
 /*
     Periodically spawns predator attacks on players and cleans up finished groups.
-    STALKER_activePredators entries: [group, target]
+    STALKER_activePredators entries: [group, target, marker]
 */
 
 ["managePredators"] call VIC_fnc_debugLog;
@@ -14,11 +14,12 @@ private _nightOnly = ["VSA_predatorNightOnly", true] call VIC_fnc_getSetting;
 if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {
     // still cleanup existing predators
     {
-        _x params ["_grp", "_target"];
+        _x params ["_grp", "_target", "_marker"];
         if (!isNull _grp) then {
             { deleteVehicle _x } forEach units _grp;
             deleteGroup _grp;
         };
+        if (_marker != "") then { deleteMarker _marker }; 
     } forEach STALKER_activePredators;
     STALKER_activePredators = [];
 };
@@ -32,8 +33,8 @@ if ((count allPlayers) > 0 && {random 100 < _chance}) then {
 
 private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
 
-{
-    _x params ["_grp", "_target"];
+{ 
+    _x params ["_grp", "_target", "_marker"];
     private _alive = if (isNull _grp) then {0} else { {alive _x} count units _grp };
     private _near = [_target, _range] call VIC_fnc_hasPlayersNearby;
     if (_alive == 0 || {!_near}) then {
@@ -41,6 +42,7 @@ private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
             { deleteVehicle _x } forEach units _grp;
             deleteGroup _grp;
         };
+        if (_marker != "") then { deleteMarker _marker };
         STALKER_activePredators set [_forEachIndex, objNull];
     };
 } forEach STALKER_activePredators;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -17,6 +17,7 @@ private _createMarker = {
     _area setMarkerShape "ELLIPSE";
     _area setMarkerColor "ColorGreen";
     _area setMarkerSize [150,150];
+    _area setMarkerText format ["%1 Habitat Area", _type];
 
     private _label = createMarker [_base + "_label", _pos];
     _label setMarkerShape "ICON";

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -16,8 +16,17 @@ if (["VSA_enableMutants", true] call VIC_fnc_getSetting isEqualTo false) exitWit
 
 if (isNil "STALKER_activePredators") then { STALKER_activePredators = []; };
 
+private _spawnMarker = "";
 private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
-private _spawnPos = getPos _player getPos [_range, random 360];
+private _spawnPos = _player getPos [_range, random 360];
+
+if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+    _spawnMarker = createMarker [format ["pred_%1", diag_tickTime], _spawnPos];
+    _spawnMarker setMarkerShape "ICON";
+    _spawnMarker setMarkerType "mil_dot";
+    _spawnMarker setMarkerColor "ColorRed";
+    _spawnMarker setMarkerText "Predator Spawn";
+};
 
 private _chimeraClasses = ["armst_chimera"];
 private _bloodsuckerClasses = ["armst_krovosos","armst_krovosos2"];
@@ -40,4 +49,4 @@ switch (_type) do {
 
 [_grp, _player] call BIS_fnc_taskAttack;
 
-STALKER_activePredators pushBack [_grp, _player];
+STALKER_activePredators pushBack [_grp, _player, _spawnMarker];


### PR DESCRIPTION
## Summary
- widen sliders for anomaly and mutant counts
- allow far more chemical zones after an emission
- greatly increase maximum roaming herds and hostile groups
- show predator spawn marker at correct position

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_684af3a12e00832f8b07a7c03328ef02