### PR TITLE
Refactor ambush and mine management

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 ### Minefields
 * Generates APERS minefields on town outskirts and single IEDs on roads. These no longer spawn automatically on mission start.
 * Mines despawn when no players are nearby and respawn when someone approaches.
-* Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way.
+* Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way. Use the new actions to start the minefield and ambush managers when testing.
 * Abandoned and damaged vehicles may appear on or near roads.
 * Fallen players leave a red X marker that vanishes once the body is removed.
 

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -110,6 +110,7 @@ class CfgFunctions
             class spawnAPERSField{};
             class spawnIED{};
             class manageMinefields{};
+            class startMinefieldManager{};
         };
         class Wrecks
         {
@@ -122,6 +123,7 @@ class CfgFunctions
             file = "Viceroys-STALKER-ALife\functions\ambushes";
             class spawnAmbushes{};
             class manageAmbushes{};
+            class startAmbushManager{};
         };
         class Blowouts
         {

--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf
@@ -23,8 +23,13 @@ private _maxUnits = ["VSA_ambushMaxUnits", 6] call VIC_fnc_getSetting;
         };
 
         if (_mines isEqualTo []) then {
-            private _road = nearestRoad _pos;
-            private _dir = if (!isNull _road) then { getDir _road } else { 0 };
+            private _roadPos = [_pos, 50, 5] call VIC_fnc_findRoadPosition;
+            private _dir = 0;
+            if (!isNil "_roadPos") then {
+                private _road = roadAt _roadPos;
+                if (isNull _road) then { _road = nearestRoad _roadPos; };
+                if (!isNull _road) then { _dir = getDir _road; };
+            };
             for "_i" from -8 to 8 step 3 do {
                 private _cPos = _pos getPos [_i, _dir];
                 private _left = _cPos getPos [2, _dir + 90];
@@ -39,10 +44,12 @@ private _maxUnits = ["VSA_ambushMaxUnits", 6] call VIC_fnc_getSetting;
             private _grp2 = createGroup east;
             private _count = floor(random (_maxUnits - _minUnits + 1)) + _minUnits;
             private _half = ceil(_count / 2);
-            private _road = nearestRoad _pos;
+            private _roadPos = [_pos, 50, 5] call VIC_fnc_findRoadPosition;
             private _dir = 0;
-            if (!isNull _road) then {
-                _dir = getDir _road;
+            if (!isNil "_roadPos") then {
+                private _road = roadAt _roadPos;
+                if (isNull _road) then { _road = nearestRoad _roadPos; };
+                if (!isNull _road) then { _dir = getDir _road; };
             };
             for "_i" from 1 to _half do {
                 private _p = _pos getPos [10 + random 5, _dir + 90];

--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_startAmbushManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_startAmbushManager.sqf
@@ -1,0 +1,18 @@
+/*
+    Starts the ambush management loop. Debug use only.
+*/
+["startAmbushManager"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+if (missionNamespace getVariable ["VIC_ambushManagerRunning", false]) exitWith {};
+missionNamespace setVariable ["VIC_ambushManagerRunning", true];
+
+[] spawn {
+    while { missionNamespace getVariable ["VIC_ambushManagerRunning", false] } do {
+        [] call VIC_fnc_manageAmbushes;
+        sleep 60;
+    };
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -102,8 +102,10 @@ VIC_fnc_spawnAPERSField        = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnIED.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
+VIC_fnc_startMinefieldManager  = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_startMinefieldManager.sqf");
 VIC_fnc_spawnAmbushes          = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_spawnAmbushes.sqf");
 VIC_fnc_manageAmbushes         = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_manageAmbushes.sqf");
+VIC_fnc_startAmbushManager     = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_startAmbushManager.sqf");
 VIC_fnc_spawnAmbientHerds        = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnAmbientHerds.sqf");
 VIC_fnc_setupMutantHabitats      = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_setupMutantHabitats.sqf");
 VIC_fnc_spawnMutantNest         = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnMutantNest.sqf");
@@ -260,17 +262,7 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
     [
         {
             while {true} do {
-                [] call VIC_fnc_manageMinefields;
-                sleep 60;
-            };
-        }, [], 27
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
                 [] call VIC_fnc_manageStalkerCamps;
-                [] call VIC_fnc_manageAmbushes;
                 sleep 60;
             };
         }, [], 29

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -66,8 +66,14 @@ player addAction ["Spawn Predator Attack", {
 player addAction ["Spawn Minefields", {
     [getPos player, 300] remoteExec ["VIC_fnc_spawnMinefields", 2];
 }];
+player addAction ["Start Minefield Logic", {
+    [] remoteExec ["VIC_fnc_startMinefieldManager", 2];
+}];
 player addAction ["Spawn Ambush", {
     [getPos player, 300] remoteExec ["VIC_fnc_spawnAmbushes", 2];
+}];
+player addAction ["Start Ambush Logic", {
+    [] remoteExec ["VIC_fnc_startAmbushManager", 2];
 }];
 player addAction ["Generate Mutant Habitats", {
     [] remoteExec ["VIC_fnc_setupMutantHabitats", 2];

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf
@@ -1,0 +1,18 @@
+/*
+    Starts the minefield management loop. Debug use only.
+*/
+["startMinefieldManager"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+if (missionNamespace getVariable ["VIC_minefieldManagerRunning", false]) exitWith {};
+missionNamespace setVariable ["VIC_minefieldManagerRunning", true];
+
+[] spawn {
+    while { missionNamespace getVariable ["VIC_minefieldManagerRunning", false] } do {
+        [] call VIC_fnc_manageMinefields;
+        sleep 60;
+    };
+};
+
+true


### PR DESCRIPTION
## Summary
- add debug-only start manager functions for ambushes and minefields
- rely on helper road search when spawning ambush mines and AI
- remove automatic ambush/mine management from master init
- expose new manager functions in config and debug actions
- clarify debug actions in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d74917c3c832f9b89fefed7943bfd