### PR TITLE
Fix beach and swamp search

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
@@ -1,14 +1,23 @@
 /*
-    Scans the map for water positions that have nearby land, roughly indicating a beach.
+    Scans the entire map on a grid to locate shallow water positions that touch
+    land and have little nearby vegetation. These are considered potential
+    beach sites.
 
     Params:
-        0: NUMBER - grid step size in meters (default: 200)
-        1: NUMBER - distance to check for land (default: 40)
+        0: NUMBER - grid step size in meters (default: 100)
+        1: NUMBER - maximum water depth in meters to count as "shallow" (default: 1)
+        2: NUMBER - radius to check for nearby vegetation (default: 20)
+        3: NUMBER - maximum vegetation objects allowed within the radius (default: 2)
 
     Returns:
         ARRAY of positions in AGL coordinates representing beach spots
 */
-params [["_step", 200], ["_distance", 40]];
+params [
+    ["_step", 100],
+    ["_maxDepth", 1],
+    ["_vegRadius", 20],
+    ["_vegThreshold", 2]
+];
 
 private _spots = [];
 
@@ -16,14 +25,20 @@ for "_xCoord" from 0 to worldSize step _step do {
     for "_yCoord" from 0 to worldSize step _step do {
         private _pos = [_xCoord, _yCoord, 0];
         if ([_pos] call VIC_fnc_isWaterPosition) then {
-            private _landNearby = false;
-            {
-                private _test = [_pos, _distance, _x] call BIS_fnc_relPos;
-                if (!([_test] call VIC_fnc_isWaterPosition)) exitWith { _landNearby = true };
-            } forEach [0, 90, 180, 270];
-            if (_landNearby) then {
-                private _surf = [_pos] call VIC_fnc_getSurfacePosition;
-                _spots pushBack (ASLToAGL _surf);
+            private _depth = abs (getTerrainHeightASL _pos);
+            if (_depth <= _maxDepth) then {
+                private _landNearby = false;
+                {
+                    private _test = [_pos, _step, _x] call BIS_fnc_relPos;
+                    if (!([_test] call VIC_fnc_isWaterPosition)) exitWith { _landNearby = true };
+                } forEach [0, 90, 180, 270];
+                if (_landNearby) then {
+                    private _veg = nearestTerrainObjects [_pos, ["BUSH","REED","SMALL TREE","TREE"], _vegRadius, false];
+                    if ((count _veg) <= _vegThreshold) then {
+                        private _surf = [_pos] call VIC_fnc_getSurfacePosition;
+                        _spots pushBack (ASLToAGL _surf);
+                    };
+                };
             };
         };
     };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
@@ -1,17 +1,18 @@
 /*
-    Identifies swamp-like regions based on terrain, water, and vegetation density.
+    Identifies swamp-like areas by scanning the entire map for shallow water
+    with dense vegetation.
 
     Params:
-        0: SCALAR - Grid step for scanning (default: 300m)
-        1: SCALAR - Elevation threshold (max height in meters, default: 3)
-        2: SCALAR - Minimum number of bushes (default: 10)
-        3: SCALAR - Radius to check vegetation (default: 30m)
+        0: SCALAR - Grid step in meters (default: 100)
+        1: SCALAR - Maximum water depth considered (default: 2)
+        2: SCALAR - Minimum vegetation objects required (default: 5)
+        3: SCALAR - Radius used to count vegetation (default: 25)
 
     Returns:
         ARRAY of POSITIONs - Swamp center positions
 */
 
-params [["_step", 300], ["_maxElevation", 3], ["_minBushes", 10], ["_radius", 30]];
+params [["_step", 100], ["_maxDepth", 2], ["_minVeg", 5], ["_radius", 25]];
 
 ["findSwamps"] call VIC_fnc_debugLog;
 
@@ -20,23 +21,14 @@ private _swamps = [];
 for "_x" from 0 to worldSize step _step do {
     for "_y" from 0 to worldSize step _step do {
         private _pos = [_x, _y, 0];
-        private _elev = getTerrainHeightASL _pos;
-
-        // Skip high or dry zones
-        if (_elev > _maxElevation) then { continue; };
-
-        // Needs to be wet-ish but not submerged
-        if (!([_pos] call VIC_fnc_isWaterPosition)) then { continue; };
-
-        // Count bushes nearby (reeds, low growth)
-        private _nearVeg = _pos nearObjects ["All", _radius];
-        private _bushes = _nearVeg select {
-            private _type = typeOf _x;
-            (_type find "Bush" > -1 || _type find "Reed" > -1)
-        };
-
-        if ((count _bushes) >= _minBushes) then {
-            _swamps pushBack _pos;
+        if ([_pos] call VIC_fnc_isWaterPosition) then {
+            private _depth = abs (getTerrainHeightASL _pos);
+            if (_depth <= _maxDepth) then {
+                private _veg = nearestTerrainObjects [_pos, ["BUSH","REED","SMALL TREE","TREE"], _radius, false];
+                if ((count _veg) >= _minVeg) then {
+                    _swamps pushBack _pos;
+                };
+            };
         };
     };
 };


### PR DESCRIPTION
## Summary
- refine beach search to scan all cells for shallow water near land
- rework swamp finder to use shallow water and heavy vegetation

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684d8387fb48832fa2084cfeab13c815