### PR TITLE
Add day/night predator attacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
   the herd when players come within a configurable nearby range (default 1500
   meters). Their population slowly
   regenerates over time.
-* Rare predator ambushes may spawn a chimera or pack of bloodsuckers at night to
-  hunt nearby players.
+* Predator ambushes now depend on the time of day. Daylight attacks can bring
+  packs of dogs, herds of boars or even snorks. When night falls chimeras,
+  bloodsuckers, cats or pseudodogs stalk their prey. Very rarely a lone goliath
+  or crusher may strike.
 * Mutants no longer use default Arma voices and remain silent when spawned.
 
 ### Mutant Habitats

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -30,13 +30,58 @@ if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     _spawnMarker setMarkerText "Predator Spawn";
 };
 
-private _chimeraClasses = ["armst_chimera"];
+private _dogClasses       = ["armst_blinddog1","armst_blinddog2","armst_blinddog3"];
+private _boarClasses      = ["armst_boar","armst_boar2"];
+private _snorkClasses     = ["armst_snork"];
+private _pseudodogClasses = ["armst_pseudodog","armst_pseudodog2"];
+private _catClasses       = ["armst_cat"];
+private _chimeraClasses   = ["armst_chimera"];
 private _bloodsuckerClasses = ["armst_krovosos","armst_krovosos2"];
+private _goliathClasses   = ["WBK_Goliaph_3"];
+private _crusherClasses   = ["WBK_SpecialZombie_Smasher_3"];
 
-private _type = selectRandom ["chimera","bloodsucker"];
+private _isNight = !(daytime > 5 && daytime < 20);
+
+private _dayTypes   = ["dog","boar","snork"];
+private _nightTypes = ["chimera","bloodsucker","cat","pseudodog"];
+private _rareTypes  = ["goliath","crusher"];
+
+private _type = if (random 100 < 3) then { selectRandom _rareTypes } else {
+    if (_isNight) then { selectRandom _nightTypes } else { selectRandom _dayTypes }
+};
 private _grp = createGroup east;
 
 switch (_type) do {
+    case "dog": {
+        for "_i" from 1 to 4 do {
+            private _u = _grp createUnit [selectRandom _dogClasses, _spawnPos, [], 0, "FORM"];
+            [_u] call VIC_fnc_initMutantUnit;
+        };
+    };
+    case "boar": {
+        for "_i" from 1 to 3 do {
+            private _u = _grp createUnit [selectRandom _boarClasses, _spawnPos, [], 0, "FORM"];
+            [_u] call VIC_fnc_initMutantUnit;
+        };
+    };
+    case "snork": {
+        for "_i" from 1 to 3 do {
+            private _u = _grp createUnit [selectRandom _snorkClasses, _spawnPos, [], 0, "FORM"];
+            [_u] call VIC_fnc_initMutantUnit;
+        };
+    };
+    case "pseudodog": {
+        for "_i" from 1 to 3 do {
+            private _u = _grp createUnit [selectRandom _pseudodogClasses, _spawnPos, [], 0, "FORM"];
+            [_u] call VIC_fnc_initMutantUnit;
+        };
+    };
+    case "cat": {
+        for "_i" from 1 to 2 do {
+            private _u = _grp createUnit [selectRandom _catClasses, _spawnPos, [], 0, "FORM"];
+            [_u] call VIC_fnc_initMutantUnit;
+        };
+    };
     case "chimera": {
         private _u = _grp createUnit [selectRandom _chimeraClasses, _spawnPos, [], 0, "FORM"];
         [_u] call VIC_fnc_initMutantUnit;
@@ -46,6 +91,14 @@ switch (_type) do {
             private _u = _grp createUnit [selectRandom _bloodsuckerClasses, _spawnPos, [], 0, "FORM"];
             [_u] call VIC_fnc_initMutantUnit;
         };
+    };
+    case "goliath": {
+        private _u = _grp createUnit [selectRandom _goliathClasses, _spawnPos, [], 0, "FORM"];
+        [_u] call VIC_fnc_initMutantUnit;
+    };
+    case "crusher": {
+        private _u = _grp createUnit [selectRandom _crusherClasses, _spawnPos, [], 0, "FORM"];
+        [_u] call VIC_fnc_initMutantUnit;
     };
 };
 


### PR DESCRIPTION
## Summary
- expand predator attack to spawn different mutant groups based on time of day
- include rare goliath or crusher encounters
- document the new behavior in README
- fix snork class in predator attack

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_684b75efd7e4832fbe32a13ed77c206d