### PR TITLE
Fix call to CBRN gas module

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -37,7 +37,7 @@ _module setVariable ["CBRN_Thickness", 1, true];
 _module setVariable ["CBRN_ChemType", 1, true]; // Asphyxiant gas
 [
     "init",
-    _module
+    [_module]
 ] call CBRN_fnc_ModuleSpawnCSGas;
 
 // Create and configure a map marker for this chemical zone


### PR DESCRIPTION
## Summary
- pass gas module object in an array when initializing CBRN module

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b70f443e8832fa62ffcd2558faf96