### PR TITLE
Improve debugging and remove trace compile

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalies.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalies.sqf
@@ -8,10 +8,18 @@
 
 ["fn_avoidAnomalies"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
-if (["VSA_enableAIBehaviour", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
-if (["VSA_aiNightOnly", false] call VIC_fnc_getSetting && { daytime > 5 && daytime < 20 }) exitWith {};
-if (isNil "STALKER_anomalyFields") exitWith {};
+if (!isServer) exitWith {
+    ["fn_avoidAnomalies exit: not server"] call VIC_fnc_debugLog;
+};
+if (["VSA_enableAIBehaviour", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["fn_avoidAnomalies exit: behaviour disabled"] call VIC_fnc_debugLog;
+};
+if (["VSA_aiNightOnly", false] call VIC_fnc_getSetting && { daytime > 5 && daytime < 20 }) exitWith {
+    ["fn_avoidAnomalies exit: day time"] call VIC_fnc_debugLog;
+};
+if (isNil "STALKER_anomalyFields") exitWith {
+    ["fn_avoidAnomalies exit: no fields"] call VIC_fnc_debugLog;
+};
 
 private _chance = ["VSA_aiAnomalyAvoidChance", 50] call VIC_fnc_getSetting;
 private _range  = ["VSA_aiAnomalyAvoidRange", 20] call VIC_fnc_getSetting;
@@ -39,5 +47,7 @@ if (_anoms isEqualTo []) exitWith {};
         _unit doMove _dest;
     };
 } forEach allUnits;
+
+["fn_avoidAnomalies completed"] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf
@@ -6,19 +6,32 @@
     Parameter(s): none
 */
 
+
 ["fn_avoidAnomalyFields"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
-if (["VSA_enableAIBehaviour", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
-if !(missionNamespace getVariable ["VSA_fieldAvoidEnabled", true]) exitWith {};
-if (["VSA_aiNightOnly", false] call VIC_fnc_getSetting && { daytime > 5 && daytime < 20 }) exitWith {};
-if (isNil "STALKER_anomalyFields") exitWith {};
+if (!isServer) exitWith {
+    ["fn_avoidAnomalyFields exit: not server"] call VIC_fnc_debugLog;
+};
+if (["VSA_enableAIBehaviour", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["fn_avoidAnomalyFields exit: behaviour disabled"] call VIC_fnc_debugLog;
+};
+if !(missionNamespace getVariable ["VSA_fieldAvoidEnabled", true]) exitWith {
+    ["fn_avoidAnomalyFields exit: disabled"] call VIC_fnc_debugLog;
+};
+if (["VSA_aiNightOnly", false] call VIC_fnc_getSetting && { daytime > 5 && daytime < 20 }) exitWith {
+    ["fn_avoidAnomalyFields exit: day time"] call VIC_fnc_debugLog;
+};
+if (isNil "STALKER_anomalyFields") exitWith {
+    ["fn_avoidAnomalyFields exit: no fields"] call VIC_fnc_debugLog;
+};
 
 private _chance = ["VSA_aiAnomalyAvoidChance", 50] call VIC_fnc_getSetting;
 private _buffer = ["VSA_aiAnomalyAvoidRange", 20] call VIC_fnc_getSetting;
 
 private _fields = STALKER_anomalyFields apply { [ _x select 0, _x select 1 ] };
-if (_fields isEqualTo []) exitWith {};
+if (_fields isEqualTo []) exitWith {
+    ["fn_avoidAnomalyFields exit: no valid fields"] call VIC_fnc_debugLog;
+};
 
 {
     if (random 100 >= _chance) then { continue; };
@@ -27,18 +40,18 @@ if (_fields isEqualTo []) exitWith {};
 
     private _field = [];
     {
-        private _c = _x#0;
-        private _r = _x#1;
+        _x params ["_c","_r"];
         if (_unit distance _c < (_r + _buffer)) exitWith { _field = [_c, _r] };
     } forEach _fields;
 
     if !(_field isEqualTo []) then {
-        private _center = _field#0;
-        private _radius = _field#1;
+        _field params ["_center","_radius"];
         private _dir = _unit getDir _center;
         private _dest = [getPosATL _unit, (_radius + _buffer) * 1.2, _dir + 180] call BIS_fnc_relPos;
         _unit doMove _dest;
     };
 } forEach allUnits;
+
+["fn_avoidAnomalyFields completed"] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_toggleFieldAvoid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_toggleFieldAvoid.sqf
@@ -5,12 +5,17 @@
         Toggles AI avoidance of anomaly fields for testing.
 */
 
+
 ["fn_toggleFieldAvoid"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["fn_toggleFieldAvoid exit: not server"] call VIC_fnc_debugLog;
+};
 
 missionNamespace setVariable ["VSA_fieldAvoidEnabled", !(missionNamespace getVariable ["VSA_fieldAvoidEnabled", true]), true];
 private _state = missionNamespace getVariable ["VSA_fieldAvoidEnabled", true];
 [format ["Field avoidance %1", if (_state) then {"enabled"} else {"disabled"}]] call VIC_fnc_debugLog;
+
+["fn_toggleFieldAvoid completed"] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_placeTownSirens.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_placeTownSirens.sqf
@@ -5,10 +5,16 @@
 */
 params [["_class","Land_Siren_F"]];
 
+
 ["placeTownSirens"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
-if (["VSA_blowoutSirens", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (!isServer) exitWith {
+    ["placeTownSirens exit: not server"] call VIC_fnc_debugLog;
+};
+
+if (["VSA_blowoutSirens", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["placeTownSirens exit: disabled"] call VIC_fnc_debugLog;
+};
 
 STALKER_blowoutSirens = [];
 
@@ -18,3 +24,5 @@ private _locs = nearestLocations [[worldSize/2,worldSize/2,0],["NameVillage","Na
     private _obj = _class createVehicle _pos;
     STALKER_blowoutSirens pushBack _obj;
 } forEach _locs;
+
+["placeTownSirens completed"] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_scheduleBlowouts.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_scheduleBlowouts.sqf
@@ -3,11 +3,16 @@
     Params: None
 */
 
+
 ["scheduleBlowouts"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["scheduleBlowouts exit: not server"] call VIC_fnc_debugLog;
+};
 
-if (["VSA_enableBlowouts", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableBlowouts", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["scheduleBlowouts exit: disabled"] call VIC_fnc_debugLog;
+};
 
 private _minDelay = ["VSA_blowoutMinDelay",12] call VIC_fnc_getSetting; // hours
 private _maxDelay = ["VSA_blowoutMaxDelay",72] call VIC_fnc_getSetting; // hours
@@ -30,3 +35,5 @@ if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
         sleep 60;
     };
 };
+
+["scheduleBlowouts completed"] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_triggerBlowout.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_triggerBlowout.sqf
@@ -21,9 +21,12 @@ _dir      = ["VSA_blowoutDirection", _dir] call VIC_fnc_getSetting;
 _speedMin = ["VSA_blowoutSpeedMin", _speedMin] call VIC_fnc_getSetting;
 _speedMax = ["VSA_blowoutSpeedMax", _speedMax] call VIC_fnc_getSetting;
 
+
 ["triggerBlowout"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["triggerBlowout exit: not server"] call VIC_fnc_debugLog;
+};
 
 // ensure the TTS emission module is loaded
 if (isNil "tts_emission_fnc_startEmission") exitWith {
@@ -58,3 +61,5 @@ tts_emission_disableRain       = false;
 
 // start emission using TTS
 [] spawn tts_emission_fnc_startEmission;
+
+["triggerBlowout completed"] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
@@ -19,6 +19,8 @@ params [
     ["_vegThreshold", 2]
 ];
 
+["fn_findBeachesInMap"] call VIC_fnc_debugLog;
+
 private _spots = [];
 
 for "_xCoord" from 0 to worldSize step _step do {
@@ -42,6 +44,8 @@ for "_xCoord" from 0 to worldSize step _step do {
             };
         };
     };
-};
+}; 
+
+["fn_findBeachesInMap completed"] call VIC_fnc_debugLog;
 
 _spots

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -12,7 +12,6 @@ call compile preprocessFileLineNumbers _settings;
 
 // Compile logging function first so it can be used immediately
 VIC_fnc_debugLog                 = compile preprocessFileLineNumbers (_root + "\functions\core\fn_debugLog.sqf");
-VIC_fnc_traceFunction            = compile preprocessFileLineNumbers (_root + "\functions\core\fn_traceFunction.sqf");
 
 ["masterInit"] call VIC_fnc_debugLog;
 
@@ -167,94 +166,6 @@ VIC_fnc_startChemSample      = compile preprocessFileLineNumbers (_root + "\func
 VIC_fnc_completeArtefactHunt = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_completeArtefactHunt.sqf");
 VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_completeChemSample.sqf");
 
-
-// Functions compiled in this file that should be wrapped with trace logging.
-// VIC_fnc_getSetting is deliberately skipped to avoid recursive tracing.
-private _traceFunctions = [
-    "VIC_fnc_markAllBuildings",
-    "VIC_fnc_markPlayerRanges", "VIC_fnc_findRockClusters",
-    "VIC_fnc_markRockClusters", "VIC_fnc_findSniperSpots",
-    "VIC_fnc_markSniperSpots", "VIC_fnc_findSwamps",
-    "VIC_fnc_markSwamps", "VIC_fnc_findBeachesInMap",
-    "VIC_fnc_markBeaches", "VIC_fnc_findValleys",
-    "VIC_fnc_markValleys", "VIC_fnc_findBuildingClusters",
-    "VIC_fnc_markBuildingClusters", "VIC_fnc_createGlobalMarker",
-    "VIC_fnc_markDeathLocation", "VIC_fnc_weightedPick",
-    "VIC_fnc_selectWeightedBuilding", "VIC_fnc_findBridges",
-    "VIC_fnc_findHiddenPosition", "VIC_fnc_markHiddenPosition",
-    "VIC_fnc_findBuildingCoverSpot", "VIC_fnc_markBuildingCoverSpot",
-    "VIC_fnc_radioMessage", "VIC_fnc_resetAIBehavior",
-    "VIC_fnc_triggerAIPanic", "VIC_fnc_avoidAnomalies",
-    "VIC_fnc_avoidAnomalyFields", "VIC_fnc_toggleFieldAvoid",
-    "VIC_fnc_cleanupChemicalZones", "VIC_fnc_spawnChemicalZone",
-    "VIC_fnc_spawnRandomChemicalZones", "VIC_fnc_findValleyPosition",
-    "VIC_fnc_spawnValleyChemicalZones",
-    "VIC_fnc_manageChemicalZones", "VIC_fnc_spawnZombiesFromQueue",
-    "VIC_fnc_trackDeadForZombify", "VIC_fnc_spawnAllAnomalyFields",
-    "VIC_fnc_cycleAnomalyFields", "VIC_fnc_cleanupAnomalyMarkers",
-    "VIC_fnc_manageAnomalyFields", "VIC_fnc_generateFieldName",
-    "VIC_fnc_findSite_electra", "VIC_fnc_findSite_springboard",
-    "VIC_fnc_findSite_meatgrinder", "VIC_fnc_findSite_burner",
-    "VIC_fnc_findSite_clicker", "VIC_fnc_findSite_fruitpunch",
-    "VIC_fnc_findSite_whirligig", "VIC_fnc_findSite_gravi",
-    "VIC_fnc_findSite_launchpad", "VIC_fnc_findSite_leech",
-    "VIC_fnc_findSite_trapdoor", "VIC_fnc_findSite_zapper",
-    "VIC_fnc_createField_gravi", "VIC_fnc_createField_burner",
-    "VIC_fnc_createField_electra", "VIC_fnc_createField_fruitpunch",
-    "VIC_fnc_createField_springboard",
-    "VIC_fnc_createField_meatgrinder",
-    "VIC_fnc_createField_whirligig", "VIC_fnc_createField_clicker",
-    "VIC_fnc_createField_launchpad", "VIC_fnc_createField_leech",
-    "VIC_fnc_createField_trapdoor", "VIC_fnc_createField_zapper",
-    "VIC_fnc_schedulePsyStorms", "VIC_fnc_triggerPsyStorm",
-    "VIC_fnc_scheduleBlowouts", "VIC_fnc_triggerBlowout",
-    "VIC_fnc_triggerNecroplague", "VIC_fnc_scheduleNecroplague",
-    "VIC_fnc_placeTownSirens", "VIC_fnc_setupSpookZones",
-    "VIC_fnc_spawnSpookZone", "VIC_fnc_spawnMutantGroup",
-    "VIC_fnc_spawnMinefields", "VIC_fnc_spawnAPERSField",
-    "VIC_fnc_spawnIED", "VIC_fnc_spawnBoobyTraps",
-    "VIC_fnc_manageMinefields", "VIC_fnc_spawnAbandonedVehicles",
-    "VIC_fnc_startMinefieldManager", "VIC_fnc_spawnAmbushes",
-    "VIC_fnc_manageAmbushes", "VIC_fnc_startAmbushManager",
-    "VIC_fnc_setupAnomalyFields", "VIC_fnc_spawnAmbientHerds",
-    "VIC_fnc_setupMutantHabitats", "VIC_fnc_spawnMutantNest",
-    "VIC_fnc_spawnBloodsuckerNest", "VIC_fnc_spawnBoarNest",
-    "VIC_fnc_spawnCatNest", "VIC_fnc_spawnFleshNest",
-    "VIC_fnc_spawnBlindDogNest", "VIC_fnc_spawnPseudodogNest",
-    "VIC_fnc_spawnSnorkNest", "VIC_fnc_spawnControllerNest",
-    "VIC_fnc_spawnPseudogiantNest", "VIC_fnc_spawnIzlomNest",
-    "VIC_fnc_spawnCorruptorNest", "VIC_fnc_spawnSmasherNest",
-    "VIC_fnc_spawnAcidSmasherNest", "VIC_fnc_spawnBehemothNest",
-    "VIC_fnc_spawnPredatorAttack", "VIC_fnc_managePredators",
-    "VIC_fnc_manageHerds", "VIC_fnc_manageHostiles",
-    "VIC_fnc_manageNests", "VIC_fnc_manageHabitats",
-    "VIC_fnc_updateProximity", "VIC_fnc_onMutantKilled",
-    "VIC_fnc_initMutantUnit", "panic_fnc_onEmissionBuildUp",
-    "panic_fnc_onEmissionStart", "panic_fnc_onEmissionEnd",
-    "anomalies_fnc_onEmissionBuildUp",
-    "anomalies_fnc_onEmissionStart", "anomalies_fnc_onEmissionEnd",
-    "mutants_fnc_onEmissionStart", "mutants_fnc_onEmissionEnd",
-    "chemical_fnc_onEmissionStart", "chemical_fnc_onEmissionEnd",
-    "zombification_fnc_onEmissionEnd", "VIC_fnc_hasPlayersNearby",
-    "VIC_fnc_registerEmissionHooks",
-    "VIC_fnc_getSurfacePosition", "VIC_fnc_isWaterPosition",
-    "VIC_fnc_findLandPosition", "VIC_fnc_getLandSurfacePosition",
-    "VIC_fnc_findRoadPosition", "VIC_fnc_findRandomRoadPosition",
-    "VIC_fnc_spawnAmbientStalkers", "VIC_fnc_spawnStalkerCamp",
-    "VIC_fnc_spawnStalkerCamps", "VIC_fnc_manageStalkerCamps",
-    "VIC_fnc_isAntistasiUltimate", "VIC_fnc_startMutantHunt",
-    "VIC_fnc_startArtefactHunt", "VIC_fnc_startChemSample",
-    "VIC_fnc_completeArtefactHunt", "VIC_fnc_completeChemSample"
-];
-
-{
-    private _f = missionNamespace getVariable [_x, objNull];
-    if (typeName _f == "CODE") then {
-        missionNamespace setVariable [_x, [_f, _x] call VIC_fnc_traceFunction];
-    };
-} forEach _traceFunctions;
-
-
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
     [] call VIC_fnc_registerEmissionHooks;
@@ -374,6 +285,7 @@ private _traceFunctions = [
     };
 }] call CBA_fnc_addEventHandler;
 
+["masterInit completed"] call VIC_fnc_debugLog;
 // Track units killed during emissions for later zombification
 ["EntityKilled", {
     params ["_unit"];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_radioMessage.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_radioMessage.sqf
@@ -6,8 +6,14 @@
 */
 params ["_msg"];
 
-if (!hasInterface) exitWith {};
+["fn_radioMessage"] call VIC_fnc_debugLog;
+
+if (!hasInterface) exitWith {
+    ["fn_radioMessage exit: no interface"] call VIC_fnc_debugLog;
+};
 
 player sideChat _msg;
+
+["fn_radioMessage completed"] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
@@ -5,7 +5,9 @@
 
 ["managePredators"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["managePredators exit: not server"] call VIC_fnc_debugLog;
+};
 if (isNil "STALKER_activePredators") then { STALKER_activePredators = []; };
 
 private _chance = ["VSA_predatorAttackChance", 5] call VIC_fnc_getSetting;
@@ -34,3 +36,5 @@ private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
     };
     STALKER_activePredators set [_forEachIndex, [_grp, _target, _marker, _near]];
 } forEach STALKER_activePredators;
+
+["managePredators completed"] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantNest.sqf
@@ -8,19 +8,29 @@ params ["_pos", "_class"];
 ["spawnMutantNest"] call VIC_fnc_debugLog;
 
 _pos = [_pos] call VIC_fnc_findLandPosition;
-if (_pos isEqualTo []) exitWith {};
+if (_pos isEqualTo []) exitWith {
+    ["spawnMutantNest exit: invalid position"] call VIC_fnc_debugLog;
+};
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["spawnMutantNest exit: not server"] call VIC_fnc_debugLog;
+};
 
-if (["VSA_enableMutants", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableMutants", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["spawnMutantNest exit: mutants disabled"] call VIC_fnc_debugLog;
+};
 
 if (isNil "STALKER_mutantNests") then { STALKER_mutantNests = []; };
 
 private _max = ["VSA_maxMutantNests", 3] call VIC_fnc_getSetting;
-if ((count STALKER_mutantNests) >= _max) exitWith {};
+if ((count STALKER_mutantNests) >= _max) exitWith {
+    ["spawnMutantNest exit: max nests"] call VIC_fnc_debugLog;
+};
 
 private _nightOnly = ["VSA_nestsNightOnly", true] call VIC_fnc_getSetting;
-if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
+if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {
+    ["spawnMutantNest exit: day time"] call VIC_fnc_debugLog;
+};
 
 private _grp = createGroup east;
 for "_i" from 1 to 3 do {
@@ -32,3 +42,5 @@ private _nestObj = "Land_Campfire_F" createVehicle _pos;
 STALKER_mutantNests pushBack [_nestObj, _grp, _pos, _class];
 
 [_grp, _pos] call BIS_fnc_taskDefend;
+
+["spawnMutantNest completed"] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -10,20 +10,25 @@ params ["_player"];
 
 ["spawnPredatorAttack"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["spawnPredatorAttack exit: not server"] call VIC_fnc_debugLog;
+};
 
-if (["VSA_enableMutants", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableMutants", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["spawnPredatorAttack exit: mutants disabled"] call VIC_fnc_debugLog;
+};
 
 if (isNil "STALKER_activePredators") then { STALKER_activePredators = []; };
 
-private _spawnMarker = "";
 private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
 private _spawnPos = _player getPos [_range, random 360];
 _spawnPos = [_spawnPos] call VIC_fnc_findLandPosition;
-if (_spawnPos isEqualTo []) exitWith {};
+if (_spawnPos isEqualTo []) exitWith {
+    ["spawnPredatorAttack exit: invalid position"] call VIC_fnc_debugLog;
+};
 
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-    _spawnMarker = format ["pred_%1", diag_tickTime];
+    private _spawnMarker = format ["pred_%1", diag_tickTime];
     [_spawnMarker, _spawnPos, "ICON", "mil_dot", "ColorRed", 1, "Predator Spawn"] call VIC_fnc_createGlobalMarker;
 };
 
@@ -106,3 +111,5 @@ private _marker = _markerName;
 [_marker, _spawnPos, "ICON", "mil_warning", "ColorRed", 1] call VIC_fnc_createGlobalMarker;
 
 STALKER_activePredators pushBack [_grp, _player, _marker, true];
+
+["spawnPredatorAttack completed"] call VIC_fnc_debugLog;


### PR DESCRIPTION
## Summary
- remove traceFunction compile from masterInit
- finish masterInit with completion log
- add exit and completion logs for blowout scheduling and trigger functions
- instrument siren placement and field avoidance toggles
- ensure anomaly field avoidance logs all early exits

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf addons/Viceroys-STALKER-ALife/functions/ai/fn_toggleFieldAvoid.sqf addons/Viceroys-STALKER-ALife/functions/blowouts/fn_placeTownSirens.sqf addons/Viceroys-STALKER-ALife/functions/blowouts/fn_scheduleBlowouts.sqf addons/Viceroys-STALKER-ALife/functions/blowouts/fn_triggerBlowout.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684f0d682d2c832f8eac36c0b93172ab