### PR TITLE
Fix CBRN module spawn call

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -35,7 +35,10 @@ _module setVariable ["CBRN_Radius", _radius, true];
 _module setVariable ["CBRN_Lifetime", _duration, true];
 _module setVariable ["CBRN_Thickness", 1, true];
 _module setVariable ["CBRN_ChemType", 1, true]; // Asphyxiant gas
-[_module] call CBRN_fnc_ModuleSpawnCSGas;
+[
+    "init",
+    _module
+] call CBRN_fnc_ModuleSpawnCSGas;
 
 // Create and configure a map marker for this chemical zone
 private _markerName = format ["chem_%1", diag_tickTime];


### PR DESCRIPTION
## Summary
- call `CBRN_fnc_ModuleSpawnCSGas` with the required mode parameter

## Testing
- `grep -n "ModuleSpawnCSGas" -n addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684b0cb53b8c832fb4600982fdf190ce