### PR TITLE
Add debug range markers and zone visibility controls

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
@@ -15,26 +15,20 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 
     if (_near) then {
         if (_objs isEqualTo []) then {
-            private _spawned = [_center,_radius,_count,_pos] call _fn;
+            private _spawned = [_center,_radius,_count,_site] call _fn;
             if (!(_spawned isEqualTo [])) then {
                 _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
                 _site = getMarkerPos _marker;
                 _objs = _spawned;
             };
         };
+        if (_marker != "") then { _marker setMarkerAlpha 1; };
     } else {
         if (_objs isNotEqualTo []) then {
             { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
-            if (_marker != "") then {
-                deleteMarker _marker;
-                if (!isNil "STALKER_anomalyMarkers") then {
-                    private _idx = STALKER_anomalyMarkers find _marker;
-                    if (_idx >= 0) then { STALKER_anomalyMarkers deleteAt _idx; };
-                };
-            };
             _objs = [];
-            _marker = "";
         };
+        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
     STALKER_anomalyFields set [_forEachIndex, [_center,_radius,_fn,_count,_objs,_marker,_site]];
 } forEach STALKER_anomalyFields;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
@@ -1,0 +1,48 @@
+/*
+    Creates circle markers around all players showing the range used
+    for nearby checks. Only runs on clients when debug mode is enabled.
+
+    Returns: BOOL
+*/
+
+["markPlayerRanges"] call VIC_fnc_debugLog;
+
+if (!hasInterface) exitWith { false };
+if (missionNamespace getVariable ["VSA_rangeMarkersActive", false]) exitWith { true };
+missionNamespace setVariable ["VSA_rangeMarkersActive", true];
+
+if (isNil "STALKER_playerRangeMarkers") then { STALKER_playerRangeMarkers = [] };
+
+[] spawn {
+    while (["VSA_debugMode", false] call VIC_fnc_getSetting) do {
+        private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+        private _players = allPlayers;
+
+        {
+            private _idx = _forEachIndex;
+            private _m = if (_idx < count STALKER_playerRangeMarkers) then {
+                STALKER_playerRangeMarkers select _idx
+            } else {
+                private _name = format ["playerRange_%1_%2", _idx, diag_tickTime];
+                private _marker = createMarkerLocal [_name, getPosATL _x];
+                _marker setMarkerShape "ELLIPSE";
+                _marker setMarkerColor "ColorBlue";
+                STALKER_playerRangeMarkers pushBack _marker;
+                _marker
+            };
+            _m setMarkerPosLocal getPosATL _x;
+            _m setMarkerSizeLocal [_range, _range];
+        } forEach _players;
+
+        for [{_i = count STALKER_playerRangeMarkers - 1}, {_i >= count _players}, {_i = _i - 1}] do {
+            deleteMarkerLocal (STALKER_playerRangeMarkers deleteAt _i);
+        };
+
+        sleep 1;
+    };
+    { deleteMarkerLocal _x } forEach STALKER_playerRangeMarkers;
+    STALKER_playerRangeMarkers = [];
+    missionNamespace setVariable ["VSA_rangeMarkersActive", false];
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -100,6 +100,7 @@ VIC_fnc_getSurfacePosition       = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_debugLog                 = compile preprocessFileLineNumbers (_root + "\functions\core\fn_debugLog.sqf");
 VIC_fnc_setupDebugActions        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_setupDebugActions.sqf");
 VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markAllBuildings.sqf");
+VIC_fnc_markPlayerRanges        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markPlayerRanges.sqf");
 
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
@@ -181,6 +182,7 @@ VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\f
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         [] call VIC_fnc_setupDebugActions;
         [] call VIC_fnc_markAllBuildings;
+        [] call VIC_fnc_markPlayerRanges;
     };
 }] call CBA_fnc_addEventHandler;
 
@@ -194,6 +196,7 @@ VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\f
         if (hasInterface && ["VSA_debugMode", false] call VIC_fnc_getSetting) then {
             [] call VIC_fnc_setupDebugActions;
             [] call VIC_fnc_markAllBuildings;
+            [] call VIC_fnc_markPlayerRanges;
         };
     }] call CBA_fnc_addEventHandler;
 };
