### PR TITLE
Spawn habitats empty and grow

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Defines territory areas via **fn_setupMutantHabitats.sqf**.
 * Each habitat now uses an ellipse marker to show its bounds and a labeled icon displaying the current population (e.g. `Bloodsucker Habitat: 4/12`).
 * Systems rely on **fn_hasPlayersNearby.sqf** so habitats sleep and despawn when players are farther than the configured nearby range (default 1500m).
-* Population counts persist while sleeping and gradually replenish between spawn cycles.
+* Habitats now spawn empty and gain one mutant each habitat cycle when no players are nearby.
 * Player proximity is checked on a separate timer via `VSA_proximityCheckInterval`.
 * Habitat updates run on their own timer via `VSA_habitatCheckInterval`.
 * Habitat and herd counts update immediately when mutants are killed.

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -31,7 +31,6 @@ private _getClass = {
     };
 };
 
-private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
 
 {
 
@@ -66,7 +65,7 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
             _grp = grpNull;
         };
 
-        if (_count < _max && { random 100 < _chance }) then {
+        if (_count < _max) then {
             _count = _count + 1;
             if (_count > _max) then { _count = _max; };
         };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -53,8 +53,8 @@ private _createMarker = {
         default {10};
     };
 
-    _label setMarkerText format ["%1 Habitat: %2/%2", _type, _max];
-    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, _max, false];
+    _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
+    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
 };
 
 private _weightedPick = {


### PR DESCRIPTION
## Summary
- spawn mutant habitats with zero population
- increment habitat population by one each cycle
- document new behaviour in README

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf README.md` *(fails: SQF syntax check warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684e24655770832f9935dc0484c0ef8d