### PR TITLE
Add AI avoidance of anomaly fields

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -500,6 +500,14 @@ true
     [0, 100, 20, 0]
 ] call CBA_fnc_addSetting;
 
+[
+    "VSA_fieldAvoidEnabled",
+    "CHECKBOX",
+    ["Avoid Anomaly Fields", "AI will steer clear of anomaly field areas"],
+    "Viceroy's STALKER ALife - AI",
+    true
+] call CBA_fnc_addSetting;
+
 
 // Hostile mutant spawns
 [

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -39,6 +39,8 @@ class CfgFunctions
             class resetAIBehavior{};
             class triggerAIPanic{};
             class avoidAnomalies{};
+            class avoidAnomalyFields{};
+            class toggleFieldAvoid{};
         };
 
         class Panic

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf
@@ -1,0 +1,44 @@
+/*
+    File: fn_avoidAnomalyFields.sqf
+    Author: Viceroy's STALKER ALife
+    Description:
+        Causes AI units to keep clear of anomaly field areas.
+    Parameter(s): none
+*/
+
+["fn_avoidAnomalyFields"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (["VSA_enableAIBehaviour", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if !(missionNamespace getVariable ["VSA_fieldAvoidEnabled", true]) exitWith {};
+if (["VSA_aiNightOnly", false] call VIC_fnc_getSetting && { daytime > 5 && daytime < 20 }) exitWith {};
+if (isNil "STALKER_anomalyFields") exitWith {};
+
+private _chance = ["VSA_aiAnomalyAvoidChance", 50] call VIC_fnc_getSetting;
+private _buffer = ["VSA_aiAnomalyAvoidRange", 20] call VIC_fnc_getSetting;
+
+private _fields = STALKER_anomalyFields apply { [ _x select 0, _x select 1 ] };
+if (_fields isEqualTo []) exitWith {};
+
+{
+    if (random 100 >= _chance) then { continue; };
+    private _unit = _x;
+    if (!alive _unit || {isPlayer _unit}) then { continue; };
+
+    private _field = [];
+    {
+        private _c = _x#0;
+        private _r = _x#1;
+        if (_unit distance _c < (_r + _buffer)) exitWith { _field = [_c, _r] };
+    } forEach _fields;
+
+    if !(_field isEqualTo []) then {
+        private _center = _field#0;
+        private _radius = _field#1;
+        private _dir = _unit getDir _center;
+        private _dest = [getPosATL _unit, (_radius + _buffer) * 1.2, _dir + 180] call BIS_fnc_relPos;
+        _unit doMove _dest;
+    };
+} forEach allUnits;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_toggleFieldAvoid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_toggleFieldAvoid.sqf
@@ -1,0 +1,16 @@
+/*
+    File: fn_toggleFieldAvoid.sqf
+    Author: Viceroy's STALKER ALife
+    Description:
+        Toggles AI avoidance of anomaly fields for testing.
+*/
+
+["fn_toggleFieldAvoid"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+missionNamespace setVariable ["VSA_fieldAvoidEnabled", !(missionNamespace getVariable ["VSA_fieldAvoidEnabled", true]), true];
+private _state = missionNamespace getVariable ["VSA_fieldAvoidEnabled", true];
+[format ["Field avoidance %1", if (_state) then {"enabled"} else {"disabled"}]] call VIC_fnc_debugLog;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -50,8 +50,10 @@ if (isServer) then {
 
 // --- Function Registration -------------------------------------------------
 VIC_fnc_resetAIBehavior          = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_resetAIBehavior.sqf");
-VIC_fnc_triggerAIPanic           = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_triggerAIPanic.sqf");
-VIC_fnc_avoidAnomalies           = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_avoidAnomalies.sqf");
+    VIC_fnc_triggerAIPanic           = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_triggerAIPanic.sqf");
+    VIC_fnc_avoidAnomalies           = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_avoidAnomalies.sqf");
+    VIC_fnc_avoidAnomalyFields       = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_avoidAnomalyFields.sqf");
+    VIC_fnc_toggleFieldAvoid         = compile preprocessFileLineNumbers (_root + "\functions\ai\fn_toggleFieldAvoid.sqf");
 VIC_fnc_cleanupChemicalZones    = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_cleanupChemicalZones.sqf");
 VIC_fnc_spawnChemicalZone       = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_spawnChemicalZone.sqf");
 VIC_fnc_spawnRandomChemicalZones = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_spawnRandomChemicalZones.sqf");
@@ -215,6 +217,15 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
                 sleep 30;
             };
         }, [], 16
+    ] call CBA_fnc_waitAndExecute;
+
+    [
+        {
+            while {true} do {
+                [] call VIC_fnc_avoidAnomalyFields;
+                sleep 30;
+            };
+        }, [], 17
     ] call CBA_fnc_waitAndExecute;
 
     [

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -81,6 +81,9 @@ player addAction ["Trigger AI Panic", {
 player addAction ["Reset AI Behaviour", {
     [] remoteExec ["VIC_fnc_resetAIBehavior", 2];
 }];
+player addAction ["Toggle Field Avoidance", {
+    [] remoteExec ["VIC_fnc_toggleFieldAvoid", 2];
+}];
 player addAction ["Mark All Buildings", { [] call VIC_fnc_markAllBuildings }];
 player addAction ["Mark Rock Clusters", { [] call VIC_fnc_markRockClusters }];
 player addAction ["Mark Sniper Spots", { [] call VIC_fnc_markSniperSpots }];


### PR DESCRIPTION
## Summary
- add `fn_avoidAnomalyFields` to keep AI units out of anomaly field areas
- add debug function `fn_toggleFieldAvoid` and action to toggle the behaviour
- hook new function and toggle into `fn_masterInit`
- expose CBA setting `VSA_fieldAvoidEnabled`
- register new functions in config

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d73cfbc84832f9c0592b1c71bba80