### PR TITLE
Add necroplague mutant habitats

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,13 @@ Every mutant type can establish a nest which spawns defenders when players are n
 * **Goliath** – Massive mutant that hurls rocks and bone shards, devastating everything in its path.
 * **Smasher** – Mini-boss monster that leaps and crushes obstacles with ease.
 * **Acid Smasher** – Corrosive variant that spews acid while smashing through targets.
+* **Parasite** – Small insectoid horrors that can cause instant death.
+* **Jumper** – Mutated humans that pounce from afar.
+* **Spitter** – Hulking mutants that spit acid at range.
+* **Stalker** – Mutated canines that live in toxic clouds and swamps.
+* **Bully** – Brawny humanoid mutants.
+* **Hivemind** – Organic growths that mindcontrol and psionically attack stalkers.
+* **Zombie** – Standard undead from WebKnight's mod.
 
 ## Spooks and Other Anomalies
 Drongo’s system adds creepy events such as ghostly whispers or sudden darkening of the sky. These spook zones appear mostly at night and vanish after a short time, keeping players uneasy as they travel. When a zone spawns the mod now creates one of the DSA creature classes (currently only `DSA_Abomination`) at the location and cleans it up once the zone expires.

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -27,6 +27,13 @@ private _getClass = {
         case "Smasher": { "WBK_SpecialZombie_Smasher_3" };
         case "Acid Smasher": { "WBK_SpecialZombie_Smasher_Acid_3" };
         case "Behemoth": { "WBK_Goliaph_3" };
+        case "Parasite": { "dev_parasite_i" };
+        case "Jumper": { "def_asymhuman_stage2_i" };
+        case "Spitter": { "dev_toxmut_i" };
+        case "Stalker": { "dev_form939_i" };
+        case "Bully": { "dev_asymhuman_i" };
+        case "Hivemind": { "dev_hivemind_i" };
+        case "Zombie": { selectRandom ["WBK_Zombie1","WBK_Zombie2","WBK_Zombie3"] };
         default { "O_ALF_Mutant" };
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -46,6 +46,13 @@ private _createMarker = {
         case "Smasher": { ["VSA_habitatSize_Smasher",8] call VIC_fnc_getSetting };
         case "Acid Smasher": { ["VSA_habitatSize_AcidSmasher",8] call VIC_fnc_getSetting };
         case "Behemoth": { ["VSA_habitatSize_Behemoth",6] call VIC_fnc_getSetting };
+        case "Parasite": { ["VSA_habitatSize_Parasite",10] call VIC_fnc_getSetting };
+        case "Jumper": { ["VSA_habitatSize_Jumper",10] call VIC_fnc_getSetting };
+        case "Spitter": { ["VSA_habitatSize_Spitter",10] call VIC_fnc_getSetting };
+        case "Stalker": { ["VSA_habitatSize_Stalker",10] call VIC_fnc_getSetting };
+        case "Bully": { ["VSA_habitatSize_Bully",10] call VIC_fnc_getSetting };
+        case "Hivemind": { ["VSA_habitatSize_Hivemind",10] call VIC_fnc_getSetting };
+        case "Zombie": { ["VSA_habitatSize_Zombie",10] call VIC_fnc_getSetting };
         default {10};
     };
 
@@ -70,27 +77,32 @@ private _weightedPick = {
 private _weightsGeneric = [
     ["Bloodsucker",1],["Boar",1],["Cat",1],["Flesh",1],["Blind Dog",1],
     ["Pseudodog",1],["Snork",1],["Controller",1],["Pseudogiant",1],["Izlom",1],
-    ["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+    ["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1],
+    ["Parasite",1],["Jumper",1],["Spitter",1],["Stalker",1],["Bully",1],["Hivemind",1],["Zombie",1]
 ];
 private _weightsUrban = [
     ["Snork",3],["Blind Dog",3],["Controller",2],["Izlom",2],
     ["Pseudodog",1],["Boar",1],["Bloodsucker",1],["Flesh",1],["Pseudogiant",1],
-    ["Cat",1],["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+    ["Cat",1],["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1],
+    ["Parasite",1],["Jumper",1],["Spitter",1],["Stalker",1],["Bully",1],["Hivemind",1],["Zombie",2]
 ];
 private _weightsRural = [
     ["Boar",3],["Pseudodog",3],["Pseudogiant",2],
     ["Blind Dog",1],["Bloodsucker",1],["Flesh",1],["Cat",1],["Snork",1],
-    ["Controller",1],["Izlom",1],["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+    ["Controller",1],["Izlom",1],["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1],
+    ["Parasite",1],["Jumper",1],["Spitter",1],["Stalker",1],["Bully",1],["Hivemind",1],["Zombie",1]
 ];
 private _weightsForest = [
     ["Cat",3],["Pseudodog",2],["Boar",1],["Bloodsucker",1],["Flesh",1],
     ["Snork",1],["Controller",1],["Blind Dog",1],["Izlom",1],["Pseudogiant",1],
-    ["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1]
+    ["Corruptor",1],["Smasher",1],["Acid Smasher",1],["Behemoth",1],
+    ["Parasite",1],["Jumper",1],["Spitter",1],["Stalker",1],["Bully",1],["Hivemind",1],["Zombie",1]
 ];
 private _weightsSwamp = [
     ["Bloodsucker",3],["Flesh",3],["Acid Smasher",2],
     ["Boar",1],["Pseudodog",1],["Pseudogiant",1],["Cat",1],["Snork",1],
-    ["Controller",1],["Blind Dog",1],["Izlom",1],["Corruptor",1],["Smasher",1],["Behemoth",1]
+    ["Controller",1],["Blind Dog",1],["Izlom",1],["Corruptor",1],["Smasher",1],["Behemoth",1],
+    ["Parasite",1],["Jumper",1],["Spitter",1],["Stalker",3],["Bully",1],["Hivemind",1],["Zombie",1]
 ];
 
 private _selectType = {


### PR DESCRIPTION
## Summary
- include parasite, jumper, spitter, stalker, bully, hivemind and zombie habitats
- document the new mutants

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf` *(fails: Local variable warnings)*

------
https://chatgpt.com/codex/tasks/task_e_684e322e1a34832fa8f3cecb33c66081