### PR TITLE
Fix spawnAbandonedVehicles syntax

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -25,19 +25,20 @@ for "_i" from 1 to _count do {
     if (isNull _road) then {
         _road = nearestRoad _base;
     };
-    if (isNull _road) then { continue; };
 
-    private _pos = getPos _road;
-    _pos = _pos getPos [2 + random 3, random 360];
-    _pos = [_pos] call VIC_fnc_getLandSurfacePosition;
-    if (_pos isEqualTo []) then { continue; };
-
-    private _veh = createVehicle [selectRandom _classes, ASLtoATL _pos, [], 0, "CAN_COLLIDE"];
-    _veh setPosATL (ASLtoATL _pos);
-    _veh setVectorUp surfaceNormal (ASLtoATL _pos);
-    _veh setDamage (0.3 + random 0.7);
-    _veh setFuel 0;
-    _veh lock 2;
-    STALKER_wrecks pushBack _veh;
+    if (!isNull _road) then {
+        private _pos = getPos _road;
+        _pos = _pos getPos [2 + random 3, random 360];
+        _pos = [_pos] call VIC_fnc_getLandSurfacePosition;
+        if !(_pos isEqualTo []) then {
+            private _veh = createVehicle [selectRandom _classes, ASLtoATL _pos, [], 0, "CAN_COLLIDE"];
+            _veh setPosATL (ASLtoATL _pos);
+            _veh setVectorUp surfaceNormal (ASLtoATL _pos);
+            _veh setDamage (0.3 + random 0.7);
+            _veh setFuel 0;
+            _veh lock 2;
+            STALKER_wrecks pushBack _veh;
+        };
+    };
 };
 


### PR DESCRIPTION
## Summary
- avoid `continue` statements in `spawnAbandonedVehicles`
- only spawn vehicles when a road and valid position are found

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684c3e220e54832f8b5deedc263aceb4