### PR TITLE
Fix building selection for mutant habitat generation

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -99,7 +99,9 @@ private _selectType = {
 
 private _center = [worldSize/2, worldSize/2, 0];
 private _locations = nearestLocations [_center, [], worldSize];
-private _buildings = allMissionObjects "building";
+private _buildings = nearestObjects [_center, ["House"], worldSize];
+_buildings append (allMissionObjects "building");
+_buildings = _buildings arrayIntersect _buildings; // remove duplicates
 
 {
     private _pos = locationPosition _x;
@@ -121,6 +123,7 @@ private _buildings = allMissionObjects "building";
 } forEach _locations;
 
 for "_i" from 1 to 20 do {
+    if (_buildings isEqualTo []) exitWith {};
     private _b = selectRandom _buildings;
     private _pos = getPosATL _b;
     _pos = [_pos, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
@@ -154,9 +157,11 @@ private _allTypes = _weightsGeneric apply { _x#0 };
 private _existing = STALKER_mutantHabitats apply { _x#4 };
 {
     if (!(_x in _existing)) then {
-        private _p = getPosATL (selectRandom _buildings);
-        _p = [_p, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
-        if (!([_p] call VIC_fnc_isWaterPosition)) then { [_x, _p] call _createMarker; };
+        if !(_buildings isEqualTo []) then {
+            private _p = getPosATL (selectRandom _buildings);
+            _p = [_p, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+            if (!([_p] call VIC_fnc_isWaterPosition)) then { [_x, _p] call _createMarker; };
+        };
     };
 } forEach _allTypes;
 


### PR DESCRIPTION
## Summary
- improve building retrieval by checking nearest objects
- handle missing buildings when generating mutant habitats

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c325c6db8832fa7be992516d48ce7