### PR TITLE
Add SQF syntax checker to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: sqflint
+    name: SQF syntax check
+    entry: ./scripts/sqflint-hook.sh
+    language: script
+    files: \.sqf$

--- a/scripts/sqflint-hook.sh
+++ b/scripts/sqflint-hook.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+failed=0
+for file in "$@"; do
+  if ! sqflint -e w "$file"; then
+    failed=1
+  fi
+done
+exit $failed


### PR DESCRIPTION
## Summary
- run SQFLint on `.sqf` files via pre-commit
- add helper script to invoke SQFLint per file

## Testing
- `pre-commit run --files $(git ls-files '*.sqf' | head -n 5)`

------
https://chatgpt.com/codex/tasks/task_e_684da03c689c832fbdc5c0091896468c