### PR TITLE
Fix isWaterPosition param parsing

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
@@ -6,7 +6,10 @@
         BOOL - true if water surface
 */
 // Accepts either [x,y] or [x,y,z] and normalises to 3D
-params ["_x","_y",["_z",0]];
+if !(_this isEqualType []) exitWith { false };
+if ((count _this) < 2) exitWith { false };
+
+_this params ["_x","_y",["_z",0]];
 
 private _asl = AGLToASL [_x,_y,_z];
 (surfaceIsWater _asl)


### PR DESCRIPTION
## Summary
- handle invalid arrays in `fn_isWaterPosition`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c997164bc832fbf849dbd3864fa0f