@@ -204,5 +207,6 @@ VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\f
     if (hasInterface && {_setting isEqualTo "VSA_debugMode" && {_value}}) then {
         [] call VIC_fnc_setupDebugActions;
         [] call VIC_fnc_markAllBuildings;
+        [] call VIC_fnc_markPlayerRanges;
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -71,6 +71,10 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
     _label setMarkerColor (if (_count > 0) then {"ColorRed"} else {"ColorGreen"});
     _label setMarkerText format ["%1 Habitat: %2/%3", _type, _count, _max];
 
+    private _alpha = if (_near) then {1} else {0.2};
+    _area setMarkerAlpha _alpha;
+    _label setMarkerAlpha _alpha;
+
     STALKER_mutantHabitats set [_forEachIndex, [_area,_label,_grp,_pos,_type,_max,_count,_near]];
 } forEach STALKER_mutantHabitats;
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHerds.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHerds.sqf
@@ -1,7 +1,7 @@
 /*
     Handles roaming mutant herds. The leader always remains in the world
     while the rest of the herd is only spawned when players are nearby.
-    STALKER_activeHerds entries: [leader, group, max, count, near]
+    STALKER_activeHerds entries: [leader, group, max, count, near, marker]
 */
 
 ["manageHerds"] call VIC_fnc_debugLog;
@@ -11,7 +11,7 @@ if (isNil "STALKER_activeHerds") exitWith {};
 private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
 
 {
-    _x params ["_leader", "_grp", "_max", "_count", "_near"];
+    _x params ["_leader", "_grp", "_max", "_count", "_near", "_marker"];
 
     if (isNull _grp) then { _grp = createGroup civilian; };
 
@@ -32,6 +32,7 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
     };
 
     private _pos = getPos _leader;
+    if (_marker != "") then { _marker setMarkerPos _pos; };
 
     if (_near) then {
         private _alive = { alive _x } count units _grp;
@@ -49,7 +50,7 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
         _count = { alive _x } count units _grp;
     } else {
         {
-            if (_x != _leader) then { deleteVehicle _x }; 
+            if (_x != _leader) then { deleteVehicle _x };
         } forEach units _grp;
 
         if (_count < _max && { random 100 < _chance }) then {
@@ -58,6 +59,10 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
         };
     };
 
-    STALKER_activeHerds set [_forEachIndex, [_leader, _grp, _max, _count, _near]];
+    if (_marker != "") then {
+        _marker setMarkerAlpha (if (_near) then {1} else {0.2});
+    };
+
+    STALKER_activeHerds set [_forEachIndex, [_leader, _grp, _max, _count, _near, _marker]];
 } forEach STALKER_activeHerds;
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHostiles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHostiles.sqf
@@ -10,9 +10,9 @@ if (isNil "STALKER_activeHostiles") exitWith {};
 private _size = ["VSA_mutantThreat", 3] call VIC_fnc_getSetting;
 
 {
-    _x params ["_grp", "_type", "_pos"];
+    _x params ["_grp", "_type", "_pos", "_marker", "_near"];
     private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
-    private _near = [_pos, _dist] call VIC_fnc_hasPlayersNearby;
+    _near = [_pos, _dist] call VIC_fnc_hasPlayersNearby;
     if (_near) then {
         if (isNull _grp || { count units _grp == 0 }) then {
             private _new = createGroup east;
@@ -21,14 +21,16 @@ private _size = ["VSA_mutantThreat", 3] call VIC_fnc_getSetting;
                 [_u] call VIC_fnc_initMutantUnit;
             };
             [_new, _pos] call BIS_fnc_taskPatrol;
-            STALKER_activeHostiles set [_forEachIndex, [_new, _type, _pos]];
+            _grp = _new;
         };
     } else {
         if (!isNull _grp) then {
             { deleteVehicle _x } forEach units _grp;
             deleteGroup _grp;
-            STALKER_activeHostiles set [_forEachIndex, [grpNull, _type, _pos]];
+            _grp = grpNull;
         };
     };
