### PR TITLE
Improve debug spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Supports common anomaly types like burners, electras, fruit punches and springboards.
 * Relies on **Diwako’s Anomalies** for the core anomaly logic.
 * Map markers are removed when their anomaly field despawns after `STALKER_AnomalyFieldDuration` minutes.
+* Fields are distributed randomly across the entire map.
+* Anomalies only activate when players are nearby and go dormant when no one is in range.
 
 ### Mutants
 * Spawns roaming mutant packs and ambient herds.
@@ -126,7 +128,7 @@ spawns at night, during the day or both.
 4. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    This option can now be toggled while a mission is running and the debug
    actions will appear automatically.
-5. When debug mode is active, your scroll menu includes options to trigger storms, spawn anomaly fields or spook zones, generate habitats, spawn ambient herds, summon predator attacks and other test helpers.
+5. When debug mode is active, your scroll menu includes options to trigger storms, spawn anomaly fields or spook zones, generate habitats, spawn ambient herds, summon predator attacks and other test helpers. All spawn actions run on the server so they work correctly in multiplayer and the anomaly field option populates random locations across the map.
 
 If your mission reports undefined CBA settings, ensure that **CBA A3** is loaded and initialized before this mod. Settings now fall back to defaults via `VIC_fnc_getSetting` when CBA has not yet finished loading.
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -11,19 +11,44 @@ player addAction ["Spawn Psy-Storm", {
     private _dur = ["VSA_stormDuration", 180] call VIC_fnc_getSetting;
     private _start = ["VSA_stormIntensityStart", 2] call VIC_fnc_getSetting;
     private _end = ["VSA_stormIntensityEnd", 6] call VIC_fnc_getSetting;
-    [_dur, _start, _end] call VIC_fnc_triggerPsyStorm
+    [_dur, _start, _end] remoteExec ["VIC_fnc_triggerPsyStorm", 2];
 }];
-player addAction ["Spawn Chemical Zone", { [getPos player, 100] call VIC_fnc_spawnChemicalZone }];
-player addAction ["Spawn Random Chemicals", { [getPos player, 200] call VIC_fnc_spawnRandomChemicalZones }];
-player addAction ["Spawn Anomaly Fields", { [getPos player, 200] call VIC_fnc_spawnAllAnomalyFields }];
-player addAction ["Spawn Mutant Group", { [getPos player] call VIC_fnc_spawnMutantGroup }];
-player addAction ["Spawn Spook Zone", { [] call VIC_fnc_spawnSpookZone }];
-player addAction ["Spawn Zombies From Queue", { [] call VIC_fnc_spawnZombiesFromQueue }];
-player addAction ["Spawn Ambient Herds", { [] call VIC_fnc_spawnAmbientHerds }];
-player addAction ["Spawn Predator Attack", { [player] call VIC_fnc_spawnPredatorAttack }];
-player addAction ["Spawn Minefields", { [getPos player, 300] call VIC_fnc_spawnMinefields }];
-player addAction ["Generate Mutant Habitats", { [] call VIC_fnc_setupMutantHabitats }];
-player addAction ["Cycle Habitats", { [] call VIC_fnc_manageHabitats }];
+player addAction ["Spawn Chemical Zone", {
+    [getPos player, 100] remoteExec ["VIC_fnc_spawnChemicalZone", 2];
+}];
+player addAction ["Spawn Random Chemicals", {
+    [getPos player, 200] remoteExec ["VIC_fnc_spawnRandomChemicalZones", 2];
+}];
+player addAction ["Spawn Anomaly Fields", {
+    for "_i" from 1 to 100 do {
+        private _pos = [random worldSize, random worldSize, 0];
+        [_pos, 1000] remoteExec ["VIC_fnc_spawnAllAnomalyFields", 2];
+    };
+}];
+player addAction ["Spawn Mutant Group", {
+    [getPos player] remoteExec ["VIC_fnc_spawnMutantGroup", 2];
+}];
+player addAction ["Spawn Spook Zone", {
+    [] remoteExec ["VIC_fnc_spawnSpookZone", 2];
+}];
+player addAction ["Spawn Zombies From Queue", {
+    [] remoteExec ["VIC_fnc_spawnZombiesFromQueue", 2];
+}];
+player addAction ["Spawn Ambient Herds", {
+    [] remoteExec ["VIC_fnc_spawnAmbientHerds", 2];
+}];
+player addAction ["Spawn Predator Attack", {
+    [player] remoteExec ["VIC_fnc_spawnPredatorAttack", 2];
+}];
+player addAction ["Spawn Minefields", {
+    [getPos player, 300] remoteExec ["VIC_fnc_spawnMinefields", 2];
+}];
+player addAction ["Generate Mutant Habitats", {
+    [] remoteExec ["VIC_fnc_setupMutantHabitats", 2];
+}];
+player addAction ["Cycle Habitats", {
+    [] remoteExec ["VIC_fnc_manageHabitats", 2];
+}];
 player addAction ["Mark All Buildings", { [] call VIC_fnc_markAllBuildings }];
 
 ["Debug actions added"] call VIC_fnc_debugLog;


### PR DESCRIPTION
## Summary
- remote exec debug spawn actions so they run on the server
- spawn anomaly fields randomly across the map via debug action
- clarify anomaly behaviour in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7180233c832fb11e282316cc98ba