### PR TITLE
Fix spawn IED syntax

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
@@ -21,4 +21,4 @@ if (isNull _road) exitWith { [] };
 private _pos = getPos _road;
 private _ied = createMine ["IEDLandSmall_F", _pos, [], 0];
 
-[_ied]
+[_ied];


### PR DESCRIPTION
## Summary
- fix `fn_spawnIED` syntax error by terminating return statement with a semicolon

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b980a152c832fbf02c603e86ed2ff