### PR TITLE
Default gas discharges

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * New settings `VSA_stormFogEnd` and `VSA_stormRainEnd` control the maximum fog and rain.
 * Duration, lightning and discharge intensity curves, the radius around players for effects, and the delay between storms can all be configured via CBA settings.
 * Works with the emission hook system for mission-specific consequences.
-* Optional Nova Gas clouds can spawn at every Psy Discharge when
-  `VSA_stormGasDischarges` is enabled, creating a 30m zone that
+* Optional Nova Gas clouds spawn at every Psy Discharge by default.
+  Controlled by `VSA_stormGasDischarges`, this creates a 30m zone that
   lasts 90 seconds.
 
 ### Zombification

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -378,7 +378,7 @@ true
 
 ["VSA_stormRadius","SLIDER",["Storm Radius","Maximum distance from players for storm effects"],"Viceroy's STALKER ALife - Storms",[100,7500,1500,0]] call CBA_fnc_addSetting;
 
-["VSA_stormGasDischarges","CHECKBOX",["Gas Under Discharges","Spawn Nova gas clouds at discharge locations"],"Viceroy's STALKER ALife - Storms",false] call CBA_fnc_addSetting;
+["VSA_stormGasDischarges","CHECKBOX",["Gas Under Discharges","Spawn Nova gas clouds at discharge locations"],"Viceroy's STALKER ALife - Storms",true] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
 // Zombification

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -27,7 +27,7 @@ params [
 private _startFog = fog;
 private _startRain = rain;
 private _range = ["VSA_stormRadius", 1500] call VIC_fnc_getSetting;
-private _gasEnabled = ["VSA_stormGasDischarges", false] call VIC_fnc_getSetting;
+private _gasEnabled = ["VSA_stormGasDischarges", true] call VIC_fnc_getSetting;
 
 if (count allPlayers == 0) exitWith {};
 


### PR DESCRIPTION
## Summary
- enable gas clouds under psy discharges by default
- adjust fallback value in storm script
- note the default in the README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684c339280fc832f875000e6899ee217