### PR TITLE
Add Antistasi mission helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,16 @@ statements are not themselves returning a final value. In your case, you have:
 
 These mods must be loaded for the scripts in this repository to function correctly.
 
+## Antistasi Integration
+
+When Antistasi Ultimate is detected, several helper functions can create side missions:
+
+* **VIC_fnc_startMutantHunt** – awards money for each mutant killed during the hunt period.
+* **VIC_fnc_startArtefactHunt** – places an artefact in an existing anomaly field and tasks players to retrieve it.
+* **VIC_fnc_startChemSample** – chooses a chemical zone and requires players to stay inside for 90 seconds to collect samples.
+
+These helpers do nothing if Antistasi Ultimate is not loaded.
+
 ## Branding
 
 The repository ships with `logo.paa` as the main logo and `Icon.paa` for smaller

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -183,6 +183,17 @@ class CfgFunctions
             class findSite_trapdoor{};
             class findSite_zapper{};
         };
+
+        class Antistasi
+        {
+            file = "Viceroys-STALKER-ALife\functions\antistasi";
+            class isAntistasiUltimate{};
+            class startMutantHunt{};
+            class startArtefactHunt{};
+            class startChemSample{};
+            class completeArtefactHunt{};
+            class completeChemSample{};
+        };
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_completeArtefactHunt.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_completeArtefactHunt.sqf
@@ -1,0 +1,11 @@
+/*
+    Completes the active artefact hunt and pays the reward.
+*/
+
+if (!isServer) exitWith {};
+
+private _reward = missionNamespace getVariable ["STALKER_artifactReward",0];
+if (!isNil "A3U_fnc_addMoney") then { [_reward] call A3U_fnc_addMoney; };
+
+missionNamespace setVariable ["STALKER_artifactReward", nil];
+missionNamespace setVariable ["STALKER_artifactTarget", objNull];

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_completeChemSample.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_completeChemSample.sqf
@@ -1,0 +1,14 @@
+/*
+    Completes the chemical sampling mission and pays the reward.
+    Params:
+        0: NUMBER - reward amount (optional)
+*/
+params [["_reward",-1]];
+
+if (!isServer) exitWith {};
+
+if (_reward < 0) then { _reward = missionNamespace getVariable ["STALKER_chemSample_data", [0,0,0,0]] select 3; };
+if (!isNil "A3U_fnc_addMoney") then { [_reward] call A3U_fnc_addMoney; };
+
+missionNamespace setVariable ["STALKER_chemSample_active", false];
+missionNamespace setVariable ["STALKER_chemSample_data", nil];

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_isAntistasiUltimate.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_isAntistasiUltimate.sqf
@@ -1,0 +1,9 @@
+/*
+    Returns true when Antistasi Ultimate patches are loaded.
+*/
+
+private _patches = configProperties [configFile >> "CfgPatches", "isClass _x"];
+(_patches findIf {
+    private _name = toLower configName _x;
+    (_name find "a3u") >= 0 || (_name find "antistasi") >= 0
+}) > -1

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_startArtefactHunt.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_startArtefactHunt.sqf
@@ -1,0 +1,32 @@
+/*
+    Starts an artefact retrieval mission using an existing anomaly field.
+
+    Params:
+        0: NUMBER - cash reward when the artefact is collected (default 100)
+
+    Returns:
+        BOOL - true when the mission starts
+*/
+params [["_reward",100]];
+
+if !(call VIC_fnc_isAntistasiUltimate) exitWith {false};
+if (!isServer) exitWith {false};
+if (isNil "STALKER_anomalyFields" || {STALKER_anomalyFields isEqualTo []}) exitWith {false};
+
+private _entry = selectRandom STALKER_anomalyFields;
+_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site"];
+private _pos = if (_site isEqualTo []) then {_center} else {_site};
+
+private _artifact = createVehicle ["GroundWeaponHolder_Single_F", _pos, [], 0, "CAN_COLLIDE"];
+_artifact addItemCargoGlobal ["ss_artifact_dummy",1];
+
+missionNamespace setVariable ["STALKER_artifactTarget", _artifact];
+missionNamespace setVariable ["STALKER_artifactReward", _reward];
+
+[_artifact, ["Take Artefact", { deleteVehicle (_this select 0); [] call VIC_fnc_completeArtefactHunt; }]] remoteExec ["addAction", 0, _artifact];
+
+if (!isNil "A3U_fnc_createTask") then {
+    ["VIC_ArtefactHunt","Artefact Hunt","Retrieve the artefact from the anomaly.",_pos] call A3U_fnc_createTask;
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_startChemSample.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_startChemSample.sqf
@@ -1,0 +1,37 @@
+/*
+    Starts a chemical sample mission that requires staying inside a zone.
+
+    Params:
+        0: NUMBER - duration in seconds to remain in the zone (default 90)
+        1: NUMBER - reward upon completion (default 100)
+
+    Returns:
+        BOOL - true when the mission starts
+*/
+params [["_duration",90],["_reward",100]];
+
+if !(call VIC_fnc_isAntistasiUltimate) exitWith {false};
+if (!isServer) exitWith {false};
+if (isNil "STALKER_chemicalZones" || {STALKER_chemicalZones isEqualTo []}) exitWith {false};
+
+private _entry = selectRandom STALKER_chemicalZones;
+_entry params ["_pos","_radius","_active","_marker","_exp"];
+
+missionNamespace setVariable ["STALKER_chemSample_active", true];
+
+[_pos,_radius,_duration,_reward] spawn {
+    params ["_pos","_rad","_dur","_reward"];
+    private _time = 0;
+    while {missionNamespace getVariable ["STALKER_chemSample_active",false] && {_time < _dur}} do {
+        if ([_pos,_rad] call VIC_fnc_hasPlayersNearby) then { _time = _time + 1; };
+        sleep 1;
+    };
+    if (_time >= _dur) then { [_reward] call VIC_fnc_completeChemSample; };
+    missionNamespace setVariable ["STALKER_chemSample_active", false];
+};
+
+if (!isNil "A3U_fnc_createTask") then {
+    ["VIC_ChemSample","Chemical Sample","Hold inside the chemical zone.",_pos] call A3U_fnc_createTask;
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_startMutantHunt.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_startMutantHunt.sqf
@@ -1,0 +1,27 @@
+/*
+    Starts a timed mutant hunting mission that awards money per kill.
+
+    Params:
+        0: NUMBER - duration in seconds (default 600)
+        1: NUMBER - cash reward per kill (default 50)
+
+    Returns:
+        BOOL - true when the mission starts
+*/
+params [["_duration",600],["_reward",50]];
+
+if !(call VIC_fnc_isAntistasiUltimate) exitWith {false};
+if (!isServer) exitWith {false};
+
+missionNamespace setVariable ["STALKER_mutantHunt", [0,_reward,diag_tickTime + _duration]];
+missionNamespace setVariable ["STALKER_mutantHunt_active", true];
+
+[{
+    missionNamespace setVariable ["STALKER_mutantHunt_active", false];
+}, [], _duration] call CBA_fnc_waitAndExecute;
+
+if (!isNil "A3U_fnc_createTask") then {
+    ["VIC_MutantHunt","Mutant Hunt","Eliminate mutants for cash.",objNull] call A3U_fnc_createTask;
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -129,6 +129,13 @@ VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
 VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageStalkerCamps.sqf");
 
+VIC_fnc_isAntistasiUltimate  = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_isAntistasiUltimate.sqf");
+VIC_fnc_startMutantHunt      = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_startMutantHunt.sqf");
+VIC_fnc_startArtefactHunt    = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_startArtefactHunt.sqf");
+VIC_fnc_startChemSample      = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_startChemSample.sqf");
+VIC_fnc_completeArtefactHunt = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_completeArtefactHunt.sqf");
+VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_completeChemSample.sqf");
+
 
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_onMutantKilled.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_onMutantKilled.sqf
@@ -30,4 +30,12 @@ if (_habIndex > -1 && {!isNil "STALKER_mutantHabitats"}) then {
     STALKER_mutantHabitats set [_habIndex, [_area,_label,_grp,_pos,_type,_max,_count,_near]];
 };
 
+if (missionNamespace getVariable ["STALKER_mutantHunt_active", false]) then {
+    private _entry = missionNamespace getVariable ["STALKER_mutantHunt", [0,0,0]];
+    _entry params ["_kills","_reward","_end"];
+    _kills = _kills + 1;
+    missionNamespace setVariable ["STALKER_mutantHunt", [_kills,_reward,_end]];
+    if (!isNil "A3U_fnc_addMoney") then { [_reward] call A3U_fnc_addMoney; };
+};
+
 true


### PR DESCRIPTION
## Summary
- integrate new Antistasi helper functions
- detect Antistasi Ultimate at runtime
- add missions for mutant hunts, artefact hunts and chemical samples
- pay players for mutant kills during hunts
- document Antistasi integration

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684cb6294788832f86c752376a113ae8