### PR TITLE
Simplify anomaly spawn logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Relies on **Diwako’s Anomalies** for the core anomaly logic.
 * Map markers are removed automatically when their anomaly field expires after
   `STALKER_AnomalyFieldDuration` minutes.
-* Fields are distributed randomly across the entire map.
+* Fields are distributed randomly across the entire map but avoid towns by 500 meters.
 * Fields can be **Permanent** or **Temporary**. Permanent fields remain in place
   and only reshuffle their anomalies during an emission. Temporary fields are
   deleted after an emission and respawn at new random positions. The ratio of

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
@@ -22,4 +22,4 @@ if (_candidates isEqualTo []) exitWith { [] };
 
 private _bridge = selectRandom _candidates;
 private _pos = getPosATL _bridge;
-[_pos] call VIC_fnc_findLandPosition
+[_pos, 0, 10, true] call VIC_fnc_findLandPosition

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
@@ -11,6 +11,6 @@ params ["_center", "_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _pos = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _pos = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_pos isEqualTo []) exitWith { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, true] call VIC_fnc_findLandPosition;
 if (_site isEqualTo []) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -71,48 +71,6 @@ for "_i" from 1 to _fieldCount do {
     [format ["spawnAllAnomalyFields: attempting %1", _typeName]] call VIC_fnc_debugLog;
     private _permanent = if (_type == -1) then { (random 100) < _permChance } else { _type == 1 };
     private _site = [];
-    if (_permanent && {random 100 < 70}) then {
-        private _cats = switch (_fn) do {
-            case VIC_fnc_createField_electra: {
-                [
-                    [["transform","highvoltage","turbine","solar","power","pole"],5],
-                    [["unfinished","construction"],1]
-                ]
-            };
-            case VIC_fnc_createField_fruitpunch: {
-                [
-                    [["pier","dock","wood","slum","shed","reservoir"],4],
-                    [["unfinished","construction"],1]
-                ]
-            };
-            case VIC_fnc_createField_gravi: {
-                [
-                    [["stone","castle","fort","rock"],4],
-                    [["unfinished","construction"],1]
-                ]
-            };
-            case VIC_fnc_createField_clicker: {
-                [
-                    [[""],4,{ params ["_b"]; (nearestLocations [getPosATL _b,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }],
-                    [["unfinished","construction"],1]
-                ]
-            };
-            case VIC_fnc_createField_leech: {
-                [
-                    [["chapel","church","grave","cemetery"],5],
-                    [["unfinished","construction"],1]
-                ]
-            };
-            default { [] };
-        };
-        if !(_cats isEqualTo []) then {
-            private _b = [_cats] call VIC_fnc_selectWeightedBuilding;
-            if (!isNull _b) then { _site = getPosATL _b; };
-        };
-    };
-    if (!(_site isEqualTo [])) then {
-        [format ["spawnAllAnomalyFields: using site %1", _site]] call VIC_fnc_debugLog;
-    };
     private _spawned = if (_site isEqualTo []) then { [_center, _radius] call _fn } else { [_center, _radius, nil, _site] call _fn };
     if (_spawned isEqualTo []) then {
         [format ["spawnAllAnomalyFields: %1 failed", _typeName]] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -7,7 +7,7 @@
     Returns:
         ARRAY - land position or [] if none found
 */
-params ["_center", ["_radius",50], ["_attempts",10]];
+params ["_center", ["_radius",50], ["_attempts",10], ["_excludeTowns", false]];
 
 // fail fast on invalid input
 if (_center isEqualTo [] && { !(_center isEqualType objNull) }) exitWith { [] };
@@ -27,7 +27,10 @@ for "_i" from 0 to _attempts do {
     };
 
     private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
-    if (!(_surf isEqualTo [])) exitWith { ASLToAGL _surf };
+    if (!(_surf isEqualTo [])) then {
+        private _pos = ASLToAGL _surf;
+        if (!_excludeTowns || { (nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { _pos };
+    };
 };
 
 // if nothing found, try a wider search once
@@ -37,6 +40,9 @@ if (_attempts < 20) then { _attempts = _attempts + 5 };
 for "_i" from 0 to _attempts do {
     private _candidate = [_base, random _radius, random 360] call BIS_fnc_relPos;
     private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
-    if (!(_surf isEqualTo [])) exitWith { ASLToAGL _surf };
+    if (!(_surf isEqualTo [])) then {
+        private _pos = ASLToAGL _surf;
+        if (!_excludeTowns || { (nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { _pos };
+    };
 };
 []


### PR DESCRIPTION
## Summary
- randomize anomaly field placement using a helper that avoids nearby towns
- drop building-weighted placement logic
- document 500 m town exclusion for anomaly fields

## Testing
- `find . -name '*test*' -maxdepth 2`

------
https://chatgpt.com/codex/tasks/task_e_684d96e6c4b0832f8da8844d081b6eab