### PR TITLE
Add abandoned vehicle spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Generates APERS minefields on town outskirts and single IEDs on roads.
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu.
+* Abandoned and damaged vehicles may appear on or near roads.
 
 ### Spooks
 * Lightweight supernatural events to unsettle players.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -496,6 +496,25 @@ true
     "Viceroy's STALKER ALife - Minefields",
     [0, 20, 2, 0]
 ] call CBA_fnc_addSetting;
+
+// -----------------------------------------------------------------------------
+// Wrecks
+// -----------------------------------------------------------------------------
+[
+    "VSA_enableWrecks",
+    "CHECKBOX",
+    ["Enable Abandoned Vehicles", "Spawn damaged vehicles near roads"],
+    "Viceroy's STALKER ALife - Wrecks",
+    true
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_wreckCount",
+    "SLIDER",
+    ["Abandoned Vehicle Count", "Number of vehicles spawned across the map"],
+    "Viceroy's STALKER ALife - Wrecks",
+    [0, 50, 10, 0]
+] call CBA_fnc_addSetting;
 // -----------------------------------------------------------------------------
 // Debug
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -98,6 +98,11 @@ class CfgFunctions
             class spawnIED{};
             class manageMinefields{};
         };
+        class Wrecks
+        {
+            file = "Viceroys-STALKER-ALife\functions\wrecks";
+            class spawnAbandonedVehicles{};
+        };
 
 
         class Storms

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -64,6 +64,7 @@ VIC_fnc_spawnMinefields        = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnAPERSField        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnAPERSField.sqf");
 VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnIED.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
+VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
 VIC_fnc_spawnAmbientHerds        = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnAmbientHerds.sqf");
 VIC_fnc_setupMutantHabitats      = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_setupMutantHabitats.sqf");
 VIC_fnc_spawnMutantNest         = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnMutantNest.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -1,0 +1,39 @@
+/*
+    Spawns damaged vehicles at random road locations.
+    Params:
+        0: NUMBER - number of vehicles to spawn (default 10)
+*/
+params [["_count",10]];
+
+["spawnAbandonedVehicles"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (["VSA_enableWrecks", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+
+if (isNil "STALKER_wrecks") then { STALKER_wrecks = []; };
+
+private _classes = [
+    "C_Offroad_01_F",
+    "C_Hatchback_01_F",
+    "C_SUV_01_F",
+    "C_Van_01_transport_F"
+];
+
+for "_i" from 1 to _count do {
+    private _base = [random worldSize, random worldSize, 0];
+    private _road = roadAt _base;
+    if (isNull _road) then { _road = nearestRoad _base; };
+    if (isNull _road) then { continue };
+    private _pos = getPos _road;
+    _pos = _pos getPos [2 + random 3, random 360];
+    _pos = [_pos] call VIC_fnc_getLandSurfacePosition;
+    if (_pos isEqualTo []) then { continue };
+    private _veh = createVehicle [selectRandom _classes, ASLtoATL _pos, [], 0, "CAN_COLLIDE"];
+    _veh setPosATL (ASLtoATL _pos);
+    _veh setVectorUp surfaceNormal (ASLtoATL _pos);
+    _veh setDamage (0.3 + random 0.7);
+    _veh setFuel 0;
+    _veh lock 2;
+    STALKER_wrecks pushBack _veh;
+};
+

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -34,3 +34,5 @@ for "_i" from 1 to 50 do {
     [_pos, 1000] call VIC_fnc_spawnMinefields;
 };
 
+private _wreckCount = ["VSA_wreckCount", 10] call VIC_fnc_getSetting;
+[_wreckCount] call VIC_fnc_spawnAbandonedVehicles;


### PR DESCRIPTION
## Summary
- spawn damaged vehicles near roads via new `fn_spawnAbandonedVehicles`
- register new `Wrecks` functions and CBA settings
- call abandoned vehicle spawns during server init
- document the feature in the README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b865482ec832f9e04c2a0d3da578c