### PR TITLE
Improve swamp detection logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Habitat updates run on their own timer via `VSA_habitatCheckInterval`.
 * Habitat and herd counts update immediately when mutants are killed.
 * Habitat placement now selects random buildings, forests and swamps with weighted preferences.
+* Swamp detection scans neighbouring grid cells for shallow water so habitats reliably appear in marshy areas.
   Locations are offset slightly each mission so nests appear in different spots every time.
 * Habitats will never overlap one another so each territory is distinct.
 * CBA settings allow mission makers to customize these behaviors.

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
@@ -21,13 +21,33 @@ private _swamps = [];
 for "_x" from 0 to worldSize step _step do {
     for "_y" from 0 to worldSize step _step do {
         private _pos = [_x, _y, 0];
+
+        private _waterNearby = false;
+        private _depthOk = false;
+
+        // Check the current grid position first
         if ([_pos] call VIC_fnc_isWaterPosition) then {
-            private _depth = abs (getTerrainHeightASL _pos);
-            if (_depth <= _maxDepth) then {
-                private _veg = nearestTerrainObjects [_pos, ["BUSH","REED","SMALL TREE","TREE"], _radius, false];
-                if ((count _veg) >= _minVeg) then {
-                    _swamps pushBack _pos;
+            _waterNearby = true;
+            if ((abs (getTerrainHeightASL _pos)) <= _maxDepth) then {
+                _depthOk = true;
+            };
+        } else {
+            // Sample neighboring grid positions for water
+            {
+                private _test = [_pos, _step / 2, _xDir] call BIS_fnc_relPos;
+                if ([_test] call VIC_fnc_isWaterPosition) exitWith {
+                    _waterNearby = true;
+                    if ((abs (getTerrainHeightASL _test)) <= _maxDepth) then {
+                        _depthOk = true;
+                    };
                 };
+            } forEach [0,45,90,135,180,225,270,315];
+        };
+
+        if (_waterNearby && _depthOk) then {
+            private _veg = nearestTerrainObjects [_pos, ["BUSH","REED","SMALL TREE","TREE"], _radius, false];
+            if ((count _veg) >= _minVeg) then {
+                _swamps pushBack _pos;
             };
         };
     };


### PR DESCRIPTION
## Summary
- sample neighbouring grid cells when scanning for swamps
- mention improved swamp detection in the documentation

## Testing
- `pre-commit` *(fails: no config)*

------
https://chatgpt.com/codex/tasks/task_e_684d9da243dc832f929f48058acaf15d