### PR TITLE
Fix debug markers and gravi anomalies

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -7,7 +7,8 @@ class CfgPatches
         requiredAddons[] = {
             "A3_Functions_F",
             "CBA_Extended_EventHandlers",
-            "cba_main"
+            "cba_main",
+            "diwako_anomalies_main"
         };
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -29,7 +29,12 @@ private _spawned = [];
 for "_i" from 1 to _count do {
     private _off = [_site, random 15, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getSurfacePosition;
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createGravi;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createGravi", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_gravi: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
@@ -14,7 +14,7 @@ missionNamespace setVariable ["VSA_rangeMarkersActive", true];
 if (isNil "STALKER_playerRangeMarkers") then { STALKER_playerRangeMarkers = [] };
 
 [] spawn {
-    while (["VSA_debugMode", false] call VIC_fnc_getSetting) do {
+    while { ["VSA_debugMode", false] call VIC_fnc_getSetting } do {
         private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
         private _players = allPlayers;
 

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -21,3 +21,9 @@ STALKER_anomalyFields = [];
 // Prepare spook zone locations
 [] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\spooks\fn_setupSpookZones.sqf";
 
+// Generate anomaly fields across the map
+for "_i" from 1 to 10 do {
+    private _pos = [random worldSize, random worldSize, 0];
+    [_pos, 1000] call VIC_fnc_spawnAllAnomalyFields;
+};
+


### PR DESCRIPTION
## Summary
- fix `while` syntax in `fn_markPlayerRanges` so it runs in debug mode
- check for Diwako gravi creation function before using it
- declare Diwako's anomalies dependency in `config.cpp`
- generate anomaly fields globally on server init

## Testing
- `git diff HEAD~1 HEAD --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b05b4072c832fae49489aacb58353