### PR TITLE
Add debug logs for anomaly naming and marker creation

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf
@@ -8,6 +8,8 @@
 */
 params ["_type", ["_pos", [0,0,0]]];
 
+[format ["generateFieldName type %1 pos %2", _type, _pos]] call VIC_fnc_debugLog;
+
 private _stalkers = [
     "Flynn","Artyom","Kolya","Strelok","Vasya","Boris","Petya","Fang","Ghost","Viktor",
     "Sidorovich","Yuri","Ivchenko","The Hermit","Kostya","Molokov","Tarkov","Zhenya","Dmitri","The Monk",
@@ -159,4 +161,6 @@ private _patterns = [
     format ["%1 of the %2", selectRandom _desc, selectRandom _places]
 ];
 
-selectRandom _patterns;
+private _name = selectRandom _patterns;
+[format ["generateFieldName result %1", _name]] call VIC_fnc_debugLog;
+_name

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
@@ -14,6 +14,8 @@
 */
 params ["_name", "_pos", ["_shape", "ICON"], ["_type", "mil_dot"], ["_color", "ColorWhite"], ["_alpha", 1], ["_text", ""]];
 
+[format ["createGlobalMarker %1 @ %2", _name, _pos]] call VIC_fnc_debugLog;
+
 if (!isServer) exitWith { _name };
 
 [_name, _pos] remoteExec ["createMarker", 0];
@@ -24,5 +26,7 @@ if (!isServer) exitWith { _name };
 if (_text != "") then {
     [_name, _text] remoteExec ["setMarkerText", 0];
 };
+
+[format ["createGlobalMarker done %1", _name]] call VIC_fnc_debugLog;
 
 _name


### PR DESCRIPTION
## Summary
- log details when generating names for anomaly fields
- log marker creation and completion steps

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684e2a2d45e4832f960e21e07bd6a999