### PR TITLE
Fix debug menu actions

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -171,7 +171,7 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
 // Functions compiled in this file that should be wrapped with trace logging.
 // VIC_fnc_getSetting is deliberately skipped to avoid recursive tracing.
 private _traceFunctions = [
-    "VIC_fnc_setupDebugActions", "VIC_fnc_markAllBuildings",
+    "VIC_fnc_markAllBuildings",
     "VIC_fnc_markPlayerRanges", "VIC_fnc_findRockClusters",
     "VIC_fnc_markRockClusters", "VIC_fnc_findSniperSpots",
     "VIC_fnc_markSniperSpots", "VIC_fnc_findSwamps",


### PR DESCRIPTION
## Summary
- stop tracing setupDebugActions function to avoid undefined variable errors

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684ef0b1841c832f92f4e4bc00aa8d1f