### PR TITLE
Fix missing initialization for script use

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_traceFunction.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_traceFunction.sqf
@@ -25,11 +25,11 @@ compileFinal format ["\
     private _data = missionNamespace getVariable ['%1', []];\n\
     private _fn = _data select 0;\n\
     private _fnName = _data select 1;\n\
-    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {\n\
+    if ([\"VSA_debugMode\", false] call VIC_fnc_getSetting) then {\n\
         [(_fnName + ' called with ' + str _args)] call VIC_fnc_debugLog;\n\
     };\n\
     private _result = _args call _fn;\n\
-    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {\n\
+    if ([\"VSA_debugMode\", false] call VIC_fnc_getSetting) then {\n\
         [(_fnName + ' returned ' + str _result)] call VIC_fnc_debugLog;\n\
     };\n\
     _result\n\

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -4,6 +4,9 @@
 
 if (!isServer) exitWith {};
 
+// Ensure core functions are compiled when running script-only
+[] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\core\fn_masterInit.sqf";
+
 // Spook zone configuration
 STALKER_MinSpookFields = 2;      // minimum zones spawned per emission
 STALKER_MaxSpookFields = 5;      // maximum zones spawned per emission


### PR DESCRIPTION
## Summary
- call `fn_masterInit` from `initServer.sqf` so all functions exist when the mod is run as a script
- escape quotes in the tracing helper

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/initServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684f0b91ac6c832fb2ee72cce84d0561