### PR TITLE
Add random habitat positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Population counts persist while sleeping and gradually replenish between spawn cycles.
 * Player proximity is checked on a separate timer via `VSA_proximityCheckInterval`.
 * Habitat and herd counts update immediately when mutants are killed.
+* Habitat placement now selects random buildings, forests and swamps with weighted preferences.
+  Locations are offset slightly each mission so nests appear in different spots every time.
 * CBA settings allow mission makers to customize these behaviors.
 
 ### Chemical Zones
@@ -92,6 +94,7 @@ Every mutant type can establish a nest which spawns defenders when players are n
 * **Flesh** – Slow but hardy pig-like creatures.
 * **Blind Dog** – Pack hunters that overwhelm with numbers.
 * **Pseudodog** – Mutated canines with psychic screeches.
+* **Snork** – Feral mutants that charge at enemies with terrifying leaps.
 * **Controller** – Psionic mutants capable of mind tricks.
 * **Pseudogiant** – Towering brutes that shake the ground.
 * **Izlom** – Twisted humanoids shuffling across the Zone.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -457,6 +457,7 @@ true
 ["VSA_habitatSize_Controller","SLIDER",["Controller Habitat Size","Max controllers per habitat"],"Viceroy's STALKER ALife - Mutants",[0, 40, 8, 0]] call CBA_fnc_addSetting;
 ["VSA_habitatSize_Pseudogiant","SLIDER",["Pseudogiant Habitat Size","Max pseudogiants per habitat"],"Viceroy's STALKER ALife - Mutants",[0, 30, 6, 0]] call CBA_fnc_addSetting;
 ["VSA_habitatSize_Izlom","SLIDER",["Izlom Habitat Size","Max izlom per habitat"],"Viceroy's STALKER ALife - Mutants",[0, 50, 10, 0]] call CBA_fnc_addSetting;
+["VSA_habitatSize_Snork","SLIDER",["Snork Habitat Size","Max snorks per habitat"],"Viceroy's STALKER ALife - Mutants",[0, 60, 12, 0]] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
 // Minefields

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -57,6 +57,7 @@ class CfgFunctions
             class spawnFleshNest{};
             class spawnBlindDogNest{};
             class spawnPseudodogNest{};
