### PR TITLE
Fix minefield placement script errors

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -28,17 +28,18 @@ for "_i" from 1 to _fieldCount do {
     private _tPos = locationPosition _town;
     private _pos = _tPos getPos [150 + random 200, random 360];
     _pos = [_pos] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue; };
-    private _marker = "";
-    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        _marker = createMarker [format ["mf_%1", diag_tickTime], _pos];
-        _marker setMarkerShape "RECTANGLE";
-        _marker setMarkerSize [_size/2,_size/2];
-        _marker setMarkerColor "ColorYellow";
-        _marker setMarkerText "APERS Field";
-        _marker setMarkerAlpha 0.2;
+    if (!(_pos isEqualTo [])) then {
+        private _marker = "";
+        if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+            _marker = createMarker [format ["mf_%1", diag_tickTime], _pos];
+            _marker setMarkerShape "RECTANGLE";
+            _marker setMarkerSize [_size/2,_size/2];
+            _marker setMarkerColor "ColorYellow";
+            _marker setMarkerText "APERS Field";
+            _marker setMarkerAlpha 0.2;
+        };
+        STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker];
     };
-    STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker];
 };
 
 for "_i" from 1 to _iedCount do {
@@ -46,17 +47,18 @@ for "_i" from 1 to _iedCount do {
     private _town = selectRandom _towns;
     private _tPos = locationPosition _town;
     private _road = nearestRoad _tPos;
-    if (isNull _road) then { continue; };
-    private _pos = getPos _road;
-    private _marker = "";
-    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        _marker = createMarker [format ["ied_%1", diag_tickTime], _pos];
-        _marker setMarkerShape "ICON";
-        _marker setMarkerType "mil_triangle";
-        _marker setMarkerColor "ColorRed";
-        _marker setMarkerText "IED";
-        _marker setMarkerAlpha 0.2;
+    if (!isNull _road) then {
+        private _pos = getPos _road;
+        private _marker = "";
+        if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+            _marker = createMarker [format ["ied_%1", diag_tickTime], _pos];
+            _marker setMarkerShape "ICON";
+            _marker setMarkerType "mil_triangle";
+            _marker setMarkerColor "ColorRed";
+            _marker setMarkerText "IED";
+            _marker setMarkerAlpha 0.2;
+        };
+        STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
     };
-    STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
 };
 


### PR DESCRIPTION
## Summary
- refactor minefield placement loops to avoid `continue` and stop syntax errors

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684b7fd3c550832f95329f90b22f457d