### PR TITLE
Implement zombie conversion after emissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 ### Zombification
 * Tracks dead units and may reanimate them as zombies after a delay.
 * Integrates with **WebKnight’s Zombies & Demons** to handle the zombies themselves.
+* Units that die while an emission is active will reanimate as zombies when the
+  storm ends.
 
 ## Anomaly Types
 Each anomaly behaves differently and creates unique hazards:

--- a/addons/Viceroys-STALKER-ALife/functions/zombification/fn_onEmissionEnd.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/zombification/fn_onEmissionEnd.sqf
@@ -5,4 +5,6 @@
 
 ["zombification_onEmissionEnd"] call VIC_fnc_debugLog;
 
+[] call VIC_fnc_spawnZombiesFromQueue;
+
 true


### PR DESCRIPTION
## Summary
- spawn zombies from queued corpses when an emission ends
- document that emission deaths become zombies

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/zombification/fn_onEmissionEnd.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684dc5bec384832fb0d580e4cfa71af5