+            class spawnSnorkNest{};
             class spawnControllerNest{};
             class spawnPseudogiantNest{};
             class spawnIzlomNest{};

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -73,6 +73,7 @@ VIC_fnc_spawnCatNest            = compile preprocessFileLineNumbers (_root + "\f
 VIC_fnc_spawnFleshNest          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnFleshNest.sqf");
 VIC_fnc_spawnBlindDogNest       = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnBlindDogNest.sqf");
 VIC_fnc_spawnPseudodogNest      = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnPseudodogNest.sqf");
+VIC_fnc_spawnSnorkNest         = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnSnorkNest.sqf");
 VIC_fnc_spawnControllerNest     = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnControllerNest.sqf");
 VIC_fnc_spawnPseudogiantNest    = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnPseudogiantNest.sqf");
 VIC_fnc_spawnIzlomNest          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnIzlomNest.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -19,9 +19,14 @@ private _getClass = {
         case "Flesh": { selectRandom ["armst_PLOT","armst_PLOT2"] };
         case "Blind Dog": { selectRandom ["armst_blinddog1","armst_blinddog2","armst_blinddog3"] };
         case "Pseudodog": { selectRandom ["armst_pseudodog","armst_pseudodog2"] };
+        case "Snork": { "armst_snork" };
         case "Controller": { selectRandom ["armst_controller_new","armst_controller_new2","armst_controller_new3"] };
         case "Pseudogiant": { selectRandom ["armst_giant","armst_giant2"] };
         case "Izlom": { "armst_izlom" };
+        case "Corruptor": { "WBK_SpecialZombie_Corrupted_3" };
+        case "Smasher": { "WBK_SpecialZombie_Smasher_3" };
+        case "Acid Smasher": { "WBK_SpecialZombie_Smasher_Acid_3" };
+        case "Behemoth": { "WBK_Goliaph_3" };
         default { "O_ALF_Mutant" };
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -27,12 +27,17 @@ private _createMarker = {
         case "Bloodsucker": { ["VSA_habitatSize_Bloodsucker",12] call VIC_fnc_getSetting };
         case "Blind Dog": { ["VSA_habitatSize_Dog",50] call VIC_fnc_getSetting };
         case "Pseudodog": { ["VSA_habitatSize_Dog",50] call VIC_fnc_getSetting };
+        case "Snork": { ["VSA_habitatSize_Snork",12] call VIC_fnc_getSetting };
         case "Boar": { ["VSA_habitatSize_Boar",10] call VIC_fnc_getSetting };
         case "Cat": { ["VSA_habitatSize_Cat",10] call VIC_fnc_getSetting };
         case "Flesh": { ["VSA_habitatSize_Flesh",10] call VIC_fnc_getSetting };
         case "Controller": { ["VSA_habitatSize_Controller",8] call VIC_fnc_getSetting };
         case "Pseudogiant": { ["VSA_habitatSize_Pseudogiant",6] call VIC_fnc_getSetting };
         case "Izlom": { ["VSA_habitatSize_Izlom",10] call VIC_fnc_getSetting };
+        case "Corruptor": { ["VSA_habitatSize_Corruptor",8] call VIC_fnc_getSetting };
+        case "Smasher": { ["VSA_habitatSize_Smasher",8] call VIC_fnc_getSetting };
+        case "Acid Smasher": { ["VSA_habitatSize_AcidSmasher",8] call VIC_fnc_getSetting };
+        case "Behemoth": { ["VSA_habitatSize_Behemoth",6] call VIC_fnc_getSetting };
         default {10};
     };
 
@@ -40,21 +45,119 @@ private _createMarker = {
     STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, _max, false];
 };
 
+private _weightedPick = {
+    params ["_list"];
+    private _sum = 0;
+    { _sum = _sum + (_x#1) } forEach _list;
+    private _r = random _sum;
+    private _acc = 0;
+    private _sel = _list#0#0;
+    {
+        _acc = _acc + (_x#1);
+        if (_r <= _acc) exitWith { _sel = _x#0 };
+    } forEach _list;
+    _sel
+};
+
+private _weightsGeneric = [
+    ["Bloodsucker",1],["Boar",1],["Cat",1],["Flesh",1],["Blind Dog",1],
+    ["Pseudodog",1],["Snork",1],["Controller",1],["Pseudogiant",1],["Izlom",1],
+    ["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+];
+private _weightsUrban = [
+    ["Snork",3],["Blind Dog",3],["Controller",2],["Izlom",2],
+    ["Pseudodog",1],["Boar",1],["Bloodsucker",1],["Flesh",1],["Pseudogiant",1],
+    ["Cat",1],["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+];
+private _weightsRural = [
+    ["Boar",3],["Pseudodog",3],["Pseudogiant",2],
+    ["Blind Dog",1],["Bloodsucker",1],["Flesh",1],["Cat",1],["Snork",1],
+    ["Controller",1],["Izlom",1],["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+];
+private _weightsForest = [
+    ["Cat",3],["Pseudodog",2],["Boar",1],["Bloodsucker",1],["Flesh",1],
+    ["Snork",1],["Controller",1],["Blind Dog",1],["Izlom",1],["Pseudogiant",1],
+    ["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+];
+private _weightsSwamp = [
+    ["Bloodsucker",3],["Flesh",3],["Acid Smasher",2],
+    ["Boar",1],["Pseudodog",1],["Pseudogiant",1],["Cat",1],["Snork",1],
+    ["Controller",1],["Blind Dog",1],["Izlom",1],["Corruptor",1],["Smasher",1],["Behemoth",1]
+];
+
+private _selectType = {
+    params ["_env"];
+    private _list = switch (_env) do {
+        case "urban": { _weightsUrban };
+        case "rural": { _weightsRural };
+        case "forest": { _weightsForest };
+        case "swamp": { _weightsSwamp };
+        default { _weightsGeneric };
+    };
+    [_list] call _weightedPick
+};
+
 private _center = [worldSize/2, worldSize/2, 0];
 private _locations = nearestLocations [_center, [], worldSize];
+private _buildings = allMissionObjects "building";
 
 {
     private _pos = locationPosition _x;
-    private _type = switch (type _x) do {
-        case "NameCity": {"Controller"};
-        case "NameCityCapital": {"Pseudogiant"};
-        case "NameVillage": {selectRandom ["Blind Dog","Izlom","Bloodsucker","Pseudodog"]};
-        case "Hill": {selectRandom ["Boar","Cat","Flesh"]};
-        default {""};
-    };
-    if (_type != "" && { !([_pos] call VIC_fnc_isWaterPosition) }) then {
-        [_type, _pos] call _createMarker;
+    _pos = [_pos, 0, 100, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+    if (random 1 > 0.5) then {
+        private _env = switch (type _x) do {
+            case "NameCity": "urban";
+            case "NameCityCapital": "urban";
+            case "NameVillage": "rural";
+            case "NameLocal": "rural";
+            case "Hill": "rural";
+            default "generic";
+        };
+        if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+            private _type = [_env] call _selectType;
+            [_type, _pos] call _createMarker;
+        };
     };
 } forEach _locations;
+
+for "_i" from 1 to 20 do {
+    private _b = selectRandom _buildings;
+    private _pos = getPosATL _b;
+    _pos = [_pos, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+    if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+        private _type = ["urban"] call _selectType;
+        [_type, _pos] call _createMarker;
+    };
+};
+
+private _forestSites = selectBestPlaces [_center, worldSize, "forest", 1, 50];
+{
+    private _pos = (_x select 0);
+    _pos = [_pos, 0, 75, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+    if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+        private _type = ["forest"] call _selectType;
+        [_type, _pos] call _createMarker;
+    };
+} forEach (_forestSites select [0,10]);
+
+private _swampSites = selectBestPlaces [_center, worldSize, "meadow", 1, 50];
+{
+    private _pos = (_x select 0);
+    _pos = [_pos, 0, 75, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+    if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+        private _type = ["swamp"] call _selectType;
+        [_type, _pos] call _createMarker;
+    };
+} forEach (_swampSites select [0,10]);
+
+private _allTypes = _weightsGeneric apply { _x#0 };
+private _existing = STALKER_mutantHabitats apply { _x#4 };
+{
+    if (!(_x in _existing)) then {
+        private _p = getPosATL (selectRandom _buildings);
+        _p = [_p, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+        if (!([_p] call VIC_fnc_isWaterPosition)) then { [_x, _p] call _createMarker; };
+    };
+} forEach _allTypes;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnSnorkNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnSnorkNest.sqf
@@ -1,0 +1,10 @@
+/*
+    Spawns a snork nest at the given position.
+    Params:
+        0: POSITION - location of the nest
+*/
+params ["_pos"];
+
+["spawnSnorkNest"] call VIC_fnc_debugLog;
+
+[_pos, "armst_snork"] call VIC_fnc_spawnMutantNest;


### PR DESCRIPTION
## Summary
- randomize habitat placement positions so nests vary each mission
- use only `armst_snork` for Snork mutants
- update docs on randomized placement

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b71f18ae4832f8f7b638d92496f27