### PR TITLE
Fix global visibility of debug markers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markAllBuildings.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markAllBuildings.sqf
@@ -7,8 +7,6 @@
 
 ["markAllBuildings"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
-
 if (isNil "STALKER_buildingMarkers") then { STALKER_buildingMarkers = [] };
 
 // Collect mission placed buildings and terrain buildings
@@ -21,11 +19,8 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
     private _type = typeOf _x;
     private _pos = getPosATL _x;
     private _name = format ["bld_%1_%2", toLower _type, diag_tickTime + random 1000];
-    private _marker = createMarker [_name, _pos];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_dot";
-    _marker setMarkerColor "ColorYellow";
-    _marker setMarkerText _type;
+    private _marker = [_name, _pos, "ICON", "mil_dot", "ColorYellow"] call VIC_fnc_createGlobalMarker;
+    [_name, _type] remoteExecCall ["setMarkerText", 0, true];
     STALKER_buildingMarkers pushBack _marker;
 } forEach _buildings;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
@@ -6,7 +6,6 @@
 
 ["markBuildingClusters"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_buildingClusterMarkers") then { STALKER_buildingClusterMarkers = [] };
 
@@ -22,10 +21,7 @@ private _clusters = [] call VIC_fnc_findBuildingClusters;
     {
         private _pos = getPosATL _x;
         private _name = format ["bcl_%1", diag_tickTime + random 1000];
-        private _marker = createMarker [_name, _pos];
-        _marker setMarkerShape "ICON";
-        _marker setMarkerType "mil_dot";
-        _marker setMarkerColor "ColorBlue";
+        private _marker = [_name, _pos, "ICON", "mil_dot", "ColorBlue"] call VIC_fnc_createGlobalMarker;
         STALKER_buildingClusterMarkers pushBack _marker;
     } forEach _x;
 } forEach _clusters;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingCoverSpot.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingCoverSpot.sqf
