### PR TITLE
Fix isWaterPosition parameter usage

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -28,7 +28,7 @@ for "_i" from 1 to _count do {
         _candidate = [_candidate] call VIC_fnc_findLandPosition;
         if (_candidate isEqualTo []) then { continue; };
 
-        if (!([_candidate] call VIC_fnc_isWaterPosition)) then {
+        if (!(_candidate call VIC_fnc_isWaterPosition)) then {
             private _locations = nearestLocations [
                 _candidate,
                 ["NameVillage","NameCity","NameCityCapital","NameLocal"],

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 private _sites = selectBestPlaces [_posCenter, _radius, "meadow", 1, 25];
 if (_sites isEqualTo []) exitWith { [] };
 private _pos = (_sites select 0) select 0;
-if ([_pos] call VIC_fnc_isWaterPosition) exitWith { [] };
+if (_pos call VIC_fnc_isWaterPosition) exitWith { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf
@@ -28,7 +28,7 @@ if (_pos isNotEqualTo []) then {
         _places = _locs apply { text _x };
     } else {
         private _feature = "";
-        if ([_pos] call VIC_fnc_isWaterPosition) then {
+        if (_pos call VIC_fnc_isWaterPosition) then {
             _feature = "Coast";
         } else {
             private _road = nearestRoad _pos;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -18,6 +18,6 @@ if (_base isEqualType []) then {
 
 for "_i" from 0 to _attempts do {
     private _candidate = if (_i == 0) then { _base } else { [_base, random _radius, random 360] call BIS_fnc_relPos };
-    if (!([_candidate] call VIC_fnc_isWaterPosition)) exitWith { _candidate };
+    if (!(_candidate call VIC_fnc_isWaterPosition)) exitWith { _candidate };
 };
 []

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getLandSurfacePosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getLandSurfacePosition.sqf
@@ -8,5 +8,5 @@
 params ["_pos"];
 
 private _surf = [_pos] call VIC_fnc_getSurfacePosition;
-if ([ASLToAGL _surf] call VIC_fnc_isWaterPosition) exitWith { [] };
+if ((ASLToAGL _surf) call VIC_fnc_isWaterPosition) exitWith { [] };
 _surf

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -122,7 +122,7 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
             case "Hill": { "rural" };
             default { "generic" };
         };
-        if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+        if (!(_pos call VIC_fnc_isWaterPosition)) then {
             private _type = [_env] call _selectType;
             [_type, _pos] call _createMarker;
         };
@@ -134,7 +134,7 @@ for "_i" from 1 to 20 do {
     private _b = selectRandom _buildings;
     private _pos = getPosATL _b;
     _pos = [_pos, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
-    if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+    if (!(_pos call VIC_fnc_isWaterPosition)) then {
         private _type = ["urban"] call _selectType;
         [_type, _pos] call _createMarker;
     };
@@ -144,7 +144,7 @@ private _forestSites = selectBestPlaces [_center, worldSize, "forest", 1, 50];
 {
     private _pos = (_x select 0);
     _pos = [_pos, 0, 75, 5, 0, 0, 0] call BIS_fnc_findSafePos;
-    if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+    if (!(_pos call VIC_fnc_isWaterPosition)) then {
         private _type = ["forest"] call _selectType;
         [_type, _pos] call _createMarker;
     };
@@ -154,7 +154,7 @@ private _swampSites = selectBestPlaces [_center, worldSize, "meadow", 1, 50];
 {
     private _pos = (_x select 0);
     _pos = [_pos, 0, 75, 5, 0, 0, 0] call BIS_fnc_findSafePos;
-    if (!([_pos] call VIC_fnc_isWaterPosition)) then {
+    if (!(_pos call VIC_fnc_isWaterPosition)) then {
         private _type = ["swamp"] call _selectType;
         [_type, _pos] call _createMarker;
     };
@@ -167,7 +167,7 @@ private _existing = STALKER_mutantHabitats apply { _x#4 };
         if !(_buildings isEqualTo []) then {
             private _p = getPosATL (selectRandom _buildings);
             _p = [_p, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
-            if (!([_p] call VIC_fnc_isWaterPosition)) then { [_x, _p] call _createMarker; };
+            if (!(_p call VIC_fnc_isWaterPosition)) then { [_x, _p] call _createMarker; };
         };
     };
 } forEach _allTypes;


### PR DESCRIPTION
## Summary
- fix calls to `VIC_fnc_isWaterPosition` so positions are passed directly

## Testing
- `grep -n "call VIC_fnc_isWaterPosition" -r addons`

------
https://chatgpt.com/codex/tasks/task_e_684c73ddb3bc832f80261add713148c5