### PR TITLE
Add storm radio message

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -31,6 +31,7 @@ class CfgFunctions
             class weightedPick{};
             class selectWeightedBuilding{};
             class findBridges{};
+            class radioMessage{};
         };
 
         class AI

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -40,6 +40,7 @@ VIC_fnc_findHiddenPosition     = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_markHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markHiddenPosition.sqf");
 VIC_fnc_findBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBuildingCoverSpot.sqf");
 VIC_fnc_markBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markBuildingCoverSpot.sqf");
+VIC_fnc_radioMessage          = compile preprocessFileLineNumbers (_root + "\functions\core\fn_radioMessage.sqf");
 
 if (isServer) then {
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_radioMessage.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_radioMessage.sqf
@@ -1,0 +1,13 @@
+/*
+    Broadcasts a radio message to all players.
+
+    Params:
+        0: STRING - message text
+*/
+params ["_msg"];
+
+if (!hasInterface) exitWith {};
+
+player sideChat _msg;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_schedulePsyStorms.sqf
@@ -48,6 +48,7 @@ if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
         if (_var != "" && { missionNamespace getVariable [_var, false] }) then {
             missionNamespace setVariable [_var, false, true];
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
+                ["Increased psy activity has been detected. We're expecting a psystorm imminently boys."] remoteExec ["VIC_fnc_radioMessage", 0];
                 [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd, _oEnd, _oTime] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));
@@ -55,6 +56,7 @@ if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
         if (time >= _nextStorm) then {
             if (random 100 < _weight && { !(_night && daytime > 5 && daytime < 20) }) then {
+                ["Increased psy activity has been detected. We're expecting a psystorm imminently boys."] remoteExec ["VIC_fnc_radioMessage", 0];
                 [_dur, _lStart, _lEnd, _dStart, _dEnd, _fEnd, _rEnd, _oEnd, _oTime] call VIC_fnc_triggerPsyStorm;
             };
             _nextStorm = time + (_min + random (_max - _min));


### PR DESCRIPTION
## Summary
- add utility to send radio chat to all players
- register radioMessage in config and masterInit
- broadcast an alert before starting a psystorm

## Testing
- `git show --stat`


------
https://chatgpt.com/codex/tasks/task_e_684d92f80214832fb9c621ca929cf42e