+    if (_marker != "") then { _marker setMarkerAlpha (if (_near) then {1} else {0.2}); };
+    STALKER_activeHostiles set [_forEachIndex, [_grp, _type, _pos, _marker, _near]];
 } forEach STALKER_activeHostiles;
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_onMutantKilled.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_onMutantKilled.sqf
@@ -11,10 +11,10 @@ if (!isServer) exitWith {};
 private _herdIndex = _unit getVariable ["VSA_herdIndex", -1];
 if (_herdIndex > -1 && {!isNil "STALKER_activeHerds"}) then {
     private _entry = STALKER_activeHerds select _herdIndex;
-    _entry params ["_leader","_grp","_max","_count","_near"];
+    _entry params ["_leader","_grp","_max","_count","_near","_marker"];
     _count = _count - 1;
     if (_count < 0) then {_count = 0;};
-    STALKER_activeHerds set [_herdIndex, [_leader,_grp,_max,_count,_near]];
+    STALKER_activeHerds set [_herdIndex, [_leader,_grp,_max,_count,_near,_marker]];
 };
 
 // Habitat members

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf
@@ -35,5 +35,12 @@ for "_i" from 1 to _herdCount do {
     _leader setVariable ["VSA_herdIndex", count STALKER_activeHerds];
     _leader addEventHandler ["Killed", { [_this#0] call VIC_fnc_onMutantKilled }];
     [_grp, _pos] call BIS_fnc_taskPatrol;
-    STALKER_activeHerds pushBack [_leader, _grp, _herdSize, _herdSize, false];
-};
+    private _markerName = format ["herd_%1_%2", count STALKER_activeHerds, diag_tickTime];
+    private _marker = createMarker [_markerName, _pos];
+    _marker setMarkerShape "ICON";
+    _marker setMarkerType "mil_dot";
+    _marker setMarkerColor "ColorOrange";
+    _marker setMarkerAlpha 0.2;
+
+    STALKER_activeHerds pushBack [_leader, _grp, _herdSize, _herdSize, false, _marker];
+}; 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf
@@ -38,6 +38,12 @@ for "_i" from 1 to _groupCount do {
         [_u] call VIC_fnc_initMutantUnit;
     };
     [_grp, _spawnPos] call BIS_fnc_taskPatrol;
-    STALKER_activeHostiles pushBack [_grp, "hostile", _spawnPos];
+    private _markerName = format ["hostile_%1_%2", _i, diag_tickTime];
+    private _marker = createMarker [_markerName, _spawnPos];
+    _marker setMarkerShape "ICON";
+    _marker setMarkerType "mil_dot";
+    _marker setMarkerColor "ColorOrange";
+    _marker setMarkerAlpha 1;
+    STALKER_activeHostiles pushBack [_grp, "hostile", _spawnPos, _marker, true];
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -40,4 +40,11 @@ switch (_type) do {
 
 [_grp, _player] call BIS_fnc_taskAttack;
 
-STALKER_activePredators pushBack [_grp, _player];
+private _markerName = format ["pred_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _spawnPos];
+_marker setMarkerShape "ICON";
+_marker setMarkerType "mil_warning";
+_marker setMarkerColor "ColorRed";
+_marker setMarkerAlpha 1;
+
+STALKER_activePredators pushBack [_grp, _player, _marker, true];

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf
@@ -17,10 +17,10 @@ if (!isNil "STALKER_mutantHabitats") then {
 
 if (!isNil "STALKER_activeHerds") then {
     {
-        _x params ["_leader","_grp","_max","_count","_near"];
+        _x params ["_leader","_grp","_max","_count","_near","_marker"];
         _near = [getPos _leader,_range] call VIC_fnc_hasPlayersNearby;
-        STALKER_activeHerds set [_forEachIndex, [_leader,_grp,_max,_count,_near]];
+        STALKER_activeHerds set [_forEachIndex, [_leader,_grp,_max,_count,_near,_marker]];
     } forEach STALKER_activeHerds;
-};
+}; 
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf
@@ -81,10 +81,20 @@ for "_i" from 1 to _count do {
     private _disp = _class select [4];
     _marker setMarkerText format ["%1 x%2", _disp, _num];
     _zone setVariable ["zoneMarker", _marker];
+    private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+
+    [_zone, _marker, _range] spawn {
+        params ["_zone","_marker","_range"];
+        while {alive _zone} do {
+            private _near = [getPosATL _zone, _range] call VIC_fnc_hasPlayersNearby;
+            _marker setMarkerAlpha (if (_near) then {1} else {0.2});
+            sleep 5;
+        };
+    };
 
     drg_activeSpookZones pushBack _zone;
-    [_zone, _spawned, _duration] spawn {
-        params ["_zone","_spooks","_dur"];
+    [_zone, _spawned, _duration, _marker] spawn {
+        params ["_zone","_spooks","_dur","_marker"];
         sleep (_dur * 60);
         {
             if (!isNull _x) then {
@@ -95,9 +105,8 @@ for "_i" from 1 to _count do {
             };
         } forEach _spooks;
         if (!isNull _zone) then {
-            private _m = _zone getVariable ["zoneMarker", ""];
-            if (_m isNotEqualTo "") then { deleteMarker _m; };
             deleteVehicle _zone;
         };
+        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
 };


### PR DESCRIPTION
## Summary
- keep anomaly markers in place and fade them when players are away
- add a new script to draw range markers on players in debug mode
- register and call the new function when debug is enabled
- fade habitat markers to 20% opacity when players aren’t nearby
- add markers for herds, hostile patrols, predator attacks and spook zones that fade when no players are near

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684af3fc54a0832f982353945f536076