### PR TITLE
Fix minefield spawn event

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -60,3 +60,7 @@ for "_i" from 1 to _iedCount do {
     STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
 };
 
+if !(missionNamespace getVariable ["VIC_minefieldManagerRunning", false]) then {
+    [] call VIC_fnc_startMinefieldManager;
+};
+


### PR DESCRIPTION
## Summary
- automatically start the minefield manager when spawning minefields

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dc48e48ec832f96d7cfc18bb2e1a6