### PR TITLE
Add gas zones to psy-storm discharges

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * New settings `VSA_stormFogEnd` and `VSA_stormRainEnd` control the maximum fog and rain.
 * Duration, lightning and discharge intensity curves, the radius around players for effects, and the delay between storms can all be configured via CBA settings.
 * Works with the emission hook system for mission-specific consequences.
+* Optional Nova Gas clouds can spawn at every Psy Discharge when
+  `VSA_stormGasDischarges` is enabled, creating a 30m zone that
+  lasts 90 seconds.
 
 ### Zombification
 * Tracks dead units and may reanimate them as zombies after a delay.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -378,6 +378,8 @@ true
 
 ["VSA_stormRadius","SLIDER",["Storm Radius","Maximum distance from players for storm effects"],"Viceroy's STALKER ALife - Storms",[100,7500,1500,0]] call CBA_fnc_addSetting;
 
+["VSA_stormGasDischarges","CHECKBOX",["Gas Under Discharges","Spawn Nova gas clouds at discharge locations"],"Viceroy's STALKER ALife - Storms",false] call CBA_fnc_addSetting;
+
 // -----------------------------------------------------------------------------
 // Zombification
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -1,12 +1,21 @@
 /*
     Spawns a Chemical Warfare Plus gas zone at the given position.
-    The zone uses the Asphyxiant gas type and lasts for three hours
-    by default.
+    The zone uses the Asphyxiant gas type by default and lasts for
+    three hours unless a different duration is provided.
 
     Params:
         0: POSITION - center of the gas cloud
         1: NUMBER   - radius of the zone in meters (default: 50)
         2: NUMBER   - duration in seconds (optional, defaults to 10800)
+        3: NUMBER   - gas type ID as defined by Chemical Warfare Plus
+                      (optional, defaults to 1 - Asphyxiant)
+
+    // Gas Type IDs:
+    // 0 - CS Gas
+    // 1 - Asphyxiant
+    // 2 - Nerve
+    // 3 - Blister
+    // 4 - Nova
 
     Returns:
         OBJECT - handle to the spawned module
@@ -15,7 +24,8 @@
 params [
     ["_position", [0,0,0]],
     ["_radius", 50],
-    ["_duration", -1]
+    ["_duration", -1],
+    ["_chemType", 1]
 ];
 
 ["spawnChemicalZone"] call VIC_fnc_debugLog;
@@ -35,7 +45,7 @@ private _module = createAgent ["PHEN_CWPLUS_ModuleSpawnCSGas", _position, [], 0,
 _module setVariable ["CBRN_Radius", _radius, true];
 _module setVariable ["CBRN_Lifetime", _duration, true];
 _module setVariable ["CBRN_Thickness", 1, true];
-_module setVariable ["CBRN_ChemType", 1, true]; // Asphyxiant gas
+_module setVariable ["CBRN_ChemType", _chemType, true];
 [
     "init",
     [_module]

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -27,6 +27,7 @@ params [
 private _startFog = fog;
 private _startRain = rain;
 private _range = ["VSA_stormRadius", 1500] call VIC_fnc_getSetting;
+private _gasEnabled = ["VSA_stormGasDischarges", false] call VIC_fnc_getSetting;
 
 if (count allPlayers == 0) exitWith {};
 
@@ -64,6 +65,10 @@ for "_i" from 1 to _ticks do {
         private _module = "diwako_anomalies_main_modulePsyDischarge" createVehicleLocal _surf;
         private _fncDischarge = missionNamespace getVariable ["diwako_anomalies_main_fnc_modulePsyDischarge", {}];
         ["init", _module] call _fncDischarge;
+        if (_gasEnabled) then {
+            // Spawn a 30m Nova Gas cloud lasting 90 seconds
+            [_surf, 30, 90, 4] call VIC_fnc_spawnChemicalZone;
+        };
     };
 
     sleep 1;


### PR DESCRIPTION
## Summary
- spawn Nova Gas zones at psy-storm discharges when enabled
- document that the radius is 30m and lasts 90s
- list all Chemical Warfare Plus gas type IDs
- fix call to `spawnChemicalZone` to use the correct Nova gas index

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684c26831ad8832faace4112e49f5ce7