### PR TITLE
Fix exitWith syntax in ambush spawner

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -31,9 +31,7 @@ for "_i" from 1 to _count do {
         if (!([_candidate] call VIC_fnc_isWaterPosition)) then {
             if ((nearestLocations [_candidate, ["NameVillage","NameCity","NameCityCapital","NameLocal"], _townDist]) isEqualTo []) then {
                 _road = nearestRoad _candidate;
-                if (!isNull _road) exitWith {
-                    _pos = getPos _road;
-                };
+                if (!isNull _road) exitWith { _pos = getPos _road };
             };
         };
     };


### PR DESCRIPTION
## Summary
- correct `exitWith` block to use a single line expression

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c4479f9e4832fb0c4b86d9fe56a60