### PR TITLE
Spawn camps at building clusters

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamps.sqf
@@ -5,7 +5,7 @@
         1: NUMBER   - search radius (default 500)
         2: NUMBER   - camp count (optional)
 */
-params ["_center", ["_radius",500], ["_count",-1]];
+params [["_center", [worldSize/2, worldSize/2, 0]], ["_radius",500], ["_count",-1]];
 
 ["spawnStalkerCamps"] call VIC_fnc_debugLog;
 
@@ -15,9 +15,22 @@ if (["VSA_enableStalkerCamps", true] call VIC_fnc_getSetting isEqualTo false) ex
 
 if (_count < 0) then { _count = ["VSA_stalkerCampCount",1] call VIC_fnc_getSetting; };
 
+private _clusters = [] call VIC_fnc_findBuildingClusters;
+if (_clusters isEqualTo []) exitWith {};
+
 for "_i" from 1 to _count do {
-    private _pos = _center getPos [random _radius, random 360];
-    _pos = [_pos] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue };
-    [_pos] call VIC_fnc_spawnStalkerCamp;
+    private _campPos = [];
+    private _attempts = 0;
+    while {_campPos isEqualTo [] && {_attempts < 20}} do {
+        private _cluster = selectRandom _clusters;
+        private _centerPos = [0,0,0];
+        { _centerPos = _centerPos vectorAdd getPosATL _x } forEach _cluster;
+        _centerPos = _centerPos vectorMultiply (1 / (count _cluster));
+        if (_center distance2D _centerPos <= _radius) then {
+            _campPos = [_centerPos, 30, 10, true] call VIC_fnc_findLandPosition;
+        };
+        _attempts = _attempts + 1;
+    };
+    if (_campPos isEqualTo []) then { continue };
+    [_campPos] call VIC_fnc_spawnStalkerCamp;
 };


### PR DESCRIPTION
## Summary
- improve stalker camp placement logic
- pick camping spots using building clusters located away from towns

## Testing
- `echo "No tests present"`


------
https://chatgpt.com/codex/tasks/task_e_684d9723a488832fa6df24d40870e3a6