### PR TITLE
Add necroplague debug action

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Integrates with **WebKnight’s Zombies & Demons** to handle the zombies themselves.
 * Units that die while an emission is active will reanimate as zombies when the
   storm ends.
+### Necroplague
+* Random event that unleashes zombie hordes from hidden positions.
+* Zombies spawn behind nearby buildings so players often hear them before they see them.
+* Controlled via CBA settings for delay and horde size.
+* Can be manually triggered from debug actions which also mark the spawn points.
+
 
 ## Anomaly Types
 Each anomaly behaves differently and creates unique hazards:

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -461,6 +461,45 @@ true
 ] call CBA_fnc_addSetting;
 
 // -----------------------------------------------------------------------------
+// Necroplague
+// -----------------------------------------------------------------------------
+[
+    "VSA_enableNecroplague",
+    "CHECKBOX",
+    ["Enable Necroplague", "Allow periodic zombie hordes"],
+    "Viceroy's STALKER ALife - Necroplague",
+    true
+] call CBA_fnc_addSetting;
+[
+    "VSA_necroMinDelay",
+    "SLIDER",
+    ["Min Delay (s)", "Minimum seconds between necroplague events"],
+    "Viceroy's STALKER ALife - Necroplague",
+    [0,7200,1800,0]
+] call CBA_fnc_addSetting;
+[
+    "VSA_necroMaxDelay",
+    "SLIDER",
+    ["Max Delay (s)", "Maximum seconds between necroplague events"],
+    "Viceroy's STALKER ALife - Necroplague",
+    [0,7200,3600,0]
+] call CBA_fnc_addSetting;
+[
+    "VSA_necroHordes",
+    "SLIDER",
+    ["Hordes per Player", "Number of zombie groups around each player"],
+    "Viceroy's STALKER ALife - Necroplague",
+    [1,5,2,0]
+] call CBA_fnc_addSetting;
+[
+    "VSA_necroZombies",
+    "SLIDER",
+    ["Zombies per Horde", "Zombies spawned in each group"],
+    "Viceroy's STALKER ALife - Necroplague",
+    [1,20,5,0]
+] call CBA_fnc_addSetting;
+
+// -----------------------------------------------------------------------------
 // AI Behaviour
 // -----------------------------------------------------------------------------
 [

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -150,6 +150,12 @@ class CfgFunctions
             class trackDeadForZombify{};
             class onEmissionEnd{};
         };
