### PR TITLE
Separate psy-storm lightning and discharges

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 
 ### Storms
 * Periodic psy-storms that force players to seek shelter.
-* During a storm random Psy Discharges rain down across the map with Zeus lightning effects that grow more frequent over time.
-* Duration, starting and ending intensity, and the delay between storms can all be configured via CBA settings.
+* During a storm lightning and Psy Discharges strike separately across the map. Their frequency ramps up over time.
+* Duration, lightning and discharge intensity curves, and the delay between storms can all be configured via CBA settings.
 * Works with the emission hook system for mission-specific consequences.
 
 ### Zombification

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -278,8 +278,10 @@ true
 ["VSA_stormMinDelay","SLIDER",["Min Delay (s)","Minimum seconds between storms"],"Viceroy's STALKER ALife - Storms",[0,7200,1800,0]] call CBA_fnc_addSetting;
 ["VSA_stormMaxDelay","SLIDER",["Max Delay (s)","Maximum seconds between storms"],"Viceroy's STALKER ALife - Storms",[0,7200,3600,0]] call CBA_fnc_addSetting;
 ["VSA_stormDuration","SLIDER",["Storm Duration (s)","Length of each psy-storm"],"Viceroy's STALKER ALife - Storms",[30,600,180,0]] call CBA_fnc_addSetting;
