### PR TITLE
Fix position helpers for invalid input

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -9,12 +9,15 @@
 */
 params ["_center", ["_radius",50], ["_attempts",10]];
 
+// fail fast on invalid input
+if (_center isEqualTo [] && { !(_center isEqualType objNull) }) exitWith { [] };
+
 private _base = if (_center isEqualType objNull) then { getPos _center } else { _center };
-// ensure we have a 3D position
-if (_base isEqualType []) then {
-    _base params ["_bx","_by",["_bz",0]];
-    _base = [_bx,_by,_bz];
-};
+if !(_base isEqualType []) exitWith { [] };
+
+// ensure we have a 3D position and sane defaults
+_base params [["_bx",0],["_by",0],["_bz",0]];
+_base = [_bx,_by,_bz];
 
 for "_i" from 0 to _attempts do {
     private _candidate = if (_i == 0) then { _base } else { [_base, random _radius, random 360] call BIS_fnc_relPos };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
@@ -1,15 +1,17 @@
 /*
     Returns true if the given position is water.
     Params:
-        0: ARRAY - position [x,y,z] or [x,y]
+        0: ARRAY or OBJECT - position [x,y,z] or object
     Returns:
         BOOL - true if water surface
 */
-// Accepts either [x,y] or [x,y,z] and normalises to 3D
-if !(_this isEqualType []) exitWith { false };
-if ((count _this) < 2) exitWith { false };
 
-_this params ["_x","_y",["_z",0]];
+// allow passing an object directly
+private _pos = if (_this isEqualType objNull) then { getPos _this } else { _this };
+if !(_pos isEqualType []) exitWith { false };
+if ((count _pos) < 2) exitWith { false };
+
+_pos params [["_x",0],["_y",0],["_z",0]];
 
 private _asl = AGLToASL [_x,_y,_z];
 (surfaceIsWater _asl)


### PR DESCRIPTION
## Summary
- validate input to `findLandPosition` and normalize output
- handle objects and invalid arrays in `isWaterPosition`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d48fd67ac832f9d4bfc6a28fe62fa