### PR TITLE
Reduce valley finder grid size

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -2,14 +2,14 @@
     Identifies valley-like positions based on relative terrain elevation.
 
     Params:
-        0: SCALAR - Sampling step size (default: 500m grid)
+        0: SCALAR - Sampling step size (default: 250m grid)
         1: SCALAR - Elevation threshold in meters to be "lower than surrounding" (default: 15m)
 
     Returns:
         ARRAY of POSITIONs - Valley center candidates
 */
 
-params [["_step", 500], ["_depthThreshold", 15]];
+params [["_step", 250], ["_depthThreshold", 15]];
 
 ["findValleys"] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- reduce the default step size in `fn_findValleys` from 500 to 250

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d84096f14832fb1066baeec53766e