-["VSA_stormIntensityStart","SLIDER",["Intensity Start","Strikes per second at storm start"],"Viceroy's STALKER ALife - Storms",[1,20,2,0]] call CBA_fnc_addSetting;
-["VSA_stormIntensityEnd","SLIDER",["Intensity End","Strikes per second when storm ends"],"Viceroy's STALKER ALife - Storms",[1,40,6,0]] call CBA_fnc_addSetting;
+["VSA_stormLightningStart","SLIDER",["Lightning Start","Lightning strikes per second at storm start"],"Viceroy's STALKER ALife - Storms",[6,200,6,0]] call CBA_fnc_addSetting;
+["VSA_stormLightningEnd","SLIDER",["Lightning End","Lightning strikes per second when storm ends"],"Viceroy's STALKER ALife - Storms",[6,200,12,0]] call CBA_fnc_addSetting;
+["VSA_stormDischargeStart","SLIDER",["Discharge Start","Psy discharge occurrences per second at storm start"],"Viceroy's STALKER ALife - Storms",[6,200,6,0]] call CBA_fnc_addSetting;
+["VSA_stormDischargeEnd","SLIDER",["Discharge End","Psy discharge occurrences per second when storm ends"],"Viceroy's STALKER ALife - Storms",[6,200,12,0]] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
 // Zombification

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -9,9 +9,11 @@ missionNamespace setVariable ["VSA_debugActionsAdded", true];
 
 player addAction ["Spawn Psy-Storm", {
     private _dur = ["VSA_stormDuration", 180] call VIC_fnc_getSetting;
-    private _start = ["VSA_stormIntensityStart", 2] call VIC_fnc_getSetting;
-    private _end = ["VSA_stormIntensityEnd", 6] call VIC_fnc_getSetting;
-    [_dur, _start, _end] remoteExec ["VIC_fnc_triggerPsyStorm", 2];
+    private _lStart = ["VSA_stormLightningStart", 6] call VIC_fnc_getSetting;
+    private _lEnd   = ["VSA_stormLightningEnd", 12] call VIC_fnc_getSetting;
+    private _dStart = ["VSA_stormDischargeStart", 6] call VIC_fnc_getSetting;
+    private _dEnd   = ["VSA_stormDischargeEnd", 12] call VIC_fnc_getSetting;
+    [_dur, _lStart, _lEnd, _dStart, _dEnd] remoteExec ["VIC_fnc_triggerPsyStorm", 2];
 }];
 player addAction ["Spawn Chemical Zone", {
     [getPos player, 100] remoteExec ["VIC_fnc_spawnChemicalZone", 2];

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
@@ -26,8 +26,10 @@ private _interval = ["VSA_stormInterval", 30] call VIC_fnc_getSetting;
 private _spawnWeight = ["VSA_stormSpawnWeight", 50] call VIC_fnc_getSetting;
 private _nightOnly = ["VSA_stormsNightOnly", false] call VIC_fnc_getSetting;
 private _duration = ["VSA_stormDuration", 180] call VIC_fnc_getSetting;
-private _startIntensity = ["VSA_stormIntensityStart", 2] call VIC_fnc_getSetting;
-private _endIntensity = ["VSA_stormIntensityEnd", 6] call VIC_fnc_getSetting;
+private _lightningStart = ["VSA_stormLightningStart", 6] call VIC_fnc_getSetting;
+private _lightningEnd   = ["VSA_stormLightningEnd", 12] call VIC_fnc_getSetting;
+private _dischargeStart = ["VSA_stormDischargeStart", 6] call VIC_fnc_getSetting;
+private _dischargeEnd   = ["VSA_stormDischargeEnd", 12] call VIC_fnc_getSetting;
 
 _minDelay = ["VSA_stormMinDelay", _minDelay] call VIC_fnc_getSetting;
 _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
@@ -35,21 +37,21 @@ _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
 if (_minDelay < 0) then { _minDelay = 0; };
 if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
-[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _startIntensity, _endIntensity] spawn {
-    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_start", "_end"];
+[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _lightningStart, _lightningEnd, _dischargeStart, _dischargeEnd] spawn {
+    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_lStart", "_lEnd", "_dStart", "_dEnd"];
     private _nextStorm = time + (_min + random (_max - _min));
     while {true} do {
         if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
             missionNamespace setVariable [_var, false, true];
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _start, _end] call VIC_fnc_triggerPsyStorm;
+                [_dur, _lStart, _lEnd, _dStart, _dEnd] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };
 
         if (time >= _nextStorm) then {
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _start, _end] call VIC_fnc_triggerPsyStorm;
+                [_dur, _lStart, _lEnd, _dStart, _dEnd] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -2,17 +2,22 @@
     Author: Codex
     Description:
         Triggers lightning strikes and Psy Discharges across the map.
+        Lightning and discharges have separate intensity curves.
 
     Params:
         0: NUMBER - duration of the storm in seconds (default 180)
-        1: NUMBER - starting strikes per second (default 2)
-        2: NUMBER - ending strikes per second (default 6)
+        1: NUMBER - lightning strikes per second at storm start (default 6)
+        2: NUMBER - lightning strikes per second when storm ends (default 12)
+        3: NUMBER - discharge occurrences per second at storm start (default 6)
+        4: NUMBER - discharge occurrences per second when storm ends (default 12)
 */
 
 params [
     ["_duration", 180],
-    ["_startIntensity", 2],
-    ["_endIntensity", 6]
+    ["_lightningStart", 6],
+    ["_lightningEnd", 12],
+    ["_dischargeStart", 6],
+    ["_dischargeEnd", 12]
 ];
 
 ["triggerPsyStorm"] call VIC_fnc_debugLog;
@@ -20,22 +25,23 @@ params [
 private _ticks = floor _duration;
 for "_i" from 1 to _ticks do {
     private _progress = (_i - 1) / (_ticks max 1);
-    private _currentIntensity = round (_startIntensity + (_endIntensity - _startIntensity) * _progress);
+    private _currentLightning = round (_lightningStart + (_lightningEnd - _lightningStart) * _progress);
+    private _currentDischarge = round (_dischargeStart + (_dischargeEnd - _dischargeStart) * _progress);
 
-    for "_j" from 1 to _currentIntensity do {
+    for "_j" from 1 to _currentLightning do {
         private _pos = [random worldSize, random worldSize, 0];
         private _surf = [_pos] call VIC_fnc_getSurfacePosition;
-    // Psy discharge uses a module (Logic) which has a brain. Using createVehicle
-    // triggers an engine warning in recent Arma versions, so create it locally
-    // instead.
-    private _module = "diwako_anomalies_main_modulePsyDischarge" createVehicleLocal _surf;
-        private _fncDischarge = missionNamespace getVariable ["diwako_anomalies_main_fnc_modulePsyDischarge", {}];
-        ["init", _module] call _fncDischarge;
-    // BIS_fnc_moduleLightning also relies on a Logic object. Create it locally
-    // to avoid the same engine warning as above.
-    private _logic = "Logic" createVehicleLocal _surf;
+        private _logic = "Logic" createVehicleLocal _surf;
         [_logic, [], true] call BIS_fnc_moduleLightning;
         deleteVehicle _logic;
+    };
+
+    for "_j" from 1 to _currentDischarge do {
+        private _pos = [random worldSize, random worldSize, 0];
+        private _surf = [_pos] call VIC_fnc_getSurfacePosition;
+        private _module = "diwako_anomalies_main_modulePsyDischarge" createVehicleLocal _surf;
+        private _fncDischarge = missionNamespace getVariable ["diwako_anomalies_main_fnc_modulePsyDischarge", {}];
+        ["init", _module] call _fncDischarge;
     };
 
     sleep 1;


### PR DESCRIPTION
## Summary
- split lightning and psy discharge spawning
- add separate lightning and discharge CBA settings with range 6-200
- update debug actions to use new settings
- describe new storm behaviour in README

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b838a9788832fba2a23b736ecaf91