### PR TITLE
Implement variable psy-storm intensity

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 
 ### Storms
 * Periodic psy-storms that force players to seek shelter.
-* During a storm random Psy Discharges rain down across the map with Zeus lightning effects.
-* Duration, intensity and the delay between storms can be configured via CBA settings.
+* During a storm random Psy Discharges rain down across the map with Zeus lightning effects that grow more frequent over time.
+* Duration, starting and ending intensity, and the delay between storms can all be configured via CBA settings.
 * Works with the emission hook system for mission-specific consequences.
 
 ### Zombification

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -277,8 +277,9 @@ true
 
 ["VSA_stormMinDelay","SLIDER",["Min Delay (s)","Minimum seconds between storms"],"Viceroy's STALKER ALife - Storms",[0,7200,1800,0]] call CBA_fnc_addSetting;
 ["VSA_stormMaxDelay","SLIDER",["Max Delay (s)","Maximum seconds between storms"],"Viceroy's STALKER ALife - Storms",[0,7200,3600,0]] call CBA_fnc_addSetting;
-["VSA_stormDuration","SLIDER",["Storm Duration (s)","Length of each psy-storm"],"Viceroy's STALKER ALife - Storms",[5,300,60,0]] call CBA_fnc_addSetting;
-["VSA_stormStrikeIntensity","SLIDER",["Strike Intensity","Psy discharges spawned per second"],"Viceroy's STALKER ALife - Storms",[1,20,3,0]] call CBA_fnc_addSetting;
+["VSA_stormDuration","SLIDER",["Storm Duration (s)","Length of each psy-storm"],"Viceroy's STALKER ALife - Storms",[30,600,180,0]] call CBA_fnc_addSetting;
+["VSA_stormIntensityStart","SLIDER",["Intensity Start","Strikes per second at storm start"],"Viceroy's STALKER ALife - Storms",[1,20,2,0]] call CBA_fnc_addSetting;
+["VSA_stormIntensityEnd","SLIDER",["Intensity End","Strikes per second when storm ends"],"Viceroy's STALKER ALife - Storms",[1,40,6,0]] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
 // Zombification

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -8,9 +8,10 @@ if (missionNamespace getVariable ["VSA_debugActionsAdded", false]) exitWith {};
 missionNamespace setVariable ["VSA_debugActionsAdded", true];
 
 player addAction ["Spawn Psy-Storm", {
-    private _dur = ["VSA_stormDuration", 60] call VIC_fnc_getSetting;
-    private _int = ["VSA_stormStrikeIntensity", 3] call VIC_fnc_getSetting;
-    [_dur, _int] call VIC_fnc_triggerPsyStorm
+    private _dur = ["VSA_stormDuration", 180] call VIC_fnc_getSetting;
+    private _start = ["VSA_stormIntensityStart", 2] call VIC_fnc_getSetting;
+    private _end = ["VSA_stormIntensityEnd", 6] call VIC_fnc_getSetting;
+    [_dur, _start, _end] call VIC_fnc_triggerPsyStorm
 }];
 player addAction ["Spawn Chemical Zone", { [getPos player, 100] call VIC_fnc_spawnChemicalZone }];
 player addAction ["Spawn Random Chemicals", { [getPos player, 200] call VIC_fnc_spawnRandomChemicalZones }];

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
@@ -25,8 +25,9 @@ if (["VSA_enableStorms", true] call VIC_fnc_getSetting isEqualTo false) exitWith
 private _interval = ["VSA_stormInterval", 30] call VIC_fnc_getSetting;
 private _spawnWeight = ["VSA_stormSpawnWeight", 50] call VIC_fnc_getSetting;
 private _nightOnly = ["VSA_stormsNightOnly", false] call VIC_fnc_getSetting;
-private _duration = ["VSA_stormDuration", 60] call VIC_fnc_getSetting;
-private _intensity = ["VSA_stormStrikeIntensity", 3] call VIC_fnc_getSetting;
+private _duration = ["VSA_stormDuration", 180] call VIC_fnc_getSetting;
+private _startIntensity = ["VSA_stormIntensityStart", 2] call VIC_fnc_getSetting;
+private _endIntensity = ["VSA_stormIntensityEnd", 6] call VIC_fnc_getSetting;
 
 _minDelay = ["VSA_stormMinDelay", _minDelay] call VIC_fnc_getSetting;
 _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
@@ -34,21 +35,21 @@ _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
 if (_minDelay < 0) then { _minDelay = 0; };
 if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
-[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _intensity] spawn {
-    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_int"];
+[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _startIntensity, _endIntensity] spawn {
+    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_start", "_end"];
     private _nextStorm = time + (_min + random (_max - _min));
     while {true} do {
         if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
             missionNamespace setVariable [_var, false, true];
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _int] call VIC_fnc_triggerPsyStorm;
+                [_dur, _start, _end] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };
 
         if (time >= _nextStorm) then {
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _int] call VIC_fnc_triggerPsyStorm;
+                [_dur, _start, _end] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -5,17 +5,19 @@
         and can spawn spooks or zombies.
 
     Params:
-        0: NUMBER - duration of the storm in seconds (default 60)
-        1: NUMBER - strikes spawned each second (default 3)
-        2: NUMBER - damage applied to exposed units per tick (default 0.03)
-        3: BOOL   - enable hallucination effects (default true)
-        4: BOOL   - spawn spook zone when finished (default false)
-        5: BOOL   - spawn zombies when finished (default false)
+        0: NUMBER - duration of the storm in seconds (default 180)
+        1: NUMBER - starting strikes per second (default 2)
+        2: NUMBER - ending strikes per second (default 6)
+        3: NUMBER - damage applied to exposed units per tick (default 0.03)
+        4: BOOL   - enable hallucination effects (default true)
+        5: BOOL   - spawn spook zone when finished (default false)
+        6: BOOL   - spawn zombies when finished (default false)
 */
 
 params [
-    ["_duration", 60],
-    ["_intensity", 3],
+    ["_duration", 180],
+    ["_startIntensity", 2],
+    ["_endIntensity", 6],
     ["_damage", 0.03],
     ["_hallucinations", true],
     ["_spawnSpooks", false],
@@ -31,6 +33,8 @@ _effect ppEffectCommit 0;
 
 private _ticks = floor _duration;
 for "_i" from 1 to _ticks do {
+    private _progress = (_i - 1) / (_ticks max 1);
+    private _currentIntensity = round (_startIntensity + (_endIntensity - _startIntensity) * _progress);
     {
         if (alive _x) then {
             private _from = eyePos _x;
@@ -41,7 +45,7 @@ for "_i" from 1 to _ticks do {
         };
     } forEach allUnits;
 
-    for "_j" from 1 to _intensity do {
+    for "_j" from 1 to _currentIntensity do {
         private _pos = [random worldSize, random worldSize, 0];
         private _surf = [_pos] call VIC_fnc_getSurfacePosition;
         private _module = "diwako_anomalies_main_modulePsyDischarge" createVehicle _surf;


### PR DESCRIPTION
## Summary
- extend storms with start/end intensity settings and longer default duration
- grow psy-storm strike frequency over time
- expose new storm settings in debug actions and CBA options
- update README to mention the new behaviour

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b6f081874832fb7fceb2c03e588a0