### PR TITLE
Fix variable in weighted building selector

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_selectWeightedBuilding.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_selectWeightedBuilding.sqf
@@ -12,8 +12,9 @@ private _options = [];
 {
     _x params ["_words","_weight",["_cond",{true}]];
     private _subset = _all select {
-        private _type = toLower (typeOf _x);
-        ({ _type find _x2 > -1 } count _words > 0) && { [_x] call _cond };
+        private _building = _x;
+        private _type = toLower (typeOf _building);
+        ({ _type find _x > -1 } count _words > 0) && { [_building] call _cond };
     };
     if (!(_subset isEqualTo [])) then {
         _options pushBack [_subset,_weight];


### PR DESCRIPTION
## Summary
- fix reference to undefined variable `_x2`
- clarify building variable name to avoid nested scope confusion

## Testing
- `make test` *(fails: No rule to make target 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684d934b9010832fa437f16619a7efb0