### PR TITLE
Improve chemical zone placement

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -137,6 +137,13 @@
     [0, 250, 50, 0]
 ] call CBA_fnc_addSetting;
 
+["VSA_chemicalGasType",
+ "LIST",
+ ["Chemical Gas Type", "Gas used for chemical zones"],
+ "Viceroy's STALKER ALife - Chemical",
+ [[0,1,2,3,4],["CS","Asphyxiant","Nerve","Blister","Nova"],1]
+] call CBA_fnc_addSetting;
+
 [
     "VSA_emissionChemicalCount",
     "SLIDER",

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -28,7 +28,7 @@ params [
     ["_position", [0,0,0]],
     ["_radius", 50],
     ["_duration", -1],
-    ["_chemType", 1],
+    ["_chemType", -1],
     ["_verticleSpread", -0.1],
     ["_thickness", 1]
 ];
@@ -38,6 +38,10 @@ params [
 // Array to keep track of active zones and their expiration times
 if (isNil "STALKER_chemicalZones") then {
     STALKER_chemicalZones = [];
+};
+
+if (_chemType < 0) then {
+    _chemType = ["VSA_chemicalGasType", 1] call VIC_fnc_getSetting;
 };
 
 if (_duration < 0) then {
@@ -53,7 +57,7 @@ private _agl = ASLToAGL _position;
 
 // Create and configure a map marker for this chemical zone
 private _markerName = format ["chem_%1", diag_tickTime];
-private _marker = createMarker [_markerName, ASLToATL _position];
+private _marker = createMarker [_markerName, AGLToATL _agl];
 _marker setMarkerShape "ELLIPSE";
 _marker setMarkerSize [_radius, _radius];
 _marker setMarkerColor "ColorGreen";

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
@@ -23,7 +23,10 @@ if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
 
 for "_i" from 1 to _count do {
     if (random 100 >= _weight) then { continue };
-    private _pos = _center getPos [random _radius, random 360];
+    private _centerPos = if (_center isEqualType objNull) then { getPos _center } else { _center };
+    private _ang = random 360;
+    private _dist = random _radius;
+    private _pos = [(_centerPos select 0) + _dist * sin _ang, (_centerPos select 1) + _dist * cos _ang, _centerPos select 2];
     [_pos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
@@ -23,21 +23,14 @@ private _zoneRadius = ["VSA_chemicalZoneRadius", 50] call VIC_fnc_getSetting;
 if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
 
 for "_i" from 1 to _count do {
-    private _base = _center getPos [random _radius, random 360];
+    private _centerPos = if (_center isEqualType objNull) then { getPos _center } else { _center };
+    private _ang = random 360;
+    private _dist = random _radius;
+    private _base = [(_centerPos select 0) + _dist * sin _ang, (_centerPos select 1) + _dist * cos _ang, _centerPos select 2];
     private _pos = [_base, 30, 10] call VIC_fnc_findValleyPosition;
     if (_pos isEqualTo []) then { continue };
 
-    private _marker = "";
-    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        _marker = createMarker [format ["chem_%1", diag_tickTime + _i], ASLtoATL _pos];
-        _marker setMarkerShape "ELLIPSE";
-        _marker setMarkerSize [_zoneRadius,_zoneRadius];
-        _marker setMarkerColor "ColorGreen";
-        _marker setMarkerAlpha 0.2;
-    };
-
-    private _expires = if (_duration >= 0) then { diag_tickTime + _duration } else {-1};
-    STALKER_chemicalZones pushBack [_pos,_zoneRadius,false,_marker,_expires];
+    [_pos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
 };
 
 true


### PR DESCRIPTION
## Summary
- allow selecting a gas type for chemical zones
- fix spawnChemicalZone marker placement and default gas type
- spawn chemical zones in valleys and randomly in any area

## Testing
- `No tests to run`

------
https://chatgpt.com/codex/tasks/task_e_684d5143e6e0832f9f5f6a7e33f99b43