### PR TITLE
Fix debug markers for stalkers and predators

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -27,6 +27,7 @@ class CfgFunctions
             class getSetting{};
             class getSurfacePosition{};
             class hasPlayersNearby{};
+            class createGlobalMarker{};
             class weightedPick{};
             class selectWeightedBuilding{};
         };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
@@ -1,0 +1,28 @@
+/*
+    Creates a marker globally on all machines.
+
+    Params:
+        0: STRING - marker name
+        1: POSITION - marker position
+        2: STRING - marker shape (default "ICON")
+        3: STRING - marker type  (default "mil_dot")
+        4: STRING - marker color (default "ColorWhite")
+        5: NUMBER - marker alpha (default 1)
+        6: STRING - marker text  (optional)
+
+    Returns: STRING - marker name
+*/
+params ["_name", "_pos", ["_shape", "ICON"], ["_type", "mil_dot"], ["_color", "ColorWhite"], ["_alpha", 1], ["_text", ""]];
+
+if (!isServer) exitWith { _name };
+
+[_name, _pos] remoteExec ["createMarker", 0];
+[_name, _shape] remoteExec ["setMarkerShape", 0];
+[_name, _type] remoteExec ["setMarkerType", 0];
+[_name, _color] remoteExec ["setMarkerColor", 0];
+[_name, _alpha] remoteExec ["setMarkerAlpha", 0];
+if (_text != "") then {
+    [_name, _text] remoteExec ["setMarkerText", 0];
+};
+
+_name

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -120,6 +120,7 @@ VIC_fnc_debugLog                 = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_setupDebugActions        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_setupDebugActions.sqf");
 VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markAllBuildings.sqf");
 VIC_fnc_markPlayerRanges        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markPlayerRanges.sqf");
+VIC_fnc_createGlobalMarker     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_createGlobalMarker.sqf");
 VIC_fnc_weightedPick           = compile preprocessFileLineNumbers (_root + "\functions\core\fn_weightedPick.sqf");
 VIC_fnc_selectWeightedBuilding = compile preprocessFileLineNumbers (_root + "\functions\core\fn_selectWeightedBuilding.sqf");
 VIC_fnc_spawnAmbientStalkers   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnAmbientStalkers.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
@@ -29,6 +29,8 @@ private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
             _grp = grpNull;
         };
     };
-    if (_marker != "") then { _marker setMarkerAlpha (if (_alive > 0 && _near) then {1} else {0.2}); };
+    if (_marker != "") then {
+        [_marker, (if (_alive > 0 && _near) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
+    };
     STALKER_activePredators set [_forEachIndex, [_grp, _target, _marker, _near]];
 } forEach STALKER_activePredators;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -23,11 +23,8 @@ _spawnPos = [_spawnPos] call VIC_fnc_findLandPosition;
 if (_spawnPos isEqualTo []) exitWith {};
 
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-    _spawnMarker = createMarker [format ["pred_%1", diag_tickTime], _spawnPos];
-    _spawnMarker setMarkerShape "ICON";
-    _spawnMarker setMarkerType "mil_dot";
-    _spawnMarker setMarkerColor "ColorRed";
-    _spawnMarker setMarkerText "Predator Spawn";
+    _spawnMarker = format ["pred_%1", diag_tickTime];
+    [_spawnMarker, _spawnPos, "ICON", "mil_dot", "ColorRed", 1, "Predator Spawn"] call VIC_fnc_createGlobalMarker;
 };
 
 private _dogClasses       = ["armst_blinddog1","armst_blinddog2","armst_blinddog3"];
@@ -105,10 +102,7 @@ switch (_type) do {
 [_grp, _player] call BIS_fnc_taskAttack;
 
 private _markerName = format ["pred_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _spawnPos];
-_marker setMarkerShape "ICON";
-_marker setMarkerType "mil_warning";
-_marker setMarkerColor "ColorRed";
-_marker setMarkerAlpha 1;
+private _marker = _markerName;
+[_marker, _spawnPos, "ICON", "mil_warning", "ColorRed", 1] call VIC_fnc_createGlobalMarker;
 
 STALKER_activePredators pushBack [_grp, _player, _marker, true];

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -35,7 +35,9 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
         };
         if (!isNull _camp) then { deleteVehicle _camp; _camp = objNull; };
     };
-    if (_marker != "") then { _marker setMarkerAlpha (if (_near) then {1} else {0.2}); };
+    if (_marker != "") then {
+        [_marker, (if (_near) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
+    };
     STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _marker, _side]];
 } forEach STALKER_camps;
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -36,12 +36,8 @@ for "_i" from 1 to _groupCount do {
 
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        private _name = format ["stk_%1_%2", count STALKER_stalkerGroups, diag_tickTime];
-        _marker = createMarker [_name, _pos];
-        _marker setMarkerShape "ICON";
-        _marker setMarkerType "mil_dot";
-        _marker setMarkerColor "ColorGreen";
-        _marker setMarkerAlpha 0.2;
+        _marker = format ["stk_%1_%2", count STALKER_stalkerGroups, diag_tickTime];
+        [_marker, _pos, "ICON", "mil_dot", "ColorGreen", 0.2] call VIC_fnc_createGlobalMarker;
     };
 
     STALKER_stalkerGroups pushBack [_grp, _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -34,12 +34,9 @@ private _campfire = "Campfire_burning_F" createVehicle _pos;
 
 private _marker = "";
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-    private _name = format ["camp_%1", diag_tickTime];
-    _marker = createMarker [_name, _pos];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_box";
-    _marker setMarkerColor switch (_side) do { case blufor: {"ColorBlue"}; case opfor: {"ColorRed"}; default {"ColorGreen"}; };
-    _marker setMarkerAlpha 0.2;
+    _marker = format ["camp_%1", diag_tickTime];
+    private _color = switch (_side) do { case blufor: {"ColorBlue"}; case opfor: {"ColorRed"}; default {"ColorGreen"}; };
+    [_marker, _pos, "ICON", "mil_box", _color, 0.2] call VIC_fnc_createGlobalMarker;
 };
 
 STALKER_camps pushBack [_campfire, _grp, _pos, _marker, _side];


### PR DESCRIPTION
## Summary
- create new helper for globally visible markers
- hook new function in master init and config
- show debug markers for ambient stalkers, stalker camps and predator attacks
- sync marker alpha for camps and predator attacks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c5c2c2efc832f960e732eb5fef245