### PR TITLE
Improve land search for zone placement

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
@@ -26,7 +26,10 @@ for "_i" from 1 to _count do {
     private _centerPos = if (_center isEqualType objNull) then { getPos _center } else { _center };
     private _ang = random 360;
     private _dist = random _radius;
-    private _pos = [(_centerPos select 0) + _dist * sin _ang, (_centerPos select 1) + _dist * cos _ang, _centerPos select 2];
-    [_pos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
+    private _base = [(_centerPos select 0) + _dist * sin _ang, (_centerPos select 1) + _dist * cos _ang, _centerPos select 2];
+    private _pos = [_base] call VIC_fnc_findLandPosition;
+    if !(_pos isEqualTo []) then {
+        [_pos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
+    };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
@@ -36,7 +36,10 @@ for "_i" from 1 to _count do {
         private _offAng = random 360;
         private _offDist = random (_zoneRadius / 2);
         private _zonePos = [(_pos select 0) + _offDist * sin _offAng, (_pos select 1) + _offDist * cos _offAng, _pos select 2];
-        [_zonePos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
+        _zonePos = [_zonePos] call VIC_fnc_findLandPosition;
+        if !(_zonePos isEqualTo []) then {
+            [_zonePos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
+        };
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -45,4 +45,14 @@ for "_i" from 0 to _attempts do {
         if (!_excludeTowns || { (nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { _pos };
     };
 };
+
+// final attempt using BIS_fnc_findSafePos to avoid infinite failures
+private _safePos = [_base, 0, _radius max 50, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+if (_safePos isEqualType [] && {!(_safePos isEqualTo [0,0,0])}) then {
+    private _surf = [_safePos] call VIC_fnc_getLandSurfacePosition;
+    if (!(_surf isEqualTo [])) then {
+        private _pos = ASLToAGL _surf;
+        if (!_excludeTowns || {(nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo []}) exitWith { _pos };
+    };
+};
 []


### PR DESCRIPTION
## Summary
- make `findLandPosition` fallback to `BIS_fnc_findSafePos`
- ensure random chemical zones use land positions
- ensure valley chemical zones verify land before spawning

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684e209ba08c832fafad14321eb6240a