### PR TITLE
Disable sleep/wake proximity check

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
@@ -1,21 +1,8 @@
 /*
     Returns true if any player is within a given radius of a position.
 
-    Params:
-        0: POSITION - position to check
-        1: NUMBER   - radius in meters (defaults to VSA_playerNearbyRange)
-
-    Returns:
-        BOOL - true when a player is nearby
+    This check is temporarily disabled so all systems remain active
+    regardless of player proximity.
 */
-private _default = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
-params [
-    ["_pos", [0,0,0]],
-    ["_radius", _default]
-];
 
-private _near = false;
-{
-    if (_x distance _pos <= _radius) exitWith { _near = true };
-} forEach allPlayers;
-_near
+true


### PR DESCRIPTION
## Summary
- keep all systems active by returning `true` from `fn_hasPlayersNearby`

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684e1e287010832fb10f51c8632f3924