### PR TITLE
Switch to CBRN mist for gas zones

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_cleanupChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_cleanupChemicalZones.sqf
@@ -1,5 +1,6 @@
 /*
-    Removes expired Chemical Warfare Plus gas zones.
+    Removes expired chemical zone markers. The mist itself
+    despawns automatically after its lifetime.
     Zones are stored in `STALKER_chemicalZones` with their expiration
     time as recorded by `fn_spawnChemicalZone`.
 
@@ -17,13 +18,10 @@ private _now = diag_tickTime;
 
 for [{_i = (count STALKER_chemicalZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
     private _entry = STALKER_chemicalZones select _i;
-    private _zone  = _entry select 0;
-    private _marker = _entry select 1;
-    private _expires = _entry select 2;
+    _entry params ["_pos","_radius","_active","_marker","_expires"];
 
     if (_force || { _expires >= 0 && _now > _expires }) then {
-        if (!isNull _zone) then { deleteVehicle _zone; };
-        if (!isNil {_marker}) then { deleteMarker _marker; };
+        if (_marker != "") then { deleteMarker _marker; };
         STALKER_chemicalZones deleteAt _i;
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_manageChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_manageChemicalZones.sqf
@@ -1,7 +1,7 @@
 /*
     Activates or deactivates chemical zones based on player proximity
     and removes expired entries. Zones are stored in
-    STALKER_chemicalZones as [position, radius, module, marker, expires].
+    STALKER_chemicalZones as [position, radius, active, marker, expires].
 */
 
 ["manageChemicalZones"] call VIC_fnc_debugLog;
@@ -13,10 +13,9 @@ private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
 
 for [{_i = (count STALKER_chemicalZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
     private _entry = STALKER_chemicalZones select _i;
-    _entry params ["_pos","_radius","_zone","_marker","_expires"];
+    _entry params ["_pos","_radius","_active","_marker","_expires"];
 
     if (_expires >= 0 && {diag_tickTime > _expires}) then {
-        if (!isNull _zone) then { deleteVehicle _zone; };
         if (_marker != "") then { deleteMarker _marker; };
         STALKER_chemicalZones deleteAt _i;
         continue;
@@ -24,17 +23,18 @@ for [{_i = (count STALKER_chemicalZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
 
     private _near = [_pos,_range] call VIC_fnc_hasPlayersNearby;
     if (_near) then {
-        if (isNull _zone) then {
+        if (!_active) then {
             private _dur = if (_expires < 0) then {-1} else {_expires - diag_tickTime};
-            _zone = [_pos,_radius,_dur] call VIC_fnc_spawnChemicalZone;
+            [_pos,_radius,_dur] call VIC_fnc_spawnChemicalZone;
+            _active = true;
         };
         if (_marker != "") then { _marker setMarkerAlpha 1; };
     } else {
-        if (!isNull _zone) then { deleteVehicle _zone; _zone = objNull; };
+        if (_active) then { _active = false; };
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
 
-    STALKER_chemicalZones set [_i, [_pos,_radius,_zone,_marker,_expires]];
+    STALKER_chemicalZones set [_i, [_pos,_radius,_active,_marker,_expires]];
 };
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
@@ -37,7 +37,7 @@ for "_i" from 1 to _count do {
     };
 
     private _expires = if (_duration >= 0) then { diag_tickTime + _duration } else {-1};
-    STALKER_chemicalZones pushBack [_pos,_zoneRadius,objNull,_marker,_expires];
+    STALKER_chemicalZones pushBack [_pos,_zoneRadius,false,_marker,_expires];
 };
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -66,10 +66,10 @@ for "_i" from 1 to _ticks do {
         private _fncDischarge = missionNamespace getVariable ["diwako_anomalies_main_fnc_modulePsyDischarge", {}];
         ["init", _module] call _fncDischarge;
         if (_gasEnabled) then {
-            // Spawn a 30m Nova Gas cloud lasting 90 seconds
+            // Spawn a 30m Nova mist lasting 90 seconds
             // Convert the surface position from ASL to AGL so the gas spawns on the ground
             private _agl = ASLToAGL _surf;
-            [_agl, 30, 90, 4] call VIC_fnc_spawnChemicalZone;
+            [_agl, 30, 90, 4, -0.1, 1] remoteExec ["CBRN_fnc_spawnMist", 0];
         };
     };
 


### PR DESCRIPTION
## Summary
- swap gas spawn logic to use `CBRN_fnc_spawnMist`
- track chemical zones as marker entries only
- update management loop to work with new mist logic
- spawn psy-storm gas via `CBRN_fnc_spawnMist`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c3939f994832f9e7ae90bbfb7c3b2