### PR TITLE
Fix spawnAbandonedVehicles syntax

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -3,7 +3,7 @@
     Params:
         0: NUMBER - number of vehicles to spawn (default 10)
 */
-params [["_count",10]];
+params [["_count", 10]];
 
 ["spawnAbandonedVehicles"] call VIC_fnc_debugLog;
 
@@ -41,4 +41,3 @@ for "_i" from 1 to _count do {
         };
     };
 };
-


### PR DESCRIPTION
## Summary
- adjust param formatting in `spawnAbandonedVehicles`
- ensure file ends cleanly with standard characters

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684d834b941c832f9f1948dd0155a699