### PR TITLE
Improved anomaly placement

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -176,6 +176,7 @@ class CfgFunctions
             class createField_leech{};
             class createField_trapdoor{};
             class createField_zapper{};
+            class createField_bridgeElectra{};
         };
 
         class AnomalyFindSites
@@ -193,6 +194,7 @@ class CfgFunctions
             class findSite_leech{};
             class findSite_trapdoor{};
             class findSite_zapper{};
+            class findSite_bridge{};
         };
 
         class Antistasi

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -1,0 +1,46 @@
+/*
+    Creates an electra anomaly field positioned on a bridge.
+    Params:
+        0: POSITION or OBJECT - search center
+        1: NUMBER - search radius
+        2: NUMBER - anomaly count (optional, default 5)
+    Returns: ARRAY - spawned anomalies
+*/
+params ["_center","_radius", ["_count",5], ["_site", []]];
+["fn_createField_bridgeElectra"] call VIC_fnc_debugLog;
+
+if (_site isEqualTo []) then {
+    _site = [_center,_radius] call VIC_fnc_findSite_bridge;
+    if (_site isEqualTo []) exitWith {
+        ["createField_bridgeElectra: no site"] call VIC_fnc_debugLog;
+        []
+    };
+} else {
+    [format ["createField_bridgeElectra: using site %1", _site]] call VIC_fnc_debugLog;
+};
+_site = [_site] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith {
+    ["createField_bridgeElectra: land position failed"] call VIC_fnc_debugLog;
+    []
+};
+
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+private _markerName = format ["anom_bridge_%1", diag_tickTime];
+private _marker = createMarker [_markerName, _site];
+_marker setMarkerShape "ELLIPSE";
+_marker setMarkerSize [30,30];
+_marker setMarkerColor "ColorBlue";
+_marker setMarkerText "Bridge Electra 30m";
+STALKER_anomalyMarkers pushBack _marker;
+
+private _spawned = [];
+for "_i" from 1 to _count do {
+    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
+    if (_surf isEqualTo []) then { continue };
+    private _anom = [_surf] call diwako_anomalies_main_fnc_createElectra;
+    _anom setVariable ["zoneMarker", _marker];
+    _spawned pushBack _anom;
+};
+[format ["createField_bridgeElectra spawned %1", count _spawned]] call VIC_fnc_debugLog;
+_spawned

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
@@ -1,0 +1,25 @@
+/*
+    Finds a location on or near a bridge object.
+    Params:
+        0: POSITION or OBJECT - center position
+        1: NUMBER - search radius
+    Returns: ARRAY - position or [] if none found
+*/
+params ["_center","_radius"];
+["fn_findSite_bridge"] call VIC_fnc_debugLog;
+
+private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
+
+// Cache bridge objects for performance
+private _bridges = missionNamespace getVariable ["VIC_cachedBridges", []];
+if (_bridges isEqualTo []) then {
+    _bridges = [] call VIC_fnc_findBridges;
+    missionNamespace setVariable ["VIC_cachedBridges", _bridges];
+};
+
+private _candidates = _bridges select { _posCenter distance2D _x <= _radius };
+if (_candidates isEqualTo []) exitWith { [] };
+
+private _bridge = selectRandom _candidates;
+private _pos = getPosATL _bridge;
+[_pos] call VIC_fnc_findLandPosition

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
@@ -10,7 +10,7 @@ params ["_center", "_radius"];
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
-private _sites = selectBestPlaces [_posCenter, _radius, "(1 - forest - houses)", 1, 25];
-
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_clicker"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "(meadow - houses)", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_electra"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "houses", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -9,8 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_fruitpunch"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "meadow", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-private _pos = (_sites select 0) select 0;
-if (_pos call VIC_fnc_isWaterPosition) exitWith { [] };
+
+// Pick a random land position within the search radius
+private _pos = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_pos isEqualTo []) exitWith { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_gravi"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "meadow", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_launchpad"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "(1 - forest - houses)", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_leech"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "(1 - forest - houses)", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_meatgrinder"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "forest", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_springboard"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "(hills * (1 - houses))", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_trapdoor"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "(1 - forest - houses)", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_whirligig"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "(meadow * (1 - houses - forest))", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
@@ -9,6 +9,8 @@ params ["_center","_radius"];
 ["fn_findSite_zapper"] call VIC_fnc_debugLog;
 
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
-private _sites = selectBestPlaces [_posCenter, _radius, "houses", 1, 25];
-if (_sites isEqualTo []) exitWith { [] };
-(_sites select 0) select 0
+
+// Pick a random land position within the search radius
+private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+if (_site isEqualTo []) exitWith { [] };
+_site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -42,7 +42,8 @@ private _types = [
     VIC_fnc_createField_launchpad,
     VIC_fnc_createField_leech,
     VIC_fnc_createField_trapdoor,
-    VIC_fnc_createField_zapper
+    VIC_fnc_createField_zapper,
+    VIC_fnc_createField_bridgeElectra
 ];
 
 for "_i" from 1 to _fieldCount do {
@@ -64,6 +65,7 @@ for "_i" from 1 to _fieldCount do {
         case VIC_fnc_createField_leech: {"leech"};
         case VIC_fnc_createField_trapdoor: {"trapdoor"};
         case VIC_fnc_createField_zapper: {"zapper"};
+        case VIC_fnc_createField_bridgeElectra: {"bridge"};
         default {""};
     };
     [format ["spawnAllAnomalyFields: attempting %1", _typeName]] call VIC_fnc_debugLog;


### PR DESCRIPTION
## Summary
- drop special logic in anomaly site finders and just search for land spots
- support spawning electra anomalies on bridges
- keep global markers for new bridge sites

## Testing
- `pre-commit` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_684d92058c7c832fa300a1856862b389