### PR TITLE
Extend psystorm gas duration to 30s

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Works with the emission hook system for mission-specific consequences.
 * Optional Nova Gas clouds spawn at every Psy Discharge by default.
   Controlled by `VSA_stormGasDischarges`, this creates a 30m zone that
-  appears five seconds after each discharge, lasts 15 seconds, and
+  appears five seconds after each discharge, lasts 30 seconds, and
   uses a mist density of 3.
 
 ### Zombification

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -64,7 +64,7 @@ for "_i" from 1 to _ticks do {
             [_agl] spawn {
                 params ["_pos"];
                 sleep 5;
-                [_pos, 30, 15, 4, -0.1, 3] remoteExec ["CBRN_fnc_spawnMist", 0];
+                [_pos, 30, 30, 4, -0.1, 3] remoteExec ["CBRN_fnc_spawnMist", 0];
             };
         };
     };


### PR DESCRIPTION
## Summary
- extend psy-storm Nova gas clouds to last 30 seconds
- update documentation for new duration

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c5df24e34832f866001cfa7befd7c