### PR TITLE
Fix debug markers not visible to clients

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -37,11 +37,8 @@ for "_i" from 1 to _count do {
 
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        _marker = createMarker [format ["amb_%1", diag_tickTime + _i], _pos];
-        _marker setMarkerShape "ICON";
-        _marker setMarkerType "mil_triangle";
-        _marker setMarkerColor "ColorBlack";
-        _marker setMarkerAlpha 0.2;
+        _marker = format ["amb_%1", diag_tickTime + _i];
+        [_marker, _pos, "ICON", "mil_triangle", "ColorBlack", 0.2, "Ambush"] call VIC_fnc_createGlobalMarker;
     };
 
     STALKER_ambushes pushBack [_pos, objNull, [], [], false, _marker];

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -60,11 +60,9 @@ private _agl = ASLToAGL _position;
 // Create and configure a map marker for this chemical zone
 private _markerName = format ["chem_%1", diag_tickTime];
 private _atl = ASLToATL (AGLToASL _agl);
-private _marker = createMarker [_markerName, _atl];
-_marker setMarkerShape "ELLIPSE";
-_marker setMarkerSize [_radius, _radius];
-_marker setMarkerColor "ColorGreen";
-_marker setMarkerText format ["Chemical %1m", _radius];
+private _marker = _markerName;
+[_marker, _atl, "ELLIPSE", "", "ColorGreen", 1, format ["Chemical %1m", _radius]] call VIC_fnc_createGlobalMarker;
+[_marker, [_radius, _radius]] remoteExec ["setMarkerSize", 0];
 
 // Record the zone and when it should be removed
 private _expires = -1;

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -31,12 +31,9 @@ for "_i" from 1 to _fieldCount do {
     if (!(_pos isEqualTo [])) then {
         private _marker = "";
         if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-            _marker = createMarker [format ["mf_%1", diag_tickTime], _pos];
-            _marker setMarkerShape "RECTANGLE";
-            _marker setMarkerSize [_size/2,_size/2];
-            _marker setMarkerColor "ColorYellow";
-            _marker setMarkerText "APERS Field";
-            _marker setMarkerAlpha 0.2;
+            _marker = format ["mf_%1", diag_tickTime];
+            [_marker, _pos, "RECTANGLE", "", "ColorYellow", 0.2, "APERS Field"] call VIC_fnc_createGlobalMarker;
+            [_marker, [_size/2,_size/2]] remoteExec ["setMarkerSize", 0];
         };
         STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker];
     };
@@ -50,12 +47,8 @@ for "_i" from 1 to _iedCount do {
     if (isNil "_pos") then { continue; };
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        _marker = createMarker [format ["ied_%1", diag_tickTime], _pos];
-        _marker setMarkerShape "ICON";
-        _marker setMarkerType "mil_triangle";
-        _marker setMarkerColor "ColorRed";
-        _marker setMarkerText "IED";
-        _marker setMarkerAlpha 0.2;
+        _marker = format ["ied_%1", diag_tickTime];
+        [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.2, "IED"] call VIC_fnc_createGlobalMarker;
     };
     STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
 };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -25,16 +25,12 @@ private _createMarker = {
     if (_overlap) exitWith { false };
     private _base = format ["hab_%1_%2", toLower _type, diag_tickTime + random 1000];
 
-    private _area = createMarker [_base + "_area", _pos];
-    _area setMarkerShape "ELLIPSE";
-    _area setMarkerColor "ColorGreen";
-    _area setMarkerSize [150,150];
-    _area setMarkerText format ["%1 Habitat Area", _type];
+    private _area = _base + "_area";
+    [_area, _pos, "ELLIPSE", "", "ColorGreen", 1, format ["%1 Habitat Area", _type]] call VIC_fnc_createGlobalMarker;
+    [_area, [150,150]] remoteExec ["setMarkerSize", 0];
 
-    private _label = createMarker [_base + "_label", _pos];
-    _label setMarkerShape "ICON";
-    _label setMarkerType "mil_dot";
-    _label setMarkerColor "ColorGreen";
+    private _label = _base + "_label";
+    [_label, _pos, "ICON", "mil_dot", "ColorGreen", 1] call VIC_fnc_createGlobalMarker;
     private _max = switch (_type) do {
         case "Bloodsucker": { ["VSA_habitatSize_Bloodsucker",12] call VIC_fnc_getSetting };
         case "Blind Dog": { ["VSA_habitatSize_Dog",50] call VIC_fnc_getSetting };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf
@@ -38,11 +38,8 @@ for "_i" from 1 to _herdCount do {
     _leader addEventHandler ["Killed", { [_this#0] call VIC_fnc_onMutantKilled }];
     [_grp, _pos] call BIS_fnc_taskPatrol;
     private _markerName = format ["herd_%1_%2", count STALKER_activeHerds, diag_tickTime];
-    private _marker = createMarker [_markerName, _pos];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_dot";
-    _marker setMarkerColor "ColorOrange";
-    _marker setMarkerAlpha 0.2;
+    private _marker = _markerName;
+    [_marker, _pos, "ICON", "mil_dot", "ColorOrange", 0.2] call VIC_fnc_createGlobalMarker;
 
     STALKER_activeHerds pushBack [_leader, _grp, _herdSize, _herdSize, false, _marker];
-}; 
+};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf
@@ -41,11 +41,8 @@ for "_i" from 1 to _groupCount do {
     };
     [_grp, _spawnPos] call BIS_fnc_taskPatrol;
     private _markerName = format ["hostile_%1_%2", _i, diag_tickTime];
-    private _marker = createMarker [_markerName, _spawnPos];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_dot";
-    _marker setMarkerColor "ColorOrange";
-    _marker setMarkerAlpha 1;
+    private _marker = _markerName;
+    [_marker, _spawnPos, "ICON", "mil_dot", "ColorOrange", 1] call VIC_fnc_createGlobalMarker;
     STALKER_activeHostiles pushBack [_grp, "hostile", _spawnPos, _marker, true];
-};
+}; 
 

--- a/addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf
@@ -74,12 +74,9 @@ for "_i" from 1 to _count do {
     _zone setVariable ["spawnedSpooks", _spawned];
 
     private _markerName = format ["spook_%1", diag_tickTime];
-    private _marker = createMarker [_markerName, _pos];
-    _marker setMarkerShape "ELLIPSE";
-    _marker setMarkerSize [25,25];
-    _marker setMarkerColor "ColorBlack";
-    private _disp = _class select [4];
-    _marker setMarkerText format ["%1 x%2", _disp, _num];
+    private _marker = _markerName;
+    [_marker, _pos, "ELLIPSE", "", "ColorBlack", 1, format ["%1 x%2", _class select [4], _num]] call VIC_fnc_createGlobalMarker;
+    [_marker, [25,25]] remoteExec ["setMarkerSize", 0];
     _zone setVariable ["zoneMarker", _marker];
     private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
 


### PR DESCRIPTION
## Summary
- ensure ambush, minefield and other debug markers are created globally
- use global markers for mutant habitats, herds, mutant groups and spook zones
- show chemical zone markers to all clients

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf addons/Viceroys-STALKER-ALife/functions/spooks/fn_spawnSpookZone.sqf >/tmp/sqflint.log && tail -n 20 /tmp/sqflint.log`

------
https://chatgpt.com/codex/tasks/task_e_684e24b5c8b4832f9fb8ec9bdd51e502