### PR TITLE
Add death marker feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu.
 * Abandoned and damaged vehicles may appear on or near roads.
+* Fallen players leave a red X marker that vanishes once the body is removed.
 
 ### Spooks
 * Lightweight supernatural events to unsettle players.

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markDeathLocation.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markDeathLocation.sqf
@@ -1,0 +1,30 @@
+/*
+    Creates a red X marker at the location where a player dies.
+    The marker is removed automatically once the corpse is deleted.
+*/
+
+["markDeathLocation"] call VIC_fnc_debugLog;
+
+params ["_unit"];
+
+if (!isServer) exitWith {};
+if (isNull _unit || {!isPlayer _unit}) exitWith {};
+
+private _pos = getPosATL _unit;
+private _name = format ["death_%1", diag_tickTime];
+
+private _marker = [_name, _pos, "ICON", "hd_destroy", "ColorRed", 1] call VIC_fnc_createGlobalMarker;
+
+if (isNil "STALKER_deathMarkers") then { STALKER_deathMarkers = [] };
+STALKER_deathMarkers pushBack [_unit, _marker];
+
+[_unit, _marker] spawn {
+    params ["_corpse", "_markerName"];
+    waitUntil { isNull _corpse };
+    if (_markerName != "") then { deleteMarker _markerName; };
+    if (!isNil "STALKER_deathMarkers") then {
+        STALKER_deathMarkers = STALKER_deathMarkers select { _x#1 != _markerName };
+    };
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -121,6 +121,7 @@ VIC_fnc_setupDebugActions        = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_markAllBuildings        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markAllBuildings.sqf");
 VIC_fnc_markPlayerRanges        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markPlayerRanges.sqf");
 VIC_fnc_createGlobalMarker     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_createGlobalMarker.sqf");
+VIC_fnc_markDeathLocation      = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markDeathLocation.sqf");
 VIC_fnc_weightedPick           = compile preprocessFileLineNumbers (_root + "\functions\core\fn_weightedPick.sqf");
 VIC_fnc_selectWeightedBuilding = compile preprocessFileLineNumbers (_root + "\functions\core\fn_selectWeightedBuilding.sqf");
 VIC_fnc_spawnAmbientStalkers   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnAmbientStalkers.sqf");
@@ -249,6 +250,7 @@ VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\fu
 ["EntityKilled", {
     params ["_unit"];
     [_unit] call VIC_fnc_trackDeadForZombify;
+    [_unit] call VIC_fnc_markDeathLocation;
   }] call CBA_fnc_addEventHandler;
 } else {
     ["postInit", {


### PR DESCRIPTION
## Summary
- mark player death locations with a red X
- compile and register new `markDeathLocation` function
- document the new feature in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c999b9528832fb1627923252ae8c8