### PR TITLE
Disable automatic building markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ spawns at night, during the day or both.
    This option can now be toggled while a mission is running and the debug
    actions will appear automatically.
 5. When debug mode is active, your scroll menu includes options to trigger storms, spawn anomaly fields or spook zones, generate habitats, spawn ambient herds, summon predator attacks and other test helpers. All spawn actions run on the server so they work correctly in multiplayer and the anomaly field option populates random locations across the map.
+6. Use the **Mark All Buildings** action from this menu if you need to visualize every building. Buildings are no longer marked automatically when debug mode is enabled.
 
 If your mission reports undefined CBA settings, ensure that **CBA A3** is loaded and initialized before this mod. Settings now fall back to defaults via `VIC_fnc_getSetting` when CBA has not yet finished loading.
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -224,7 +224,6 @@ VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\fu
     ] call CBA_fnc_waitAndExecute;
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         [] call VIC_fnc_setupDebugActions;
-        [] call VIC_fnc_markAllBuildings;
         [] call VIC_fnc_markPlayerRanges;
     };
 }] call CBA_fnc_addEventHandler;
@@ -240,7 +239,6 @@ VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\fu
             [] call VIC_fnc_markPlayerRanges;
             if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
                 [] call VIC_fnc_setupDebugActions;
-                [] call VIC_fnc_markAllBuildings;
             };
         };
     }] call CBA_fnc_addEventHandler;
@@ -251,7 +249,6 @@ VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\fu
     params ["_setting", "_value"];
     if (hasInterface && {_setting isEqualTo "VSA_debugMode" && {_value}}) then {
         [] call VIC_fnc_setupDebugActions;
-        [] call VIC_fnc_markAllBuildings;
         [] call VIC_fnc_markPlayerRanges;
     };
 }] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
## Summary
- remove automatic calls to `markAllBuildings`
- describe new debug-only command in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684b936f4040832fb8be02e45a1c2d10