### PR TITLE
Fix anomaly markers not visible on clients

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -26,11 +26,8 @@ if (_site isEqualTo []) exitWith {
 
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_bridge_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, "Bridge Electra 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-_marker setMarkerColor "ColorBlue";
-_marker setMarkerText "Bridge Electra 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -28,11 +28,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_burner_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorOrange", 1, "Burner 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-_marker setMarkerColor "ColorOrange";
-_marker setMarkerText "Burner 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_clicker_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorPink", 1, "Clicker 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Clicker fields get a pink marker
-_marker setMarkerColor "ColorPink";
-_marker setMarkerText "Clicker 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_electra_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, "Electra 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Use blue for electra fields
-_marker setMarkerColor "ColorBlue";
-_marker setMarkerText "Electra 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_fruitpunch_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, "Fruitpunch 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Use green to distinguish fruit punch fields
-_marker setMarkerColor "ColorGreen";
-_marker setMarkerText "Fruitpunch 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_gravi_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBrown", 1, "Gravi 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Brown marker helps identify gravi fields
-_marker setMarkerColor "ColorBrown";
-_marker setMarkerText "Gravi 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -27,11 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_launchpad_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorYellow", 1, "Launchpad 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-_marker setMarkerColor "ColorYellow";
-_marker setMarkerText "Launchpad 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -27,11 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_leech_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlack", 1, "Leech 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-_marker setMarkerColor "ColorBlack";
-_marker setMarkerText "Leech 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_meatgrinder_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorRed", 1, "Meatgrinder 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Meatgrinder zones use a red marker
-_marker setMarkerColor "ColorRed";
-_marker setMarkerText "Meatgrinder 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_springboard_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorKhaki", 1, "Springboard 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Springboard markers use khaki for visibility
-_marker setMarkerColor "ColorKhaki";
-_marker setMarkerText "Springboard 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_trapdoor_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
-    _marker setMarkerSize [30,30];
-    // Replace dark green with standard green for clarity
-    _marker setMarkerColor "ColorGreen";
-_marker setMarkerText "Trapdoor 30m";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, "Trapdoor 30m"] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [30,30];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -27,12 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_whirligig_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorWhite", 1, "Whirligig 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-// Whirligig fields are marked with white
-_marker setMarkerColor "ColorWhite";
-_marker setMarkerText "Whirligig 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -27,11 +27,8 @@ if (_site isEqualTo []) exitWith {
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_zapper_%1", diag_tickTime];
-private _marker = createMarker [_markerName, _site];
-_marker setMarkerShape "ELLIPSE";
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorEAST", 1, "Zapper 30m"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [30,30];
-_marker setMarkerColor "ColorEAST";
-_marker setMarkerText "Zapper 30m";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];


### PR DESCRIPTION
## Summary
- create anomaly markers using `VIC_fnc_createGlobalMarker`
- ensure marker size set after creation

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684dbdbcbfe0832f9c7c6f46d7640606