@@ -6,7 +6,6 @@
 
 ["markBuildingCoverSpot"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_coverMarkers") then { STALKER_coverMarkers = [] };
 
@@ -17,10 +16,7 @@ private _pos = [player] call VIC_fnc_findBuildingCoverSpot;
 if (isNil {_pos}) exitWith { false };
 
 private _name = format ["cover_%1", diag_tickTime + random 1000];
-private _marker = createMarker [_name, _pos];
-_marker setMarkerShape "ICON";
-_marker setMarkerType "mil_dot";
-_marker setMarkerColor "ColorGreen";
+private _marker = [_name, _pos, "ICON", "mil_dot", "ColorGreen"] call VIC_fnc_createGlobalMarker;
 STALKER_coverMarkers pushBack _marker;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markHiddenPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markHiddenPosition.sqf
@@ -6,7 +6,6 @@
 
 ["markHiddenPosition"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_hiddenMarkers") then { STALKER_hiddenMarkers = [] };
 
@@ -20,10 +19,7 @@ private _pos = [] call VIC_fnc_findHiddenPosition;
 if (isNil {_pos}) exitWith { false };
 
 private _name = format ["hidden_%1", diag_tickTime + random 1000];
-private _marker = createMarker [_name, _pos];
-_marker setMarkerShape "ICON";
-_marker setMarkerType "mil_dot";
-_marker setMarkerColor "ColorGreen";
+private _marker = [_name, _pos, "ICON", "mil_dot", "ColorGreen"] call VIC_fnc_createGlobalMarker;
 STALKER_hiddenMarkers pushBack _marker;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf
@@ -6,7 +6,6 @@
 
 ["markRockClusters"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_rockClusterMarkers") then { STALKER_rockClusterMarkers = [] };
 
@@ -22,10 +21,7 @@ private _clusters = [] call VIC_fnc_findRockClusters;
     {
         private _pos = getPosATL _x;
         private _name = format ["rock_%1", diag_tickTime + random 1000];
-        private _marker = createMarker [_name, _pos];
-        _marker setMarkerShape "ICON";
-        _marker setMarkerType "mil_dot";
-        _marker setMarkerColor "ColorBlack";
+        private _marker = [_name, _pos, "ICON", "mil_dot", "ColorBlack"] call VIC_fnc_createGlobalMarker;
         STALKER_rockClusterMarkers pushBack _marker;
     } forEach _x;
 } forEach _clusters;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf
@@ -6,7 +6,6 @@
 
 ["markSniperSpots"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_sniperSpotMarkers") then { STALKER_sniperSpotMarkers = [] };
 
@@ -20,10 +19,7 @@ private _spots = [] call VIC_fnc_findSniperSpots;
 
 {
     private _name = format ["sniper_%1_%2", diag_tickTime, _forEachIndex];
-    private _marker = createMarker [_name, _x];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_dot";
-    _marker setMarkerColor "ColorBlue";
+    private _marker = [_name, _x, "ICON", "mil_dot", "ColorBlue"] call VIC_fnc_createGlobalMarker;
     STALKER_sniperSpotMarkers pushBack _marker;
 } forEach _spots;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf
@@ -6,7 +6,6 @@
 
 ["markSwamps"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_swampMarkers") then { STALKER_swampMarkers = [] };
 
@@ -21,10 +20,7 @@ private _swamps = [] call VIC_fnc_findSwamps;
 {
     private _pos = _x;
     private _name = format ["swamp_%1", diag_tickTime + random 1000];
-    private _marker = createMarker [_name, _pos];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_triangle";
-    _marker setMarkerColor "ColorGreen";
+    private _marker = [_name, _pos, "ICON", "mil_triangle", "ColorGreen"] call VIC_fnc_createGlobalMarker;
     STALKER_swampMarkers pushBack _marker;
 } forEach _swamps;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
@@ -6,7 +6,6 @@
 
 ["markValleys"] call VIC_fnc_debugLog;
 
-if (!hasInterface) exitWith { false };
 
 if (isNil "STALKER_valleyMarkers") then { STALKER_valleyMarkers = [] };
 
@@ -21,10 +20,7 @@ private _valleys = [] call VIC_fnc_findValleys;
 {
     private _pos = _x;
     private _name = format ["valley_%1", diag_tickTime + random 1000];
-    private _marker = createMarker [_name, _pos];
-    _marker setMarkerShape "ICON";
-    _marker setMarkerType "mil_triangle";
-    _marker setMarkerColor "ColorBlue";
+    private _marker = [_name, _pos, "ICON", "mil_triangle", "ColorBlue"] call VIC_fnc_createGlobalMarker;
     STALKER_valleyMarkers pushBack _marker;
 } forEach _valleys;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -98,15 +98,15 @@ player addAction ["Reset AI Behaviour", {
 player addAction ["Toggle Field Avoidance", {
     [] remoteExec ["VIC_fnc_toggleFieldAvoid", 2];
 }];
-player addAction ["Mark All Buildings", { [] call VIC_fnc_markAllBuildings }];
-player addAction ["Mark Rock Clusters", { [] call VIC_fnc_markRockClusters }];
-player addAction ["Mark Sniper Spots", { [] call VIC_fnc_markSniperSpots }];
-player addAction ["Mark Swamps", { [] call VIC_fnc_markSwamps }];
+player addAction ["Mark All Buildings", { [] remoteExec ["VIC_fnc_markAllBuildings", 2] }];
+player addAction ["Mark Rock Clusters", { [] remoteExec ["VIC_fnc_markRockClusters", 2] }];
+player addAction ["Mark Sniper Spots", { [] remoteExec ["VIC_fnc_markSniperSpots", 2] }];
+player addAction ["Mark Swamps", { [] remoteExec ["VIC_fnc_markSwamps", 2] }];
 player addAction ["Mark Beach Spots", { [] call VIC_fnc_markBeaches }];
-player addAction ["Mark Valleys", { [] call VIC_fnc_markValleys }];
-player addAction ["Mark Building Clusters", { [] call VIC_fnc_markBuildingClusters }];
-player addAction ["Mark Hidden Spot", { [] call VIC_fnc_markHiddenPosition }];
-player addAction ["Mark Building Cover", { [] call VIC_fnc_markBuildingCoverSpot }];
+player addAction ["Mark Valleys", { [] remoteExec ["VIC_fnc_markValleys", 2] }];
+player addAction ["Mark Building Clusters", { [] remoteExec ["VIC_fnc_markBuildingClusters", 2] }];
+player addAction ["Mark Hidden Spot", { [] remoteExec ["VIC_fnc_markHiddenPosition", 2] }];
+player addAction ["Mark Building Cover", { [] remoteExec ["VIC_fnc_markBuildingCoverSpot", 2] }];
 
 ["Debug actions added"] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- create global markers for debugging instead of local ones
- allow debug marker functions to run on server
- trigger marker functions on the server from debug actions

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_markAllBuildings.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingCoverSpot.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markHiddenPosition.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`

------
https://chatgpt.com/codex/tasks/task_e_684f7dd60e24832f840c9c09b39d91a6