### PR TITLE
Fix compile error in spawnAmbushes

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -52,4 +52,4 @@ for "_i" from 1 to _count do {
     STALKER_ambushes pushBack [_pos, objNull, [], [], false, _marker];
 };
 
-true
+true;


### PR DESCRIPTION
## Summary
- fix missing semicolon warning in `fn_spawnAmbushes.sqf`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c2c17cf58832fbb51b125a3b36990