### PR TITLE
Implement overcast buildup for psy-storms

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 ### Storms
 * Periodic psy-storms that force players to seek shelter.
 * During a storm lightning and Psy Discharges strike separately across the map. Their frequency ramps up over time.
-* Fog and rain intensify as the storm builds, then fade once it passes.
+* Fog, rain and overcast intensify as the storm builds, then fade once it passes.
 * Duration, lightning and discharge intensity curves, and the delay between storms can all be configured via CBA settings.
-* New settings `VSA_stormFogEnd` and `VSA_stormRainEnd` control the maximum fog and rain.
+* New settings `VSA_stormFogEnd`, `VSA_stormRainEnd`, `VSA_stormOvercast` and `VSA_stormOvercastTime` control weather effects and how quickly overcast builds up.
 * Duration, lightning and discharge intensity curves, the radius around players for effects, and the delay between storms can all be configured via CBA settings.
 * Works with the emission hook system for mission-specific consequences.
 * Optional Nova Gas clouds spawn at every Psy Discharge by default.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -397,6 +397,12 @@ true
 ["VSA_stormGasVertical","SLIDER",["Gas Vertical Spread","Vertical spread of the mist"],"Viceroy's STALKER ALife - Storms",[-2,2,1,2]] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
+// Overcast behaviour
+// -----------------------------------------------------------------------------
+["VSA_stormOvercast","SLIDER",["Storm Overcast","Cloud coverage during a storm"],"Viceroy's STALKER ALife - Storms",[0,1,1,2]] call CBA_fnc_addSetting;
+["VSA_stormOvercastTime","SLIDER",["Overcast Transition (s)","Seconds to reach full overcast"],"Viceroy's STALKER ALife - Storms",[0,300,60,0]] call CBA_fnc_addSetting;
+
+// -----------------------------------------------------------------------------
 // Zombification
 // -----------------------------------------------------------------------------
 [

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
@@ -32,6 +32,8 @@ private _dischargeStart = ["VSA_stormDischargeStart", 6] call VIC_fnc_getSetting
 private _dischargeEnd   = ["VSA_stormDischargeEnd", 12] call VIC_fnc_getSetting;
 private _fogEnd         = ["VSA_stormFogEnd", 0.6] call VIC_fnc_getSetting;
 private _rainEnd        = ["VSA_stormRainEnd", 0.8] call VIC_fnc_getSetting;
+private _overcastEnd    = ["VSA_stormOvercast", 1] call VIC_fnc_getSetting;
+private _overcastTime   = ["VSA_stormOvercastTime", 60] call VIC_fnc_getSetting;
 
 _minDelay = ["VSA_stormMinDelay", _minDelay] call VIC_fnc_getSetting;
 _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
@@ -39,21 +41,21 @@ _maxDelay = ["VSA_stormMaxDelay", _maxDelay] call VIC_fnc_getSetting;
 if (_minDelay < 0) then { _minDelay = 0; };
 if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
-[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _lightningStart, _lightningEnd, _dischargeStart, _dischargeEnd, _fogEnd, _rainEnd] spawn {
-    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_lStart", "_lEnd", "_dStart", "_dEnd", "_fEnd", "_rEnd"];
+[_minDelay, _maxDelay, _manualVar, _spawnWeight, _nightOnly, _duration, _lightningStart, _lightningEnd, _dischargeStart, _dischargeEnd, _fogEnd, _rainEnd, _overcastEnd, _overcastTime] spawn {
+    params ["_min", "_max", "_var", "_weight", "_night", "_dur", "_lStart", "_lEnd", "_dStart", "_dEnd", "_fEnd", "_rEnd", "_oEnd", "_oTime"];
     private _nextStorm = time + (_min + random (_max - _min));
     while {true} do {
         if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
             missionNamespace setVariable [_var, false, true];
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd] call VIC_fnc_triggerPsyStorm;
+                [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd, _oEnd, _oTime] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };
 
         if (time >= _nextStorm) then {
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
-                [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd] call VIC_fnc_triggerPsyStorm;
+                [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd, _oEnd, _oTime] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
         };

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -10,6 +10,10 @@
         2: NUMBER - lightning strikes per second when storm ends (default 12)
         3: NUMBER - discharge occurrences per second at storm start (default 6)
         4: NUMBER - discharge occurrences per second when storm ends (default 12)
+        5: NUMBER - fog level when the storm peaks (default 0.6)
+        6: NUMBER - rain intensity when the storm peaks (default 0.8)
+        7: NUMBER - overcast level during the storm (default 1)
+        8: NUMBER - seconds to reach full overcast before strikes (default 60)
 */
 
 params [
@@ -19,20 +23,36 @@ params [
     ["_dischargeStart", 6],
     ["_dischargeEnd", 12],
     ["_fogEnd", 0.6],
-    ["_rainEnd", 0.8]
+    ["_rainEnd", 0.8],
+    ["_overcastEnd", 1],
+    ["_overcastTime", 60]
 ];
 
 
 ["triggerPsyStorm"] call VIC_fnc_debugLog;
 private _startFog = fog;
 private _startRain = rain;
+private _startOvercast = overcast;
 private _range = ["VSA_stormRadius", 1500] call VIC_fnc_getSetting;
 private _gasEnabled = ["VSA_stormGasDischarges", true] call VIC_fnc_getSetting;
+
+private _stepsOvercast = floor _overcastTime;
+if (_stepsOvercast > 0) then {
+    for "_i" from 1 to _stepsOvercast do {
+        private _prog = _i / (_stepsOvercast max 1);
+        private _current = _startOvercast + (_overcastEnd - _startOvercast) * _prog;
+        0 setOvercast _current;
+        sleep 1;
+    };
+} else {
+    0 setOvercast _overcastEnd;
+};
 
 if (count allPlayers == 0) exitWith {};
 
 private _ticks = floor _duration;
 for "_i" from 1 to _ticks do {
+    0 setOvercast _overcastEnd;
     private _progress = (_i - 1) / (_ticks max 1);
     private _currentLightning = round (_lightningStart + (_lightningEnd - _lightningStart) * _progress);
     private _currentDischarge = round (_dischargeStart + (_dischargeEnd - _dischargeStart) * _progress);
@@ -78,4 +98,13 @@ for "_i" from 1 to _ticks do {
 
 0 setFog _startFog;
 0 setRain _startRain;
+if (_stepsOvercast > 0) then {
+    for "_i" from 1 to _stepsOvercast do {
+        private _prog = _i / (_stepsOvercast max 1);
+        private _current = _overcastEnd + (_startOvercast - _overcastEnd) * _prog;
+        0 setOvercast _current;
+        sleep 1;
+    };
+};
+0 setOvercast _startOvercast;
 


### PR DESCRIPTION
## Summary
- add storm overcast settings
- document new settings in README
- pass overcast parameters when scheduling storms
- fade overcast in and out around the storm

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d54c89bb8832fa0ee9eab67eabc2a