### PR TITLE
Add booby trap debug action

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way. Use the new actions to start the minefield and ambush managers when testing.
 * Abandoned and damaged vehicles may appear on or near roads.
+* Tripwires and booby traps can spawn inside buildings around towns.
 * Fallen players leave a red X marker that vanishes once the body is removed.
 
 ### Spooks
@@ -174,7 +175,7 @@ spawns at night, during the day or both.
 4. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    This option can now be toggled while a mission is running and the debug
    actions will appear automatically.
-5. When debug mode is active, your scroll menu includes options to trigger storms, spawn permanent or temporary anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Permanent fields will show a randomly generated name on their marker for easy reference.
+5. When debug mode is active, your scroll menu includes options to trigger storms, spawn permanent or temporary anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Permanent fields will show a randomly generated name on their marker for easy reference.
 6. Use the **Mark All Buildings** action from this menu if you need to visualize every building. Buildings are no longer marked automatically when debug mode is enabled.
 
 If your mission reports undefined CBA settings, ensure that **CBA A3** is loaded and initialized before this mod. Settings now fall back to defaults via `VIC_fnc_getSetting` when CBA has not yet finished loading.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -656,6 +656,22 @@ true
     [0, 20, 2, 0]
 ] call CBA_fnc_addSetting;
 
+[
+    "VSA_enableBoobyTraps",
+    "CHECKBOX",
+    ["Enable Booby Traps", "Place tripwires and booby traps in buildings"],
+    "Viceroy's STALKER ALife - Minefields",
+    true
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_boobyTrapCount",
+    "SLIDER",
+    ["Booby Traps per Area", "Number of building traps spawned"],
+    "Viceroy's STALKER ALife - Minefields",
+    [0, 20, 5, 0]
+] call CBA_fnc_addSetting;
+
 // -----------------------------------------------------------------------------
 // Wrecks
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -112,6 +112,7 @@ class CfgFunctions
             class spawnMinefields{};
             class spawnAPERSField{};
             class spawnIED{};
+            class spawnBoobyTraps{};
             class manageMinefields{};
             class startMinefieldManager{};
         };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -98,6 +98,7 @@ VIC_fnc_spawnMutantGroup         = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_spawnMinefields        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnMinefields.sqf");
 VIC_fnc_spawnAPERSField        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnAPERSField.sqf");
 VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnIED.sqf");
+VIC_fnc_spawnBoobyTraps        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnBoobyTraps.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
 VIC_fnc_startMinefieldManager  = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_startMinefieldManager.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -66,6 +66,9 @@ player addAction ["Spawn Predator Attack", {
 player addAction ["Spawn Minefields", {
     [getPos player, 300] remoteExec ["VIC_fnc_spawnMinefields", 2];
 }];
+player addAction ["Spawn Booby Traps", {
+    [getPos player, 200] remoteExec ["VIC_fnc_spawnBoobyTraps", 2];
+}];
 player addAction ["Start Minefield Logic", {
     [] remoteExec ["VIC_fnc_startMinefieldManager", 2];
 }];

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
@@ -1,0 +1,47 @@
+/*
+    Places tripwires and booby traps inside random town buildings.
+    Params:
+        0: POSITION - center position
+        1: NUMBER   - search radius (default 500)
+        2: NUMBER   - trap count (optional)
+    Returns:
+        ARRAY - spawned trap objects
+*/
+params ["_center", ["_radius",500], ["_count",-1]];
+
+["spawnBoobyTraps"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { [] };
+
+if (["VSA_enableBoobyTraps", true] call VIC_fnc_getSetting isEqualTo false) exitWith { [] };
+
+if (_count < 0) then { _count = ["VSA_boobyTrapCount",5] call VIC_fnc_getSetting; };
+
+private _towns = nearestLocations [_center, ["NameVillage","NameCity","NameCityCapital","NameLocal"], _radius];
+if (_towns isEqualTo []) exitWith { [] };
+
+private _spawned = [];
+
+for "_i" from 1 to _count do {
+    if (_towns isEqualTo []) exitWith {};
+    private _town = selectRandom _towns;
+    private _tPos = locationPosition _town;
+    private _buildings = nearestObjects [_tPos, ["House"], 150];
+    if (_buildings isEqualTo []) then { continue; };
+
+    private _bld = selectRandom _buildings;
+    private _positions = [_bld] call BIS_fnc_buildingPositions;
+    if (_positions isEqualTo []) then { continue; };
+
+    private _pos = selectRandom _positions;
+    private _type = selectRandom ["APERSTripMine_Wire","IEDUrbanSmall_F"];
+    private _mine = createMine [_type, _pos, [], 0];
+    _spawned pushBack _mine;
+
+    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+        private _marker = format ["trap_%1", diag_tickTime + _i];
+        [_marker, _pos, "ICON", "mil_triangle", "ColorOrange", 0.2, "Trap"] call VIC_fnc_createGlobalMarker;
+    };
+};
+
+_spawned


### PR DESCRIPTION
## Summary
- add a debug action to spawn booby traps in towns
- describe the new action in README
- booby trap placement already shows debug markers for each trap

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684e1649efc0832fae480afe72529d87