### PR TITLE
Add forced weather change during PsyStorm

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -41,18 +41,18 @@ if (_stepsOvercast > 0) then {
     for "_i" from 1 to _stepsOvercast do {
         private _prog = _i / (_stepsOvercast max 1);
         private _current = _startOvercast + (_overcastEnd - _startOvercast) * _prog;
-        0 setOvercast _current;
+        0 setOvercast _current; forceWeatherChange;
         sleep 1;
     };
 } else {
-    0 setOvercast _overcastEnd;
+    0 setOvercast _overcastEnd; forceWeatherChange;
 };
 
 if (count allPlayers == 0) exitWith {};
 
 private _ticks = floor _duration;
 for "_i" from 1 to _ticks do {
-    0 setOvercast _overcastEnd;
+    0 setOvercast _overcastEnd; forceWeatherChange;
     private _progress = (_i - 1) / (_ticks max 1);
     private _currentLightning = round (_lightningStart + (_lightningEnd - _lightningStart) * _progress);
     private _currentDischarge = round (_dischargeStart + (_dischargeEnd - _dischargeStart) * _progress);
@@ -102,9 +102,9 @@ if (_stepsOvercast > 0) then {
     for "_i" from 1 to _stepsOvercast do {
         private _prog = _i / (_stepsOvercast max 1);
         private _current = _overcastEnd + (_startOvercast - _overcastEnd) * _prog;
-        0 setOvercast _current;
+        0 setOvercast _current; forceWeatherChange;
         sleep 1;
     };
 };
-0 setOvercast _startOvercast;
+0 setOvercast _startOvercast; forceWeatherChange;
 


### PR DESCRIPTION
## Summary
- ensure immediate overcast application by forcing weather change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d93ad2b2c832f94d69c50a9439bde