### PR TITLE
Adjust proximity check timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Each habitat now uses an ellipse marker to show its bounds and a labeled icon displaying the current population (e.g. `Bloodsucker Habitat: 4/12`).
 * Systems rely on **fn_hasPlayersNearby.sqf** so habitats sleep and despawn when players are farther than the configured nearby range (default 1500m).
 * Habitats now spawn empty and gain one mutant each habitat cycle when no players are nearby.
-* Player proximity is checked on a separate timer via `VSA_proximityCheckInterval`.
+* Player proximity is checked every 5 seconds via `VSA_proximityCheckInterval`.
 * Habitat updates run on their own timer via `VSA_habitatCheckInterval`.
 * Habitat and herd counts update immediately when mutants are killed.
 * Habitat placement now selects random buildings, forests and swamps with weighted preferences.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -605,7 +605,7 @@ true
 ["VSA_predatorRange","SLIDER",["Predator Range","Distance from players to spawn predators"],"Viceroy's STALKER ALife - Mutants",[0, 7500, 1500, 0]] call CBA_fnc_addSetting;
 ["VSA_predatorCheckIntervalDay","SLIDER",["Predator Check (Day)","Seconds between predator attack checks during daylight"],"Viceroy's STALKER ALife - Mutants",[60, 900, 600, 0]] call CBA_fnc_addSetting;
 ["VSA_predatorCheckIntervalNight","SLIDER",["Predator Check (Night)","Seconds between predator attack checks at night"],"Viceroy's STALKER ALife - Mutants",[60, 900, 300, 0]] call CBA_fnc_addSetting;
-["VSA_proximityCheckInterval","SLIDER",["Proximity Check Interval","Seconds between player distance checks"],"Viceroy's STALKER ALife - Mutants",[10, 300, 30, 0]] call CBA_fnc_addSetting;
+["VSA_proximityCheckInterval","SLIDER",["Proximity Check Interval","Seconds between player distance checks"],"Viceroy's STALKER ALife - Mutants",[10, 300, 5, 0]] call CBA_fnc_addSetting;
 ["VSA_habitatCheckInterval","SLIDER",["Habitat Check Interval","Seconds between habitat updates"],"Viceroy's STALKER ALife - Mutants",[1, 60, 5, 0]] call CBA_fnc_addSetting;
 
 [

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -182,7 +182,7 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
         {
             while {true} do {
                 [] call VIC_fnc_updateProximity;
-                private _delay = ["VSA_proximityCheckInterval", 30] call VIC_fnc_getSetting;
+                private _delay = ["VSA_proximityCheckInterval", 5] call VIC_fnc_getSetting;
                 sleep _delay;
             };
         }, [], 8


### PR DESCRIPTION
## Summary
- run player proximity checks every 5 seconds
- set default proximity setting to 5 seconds
- note new default in README

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/cba_settings.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850060854c0832fae7c7f281c594a57