### PR TITLE
Adjust player range marker opacity

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
@@ -21,6 +21,7 @@ if (isNil "STALKER_playerRangeMarker") then { STALKER_playerRangeMarker = "" };
             STALKER_playerRangeMarker = createMarkerLocal [_name, position player];
             STALKER_playerRangeMarker setMarkerShape "ELLIPSE";
             STALKER_playerRangeMarker setMarkerColor "ColorBlue";
+            STALKER_playerRangeMarker setMarkerAlphaLocal 0.05;
         };
         STALKER_playerRangeMarker setMarkerPosLocal position player;
         STALKER_playerRangeMarker setMarkerSizeLocal [_range, _range];


### PR DESCRIPTION
## Summary
- dim player nearby range marker to 5% opacity

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b8b444d28832f9f451967a3f19192