### PR TITLE
Fix visibility checks using eyePos

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingCoverSpot.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingCoverSpot.sqf
@@ -29,7 +29,7 @@ private _nearBuildings = _playerPos nearObjects ["House", _searchRadius];
 
     if (
         !surfaceIsWater _hiddenPos &&
-        [ _player, "VIEW" ] checkVisibility [ _player eyePos, _hiddenPos ] < 0.05
+        [ _player, "VIEW" ] checkVisibility [ eyePos _player, _hiddenPos ] < 0.05
     ) exitWith {
         _hiddenPos
     };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findHiddenPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findHiddenPosition.sqf
@@ -34,7 +34,7 @@ private _validSpots = [];
         private _seen = false;
 
         {
-            if ([ _x, "VIEW" ] checkVisibility [ _x eyePos, _pos ] > 0.1) exitWith {
+            if ([ _x, "VIEW" ] checkVisibility [ eyePos _x, _pos ] > 0.1) exitWith {
                 _seen = true;
             };
         } forEach _players;


### PR DESCRIPTION
## Summary
- correct eye position syntax in visibility checks

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6e01a094832fb4a49255d59aacf3