### PR TITLE
Fix syntax errors in minefield functions

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
@@ -17,4 +17,4 @@ private _pos = if (isNull _road) then { _center } else { getPos _road };
 
 private _ied = createMine ["IEDLandSmall_F", _pos, [], 0];
 
-[_ied]
+[_ied];

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -28,7 +28,7 @@ for "_i" from 1 to _fieldCount do {
     private _tPos = locationPosition _town;
     private _pos = _tPos getPos [150 + random 200, random 360];
     _pos = [_pos] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue };
+    if (_pos isEqualTo []) then { continue; };
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = createMarker [format ["mf_%1", diag_tickTime], _pos];
@@ -46,7 +46,7 @@ for "_i" from 1 to _iedCount do {
     private _town = selectRandom _towns;
     private _tPos = locationPosition _town;
     private _road = nearestRoad _tPos;
-    if (isNull _road) then { continue };
+    if (isNull _road) then { continue; };
     private _pos = getPos _road;
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {


### PR DESCRIPTION
## Summary
- add missing semicolon to `fn_spawnIED.sqf`
- ensure `continue` statements end with semicolons in `fn_spawnMinefields.sqf`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b6fd4d22c832fa91c1fec151e9ebe