### PR TITLE
Fix missing bracket error in trace function

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_traceFunction.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_traceFunction.sqf
@@ -23,11 +23,11 @@ compileFinal format ["\
     private _data = missionNamespace getVariable ['%1', []];\n\
     private _fn = _data select 0;\n\
     private _fnName = _data select 1;\n\
-    if ([\"VSA_debugMode\", false] call VIC_fnc_getSetting) then {\n\
+    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {\n\
         [(_fnName + ' called with ' + str _args)] call VIC_fnc_debugLog;\n\
     };\n\
     private _result = _args call _fn;\n\
-    if ([\"VSA_debugMode\", false] call VIC_fnc_getSetting) then {\n\
+    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {\n\
         [(_fnName + ' returned ' + str _result)] call VIC_fnc_debugLog;\n\
     };\n\
     _result\n\


### PR DESCRIPTION
## Summary
- fix quoting in `fn_traceFunction` to avoid escaping the debug setting string

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f09f844f0832f939149d75e8871d0