### PR TITLE
Fix building cluster search

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
@@ -19,8 +19,8 @@ private _clusters = [];
 // Include all relevant town location types
 private _locations = nearestLocations [
     [worldSize / 2, worldSize / 2, 0],
-    worldSize,
-    ["NameVillage", "NameCity", "NameCityCapital", "NameLocal"]
+    ["NameVillage", "NameCity", "NameCityCapital", "NameLocal"],
+    worldSize
 ];
 
 for "_px" from 0 to worldSize step _step do {


### PR DESCRIPTION
## Summary
- fix call to `nearestLocations` so types array is passed correctly

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684dc463cc78832f85d04514998fc86b