### PR TITLE
Fix missing semicolon error

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -47,7 +47,7 @@ for "_i" from 1 to _iedCount do {
     private _town = selectRandom _towns;
     private _tPos = locationPosition _town;
     private _road = nearestRoad _tPos;
-    if (isNull _road) then { continue };
+    if (isNull _road) then { continue; };
 
     private _pos = getPos _road;
     private _marker = "";


### PR DESCRIPTION
## Summary
- fix an SQF syntax issue in `fn_spawnMinefields.sqf`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684b97f521ac832f92a9091c8c7d873e