### PR TITLE
Add fog and rain buildup for psy-storms

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 ### Storms
 * Periodic psy-storms that force players to seek shelter.
 * During a storm lightning and Psy Discharges strike separately across the map. Their frequency ramps up over time.
+* Fog and rain intensify as the storm builds, then fade once it passes.
 * Duration, lightning and discharge intensity curves, and the delay between storms can all be configured via CBA settings.
+* New settings `VSA_stormFogEnd` and `VSA_stormRainEnd` control the maximum fog and rain.
 * Works with the emission hook system for mission-specific consequences.
 
 ### Zombification

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -373,6 +373,8 @@ true
 ["VSA_stormLightningEnd","SLIDER",["Lightning End","Lightning strikes per second when storm ends"],"Viceroy's STALKER ALife - Storms",[6,200,12,0]] call CBA_fnc_addSetting;
 ["VSA_stormDischargeStart","SLIDER",["Discharge Start","Psy discharge occurrences per second at storm start"],"Viceroy's STALKER ALife - Storms",[6,200,6,0]] call CBA_fnc_addSetting;
 ["VSA_stormDischargeEnd","SLIDER",["Discharge End","Psy discharge occurrences per second when storm ends"],"Viceroy's STALKER ALife - Storms",[6,200,12,0]] call CBA_fnc_addSetting;
+["VSA_stormFogEnd","SLIDER",["Fog at Peak","Fog level when the storm peaks"],"Viceroy's STALKER ALife - Storms",[0,1,0.6,2]] call CBA_fnc_addSetting;
+["VSA_stormRainEnd","SLIDER",["Rain at Peak","Rain intensity when the storm peaks"],"Viceroy's STALKER ALife - Storms",[0,1,0.8,2]] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
 // Zombification

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
@@ -30,6 +30,8 @@ private _lightningStart = ["VSA_stormLightningStart", 6] call VIC_fnc_getSetting
 private _lightningEnd   = ["VSA_stormLightningEnd", 12] call VIC_fnc_getSetting;
 private _dischargeStart = ["VSA_stormDischargeStart", 6] call VIC_fnc_getSetting;
 private _dischargeEnd   = ["VSA_stormDischargeEnd", 12] call VIC_fnc_getSetting;
+private _fogEnd         = ["VSA_stormFogEnd", 0.6] call VIC_fnc_getSetting;
+private _rainEnd        = ["VSA_stormRainEnd", 0.8] call VIC_fnc_getSetting;
 
 _minDelay = ["VSA_stormMinDelay", _minDelay] call VIC_fnc_getSetting;
 _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
@@ -37,21 +39,21 @@ _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
 if (_minDelay < 0) then { _minDelay = 0; };
 if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
-[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _lightningStart, _lightningEnd, _dischargeStart, _dischargeEnd] spawn {
-    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_lStart", "_lEnd", "_dStart", "_dEnd"];
+[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _lightningStart, _lightningEnd, _dischargeStart, _dischargeEnd, _fogEnd, _rainEnd] spawn {
+    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_lStart", "_lEnd", "_dStart", "_dEnd", "_fEnd", "_rEnd"];
     private _nextStorm = time + (_min + random (_max - _min));
     while {true} do {
         if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
             missionNamespace setVariable [_var, false, true];
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _lStart, _lEnd, _dStart, _dEnd] call VIC_fnc_triggerPsyStorm;
+                [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };
 
         if (time >= _nextStorm) then {
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _lStart, _lEnd, _dStart, _dEnd] call VIC_fnc_triggerPsyStorm;
+                [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -17,12 +17,16 @@ params [
     ["_lightningStart", 6],
     ["_lightningEnd", 12],
     ["_dischargeStart", 6],
-    ["_dischargeEnd", 12]
+    ["_dischargeEnd", 12],
+    ["_fogEnd", 0.6],
+    ["_rainEnd", 0.8]
 ];
 
 
 ["triggerPsyStorm"] call VIC_fnc_debugLog;
 private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+private _startFog = fog;
+private _startRain = rain;
 
 if (count allPlayers == 0) exitWith {};
 
@@ -31,6 +35,10 @@ for "_i" from 1 to _ticks do {
     private _progress = (_i - 1) / (_ticks max 1);
     private _currentLightning = round (_lightningStart + (_lightningEnd - _lightningStart) * _progress);
     private _currentDischarge = round (_dischargeStart + (_dischargeEnd - _dischargeStart) * _progress);
+    private _currentFog = _startFog + (_fogEnd - _startFog) * _progress;
+    private _currentRain = _startRain + (_rainEnd - _startRain) * _progress;
+    0 setFog _currentFog;
+    0 setRain _currentRain;
 
     for "_j" from 1 to _currentLightning do {
         private _center = getPos (selectRandom allPlayers);
@@ -60,4 +68,7 @@ for "_i" from 1 to _ticks do {
 
     sleep 1;
 };
+
+0 setFog _startFog;
+0 setRain _startRain;
 


### PR DESCRIPTION
## Summary
- intensify fog and rain as psy-storms progress
- expose new settings for maximum fog and rain
- schedule storms with new parameters
- document weather effects in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684c2095a95c832f9f4579759c3286d7