### PR TITLE
Add configurable psy-storm discharges

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 
 ### Storms
 * Periodic psy-storms that force players to seek shelter.
+* During a storm random Psy Discharges rain down across the map with Zeus lightning effects.
+* Duration, intensity and the delay between storms can be configured via CBA settings.
 * Works with the emission hook system for mission-specific consequences.
 
 ### Zombification

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -275,6 +275,11 @@ true
     false
 ] call CBA_fnc_addSetting;
 
+["VSA_stormMinDelay","SLIDER",["Min Delay (s)","Minimum seconds between storms"],"Viceroy's STALKER ALife - Storms",[0,7200,1800,0]] call CBA_fnc_addSetting;
+["VSA_stormMaxDelay","SLIDER",["Max Delay (s)","Maximum seconds between storms"],"Viceroy's STALKER ALife - Storms",[0,7200,3600,0]] call CBA_fnc_addSetting;
+["VSA_stormDuration","SLIDER",["Storm Duration (s)","Length of each psy-storm"],"Viceroy's STALKER ALife - Storms",[5,300,60,0]] call CBA_fnc_addSetting;
+["VSA_stormStrikeIntensity","SLIDER",["Strike Intensity","Psy discharges spawned per second"],"Viceroy's STALKER ALife - Storms",[1,20,3,0]] call CBA_fnc_addSetting;
+
 // -----------------------------------------------------------------------------
 // Zombification
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -7,7 +7,11 @@ if (!hasInterface) exitWith {};
 if (missionNamespace getVariable ["VSA_debugActionsAdded", false]) exitWith {};
 missionNamespace setVariable ["VSA_debugActionsAdded", true];
 
-player addAction ["Spawn Psy-Storm", { [] call VIC_fnc_triggerPsyStorm }];
+player addAction ["Spawn Psy-Storm", {
+    private _dur = ["VSA_stormDuration", 60] call VIC_fnc_getSetting;
+    private _int = ["VSA_stormStrikeIntensity", 3] call VIC_fnc_getSetting;
+    [_dur, _int] call VIC_fnc_triggerPsyStorm
+}];
 player addAction ["Spawn Chemical Zone", { [getPos player, 100] call VIC_fnc_spawnChemicalZone }];
 player addAction ["Spawn Random Chemicals", { [getPos player, 200] call VIC_fnc_spawnRandomChemicalZones }];
 player addAction ["Spawn Anomaly Fields", { [getPos player, 200] call VIC_fnc_spawnAllAnomalyFields }];

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
@@ -25,6 +25,8 @@ if (["VSA_enableStorms", true] call VIC_fnc_getSetting isEqualTo false) exitWith
 private _interval = ["VSA_stormInterval", 30] call VIC_fnc_getSetting;
 private _spawnWeight = ["VSA_stormSpawnWeight", 50] call VIC_fnc_getSetting;
 private _nightOnly = ["VSA_stormsNightOnly", false] call VIC_fnc_getSetting;
+private _duration = ["VSA_stormDuration", 60] call VIC_fnc_getSetting;
+private _intensity = ["VSA_stormStrikeIntensity", 3] call VIC_fnc_getSetting;
 
 _minDelay = ["VSA_stormMinDelay", _minDelay] call VIC_fnc_getSetting;
 _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
@@ -32,21 +34,21 @@ _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
 if (_minDelay < 0) then { _minDelay = 0; };
 if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
-[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly] spawn {
-    params ["_min", "_max", "_var", "_weight", "_night"];
+[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _intensity] spawn {
+    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_int"];
     private _nextStorm = time + (_min + random (_max - _min));
     while {true} do {
         if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
             missionNamespace setVariable [_var, false, true];
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [] call VIC_fnc_triggerPsyStorm;
+                [_dur, _int] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };
 
         if (time >= _nextStorm) then {
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [] call VIC_fnc_triggerPsyStorm;
+                [_dur, _int] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -6,14 +6,16 @@
 
     Params:
         0: NUMBER - duration of the storm in seconds (default 60)
-        1: NUMBER - damage applied to exposed units per tick (default 0.03)
-        2: BOOL   - enable hallucination effects (default true)
-        3: BOOL   - spawn spook zone when finished (default false)
-        4: BOOL   - spawn zombies when finished (default false)
+        1: NUMBER - strikes spawned each second (default 3)
+        2: NUMBER - damage applied to exposed units per tick (default 0.03)
+        3: BOOL   - enable hallucination effects (default true)
+        4: BOOL   - spawn spook zone when finished (default false)
+        5: BOOL   - spawn zombies when finished (default false)
 */
 
 params [
     ["_duration", 60],
+    ["_intensity", 3],
     ["_damage", 0.03],
     ["_hallucinations", true],
     ["_spawnSpooks", false],
@@ -38,6 +40,14 @@ for "_i" from 1 to _ticks do {
             };
         };
     } forEach allUnits;
+
+    for "_j" from 1 to _intensity do {
+        private _pos = [random worldSize, random worldSize, 0];
+        private _surf = [_pos] call VIC_fnc_getSurfacePosition;
+        private _module = "diwako_anomalies_main_modulePsyDischarge" createVehicle _surf;
+        ["init", _module] call diwako_anomalies_main_fnc_modulePsyDischarge;
+        [_surf] call BIS_fnc_moduleLightning;
+    };
 
     if (_hallucinations && {random 1 < 0.15}) then {
         private _sounds = [


### PR DESCRIPTION
## Summary
- expand storm description in README
- add new storm CBA settings
- spawn Psy Discharges and lightning during storms
- support storm duration/intensity in scheduler
- allow debug action to use storm settings

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b655c97f0832f866380c28a51d3c8