### PR TITLE
Use road helpers for ambush and IED placement

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -20,28 +20,20 @@ if (_count < 0) then { _count = ["VSA_ambushCount", 3] call VIC_fnc_getSetting; 
 private _townDist = ["VSA_ambushTownDistance", 700] call VIC_fnc_getSetting;
 
 for "_i" from 1 to _count do {
-    private _pos = [];
-    private _road = objNull;
+    private _pos = nil;
 
     for "_j" from 1 to 30 do {
-        private _candidate = _center getPos [random _radius, random 360];
-        _candidate = [_candidate] call VIC_fnc_findLandPosition;
-        if (_candidate isEqualTo []) then { continue; };
+        private _candidate = [_center, _radius, 5] call VIC_fnc_findRoadPosition;
+        if (isNil "_candidate") then { continue; };
 
-        if (!(_candidate call VIC_fnc_isWaterPosition)) then {
-            private _locations = nearestLocations [
-                _candidate,
-                ["NameVillage","NameCity","NameCityCapital","NameLocal"],
-                _townDist
-            ];
-            if (_locations isEqualTo []) then {
-                _road = nearestRoad _candidate;
-                if (!isNull _road) exitWith { _pos = getPos _road };
-            };
-        };
+        private _locations = nearestLocations [
+            _candidate,
+            ["NameVillage","NameCity","NameCityCapital","NameLocal"],
+            _townDist
+        ];
+        if (_locations isEqualTo []) exitWith { _pos = _candidate };
     };
-
-    if (_pos isEqualTo []) then { continue; };
+    if (isNil "_pos") then { continue; };
 
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
@@ -11,25 +11,13 @@ params ["_center"];
 
 if (!isServer) exitWith { [] };
 
-private _road = roadAt _center;
-if (isNull _road) then {
-    private _radius = 50;
-    private _max = 200;
-    while {isNull _road && {_radius <= _max}} do {
-        private _roads = _center nearRoads _radius;
-        if (!(_roads isEqualTo [])) then {
-            _road = _roads select 0;
-        };
-        _radius = _radius + 50;
-    };
-    if (isNull _road) then {
-        _road = nearestRoad _center;
-    };
-};
-
-if (isNull _road) exitWith { [] };
-
-private _pos = getPos _road;
+private _pos = [_center, 200, 20] call VIC_fnc_findRoadPosition;
+if (isNil "_pos") exitWith { [] };
 private _ied = createMine ["IEDLandSmall_F", _pos, [], 0];
+
+if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+    private _marker = format ["ied_%1", diag_tickTime];
+    [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.2, "IED"] call VIC_fnc_createGlobalMarker;
+};
 
 [_ied];

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -46,19 +46,17 @@ for "_i" from 1 to _iedCount do {
     if (_towns isEqualTo []) exitWith {};
     private _town = selectRandom _towns;
     private _tPos = locationPosition _town;
-    private _road = nearestRoad _tPos;
-    if (!isNull _road) then {
-        private _pos = getPos _road;
-        private _marker = "";
-        if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-            _marker = createMarker [format ["ied_%1", diag_tickTime], _pos];
-            _marker setMarkerShape "ICON";
-            _marker setMarkerType "mil_triangle";
-            _marker setMarkerColor "ColorRed";
-            _marker setMarkerText "IED";
-            _marker setMarkerAlpha 0.2;
-        };
-        STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
+    private _pos = [_tPos, 200, 10] call VIC_fnc_findRoadPosition;
+    if (isNil "_pos") then { continue; };
+    private _marker = "";
+    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+        _marker = createMarker [format ["ied_%1", diag_tickTime], _pos];
+        _marker setMarkerShape "ICON";
+        _marker setMarkerType "mil_triangle";
+        _marker setMarkerColor "ColorRed";
+        _marker setMarkerText "IED";
+        _marker setMarkerAlpha 0.2;
     };
+    STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
 };
 


### PR DESCRIPTION
## Summary
- find ambush spots via `VIC_fnc_findRoadPosition`
- mark IEDs when debugging
- use road helper for spawning IEDs in minefields

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d550e82a4832f875b2b02f0b8305b