### PR TITLE
Fix missing semicolon warning in spawnAbandonedVehicles

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -25,12 +25,12 @@ for "_i" from 1 to _count do {
     if (isNull _road) then {
         _road = nearestRoad _base;
     };
-    if (isNull _road) then { continue };
+    if (isNull _road) then { continue; };
 
     private _pos = getPos _road;
     _pos = _pos getPos [2 + random 3, random 360];
     _pos = [_pos] call VIC_fnc_getLandSurfacePosition;
-    if (_pos isEqualTo []) then { continue };
+    if (_pos isEqualTo []) then { continue; };
 
     private _veh = createVehicle [selectRandom _classes, ASLtoATL _pos, [], 0, "CAN_COLLIDE"];
     _veh setPosATL (ASLtoATL _pos);


### PR DESCRIPTION
## Summary
- fix semicolon placement in `fn_spawnAbandonedVehicles.sqf`

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2be36cac832fb2c5b0e60b0b474b