+        class Necroplague
+        {
+            file = "Viceroys-STALKER-ALife\functions\necroplague";
+            class triggerNecroplague{};
+            class scheduleNecroplague{};
+        };
 
         class Anomalies
         {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -91,6 +91,8 @@ VIC_fnc_schedulePsyStorms        = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_triggerPsyStorm          = compile preprocessFileLineNumbers (_root + "\functions\storms\fn_triggerPsyStorm.sqf");
 VIC_fnc_scheduleBlowouts         = compile preprocessFileLineNumbers (_root + "\functions\blowouts\fn_scheduleBlowouts.sqf");
 VIC_fnc_triggerBlowout           = compile preprocessFileLineNumbers (_root + "\functions\blowouts\fn_triggerBlowout.sqf");
+VIC_fnc_triggerNecroplague  = compile preprocessFileLineNumbers (_root + "\functions\necroplague\fn_triggerNecroplague.sqf");
+VIC_fnc_scheduleNecroplague = compile preprocessFileLineNumbers (_root + "\functions\necroplague\fn_scheduleNecroplague.sqf");
 VIC_fnc_placeTownSirens          = compile preprocessFileLineNumbers (_root + "\functions\blowouts\fn_placeTownSirens.sqf");
 VIC_fnc_setupSpookZones          = compile preprocessFileLineNumbers (_root + "\functions\spooks\fn_setupSpookZones.sqf");
 VIC_fnc_spawnSpookZone           = compile preprocessFileLineNumbers (_root + "\functions\spooks\fn_spawnSpookZone.sqf");
@@ -169,6 +171,7 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
     [] call VIC_fnc_registerEmissionHooks;
     [] call VIC_fnc_schedulePsyStorms;
     [] call VIC_fnc_scheduleBlowouts;
+    [] call VIC_fnc_scheduleNecroplague;
     [] call VIC_fnc_placeTownSirens;
     [] call VIC_fnc_setupAnomalyFields;
     [] call VIC_fnc_setupMutantHabitats;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -51,6 +51,11 @@ player addAction ["Spawn Spook Zone", {
 player addAction ["Spawn Zombies From Queue", {
     [] remoteExec ["VIC_fnc_spawnZombiesFromQueue", 2];
 }];
+player addAction ["Trigger Necroplague", {
+    private _z = ["VSA_necroZombies",5] call VIC_fnc_getSetting;
+    private _h = ["VSA_necroHordes",2] call VIC_fnc_getSetting;
+    [_z, _h, true] remoteExec ["VIC_fnc_triggerNecroplague", 2];
+}];
 player addAction ["Spawn Ambient Herds", {
     [] remoteExec ["VIC_fnc_spawnAmbientHerds", 2];
 }];

--- a/addons/Viceroys-STALKER-ALife/functions/necroplague/fn_scheduleNecroplague.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/necroplague/fn_scheduleNecroplague.sqf
@@ -1,0 +1,30 @@
+/*
+    Periodically triggers necroplague attacks.
+
+    Params:
+        0: NUMBER - minimum delay between attacks in seconds (default 1800)
+        1: NUMBER - maximum delay between attacks in seconds (default 3600)
+*/
+params [["_minDelay",1800],["_maxDelay",3600]];
+
+["scheduleNecroplague"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (["VSA_enableNecroplague", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+
+_minDelay = ["VSA_necroMinDelay", _minDelay] call VIC_fnc_getSetting;
+_maxDelay = ["VSA_necroMaxDelay", _maxDelay] call VIC_fnc_getSetting;
+private _zPerHorde = ["VSA_necroZombies",5] call VIC_fnc_getSetting;
+private _hordeCount = ["VSA_necroHordes",2] call VIC_fnc_getSetting;
+
+[_minDelay,_maxDelay,_zPerHorde,_hordeCount] spawn {
+    params ["_min","_max","_z","_count"];
+    private _next = time + (_min + random (_max - _min));
+    while {true} do {
+        if (time >= _next) then {
+            [_z,_count] call VIC_fnc_triggerNecroplague;
+            _next = time + (_min + random (_max - _min));
+        };
+        sleep 10;
+    };
+};

--- a/addons/Viceroys-STALKER-ALife/functions/necroplague/fn_triggerNecroplague.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/necroplague/fn_triggerNecroplague.sqf
@@ -1,0 +1,45 @@
+/*
+    Spawns zombie hordes around each player from hidden positions.
+
+    Params:
+        0: NUMBER - zombies per horde (default 5)
+        1: NUMBER - horde count per player (default 2)
+        2: BOOL   - mark spawn positions when true (default false)
+*/
+params [["_zombies",5],["_hordes",2],["_mark",false]];
+
+["triggerNecroplague"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (["VSA_enableNecroplague", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+
+private _classes = ["WBK_Zombie1","WBK_Zombie2","WBK_Zombie3"];
+
+{
+    private _player = _x;
+    if (isNull _player || {!alive _player}) then { continue };
+
+    for "_h" from 1 to _hordes do {
+        private _pos = [_player,50,5] call VIC_fnc_findBuildingCoverSpot;
+        if (isNil "_pos") then { _pos = [_player,100,5] call VIC_fnc_findBuildingCoverSpot; };
+        if (isNil "_pos") then {
+            private _angle = random 360;
+            private _dist = 40 + random 40;
+            _pos = _player getPos [_dist, _angle];
+        };
+        _pos = [_pos] call VIC_fnc_findLandPosition;
+        if (_pos isEqualTo []) then { continue };
+        if (_mark) then {
+            private _markerName = format ["necro_%1", diag_tickTime + random 1000];
+            [_markerName, _pos, "ICON", "mil_dot", "ColorRed", 1, "Necro Spawn"] call VIC_fnc_createGlobalMarker;
+        };
+        private _grp = createGroup east;
+        for "_i" from 1 to _zombies do {
+            private _unit = _grp createUnit [selectRandom _classes, _pos, [], 0, "FORM"];
+            [_unit] call VIC_fnc_initMutantUnit;
+        };
+        [_grp, _player] call BIS_fnc_taskAttack;
+    };
+} forEach allPlayers;
+
+true


### PR DESCRIPTION
## Summary
- mark zombie spawn points in `triggerNecroplague` when requested
- allow manual necroplague event via debug actions
- document new debug option in README

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf addons/Viceroys-STALKER-ALife/functions/necroplague/fn_triggerNecroplague.sqf`


------
https://chatgpt.com/codex/tasks/task_e_684e19d7970c832f9dcbe9386d2d3122