### PR TITLE
Add bridge debug markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ spawns at night, during the day or both.
    This option can now be toggled while a mission is running and the debug
    actions will appear automatically.
 5. When debug mode is active, your scroll menu includes options to trigger storms, spawn permanent or temporary anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Permanent fields will show a randomly generated name on their marker for easy reference.
-6. Use the **Mark All Buildings** action from this menu if you need to visualize every building. Buildings are no longer marked automatically when debug mode is enabled.
+6. Use the **Mark All Buildings** and **Mark Bridges** actions from this menu if you need to visualize these objects. Buildings are no longer marked automatically when debug mode is enabled.
 7. The mod has been tested on locally hosted sessions and dedicated servers. Scripts execute on the server side so clients see consistent behaviour regardless of hosting method.
 
 If your mission reports undefined CBA settings, ensure that **CBA A3** is loaded and initialized before this mod. Settings now fall back to defaults via `VIC_fnc_getSetting` when CBA has not yet finished loading.

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf
@@ -1,0 +1,28 @@
+/*
+    Marks all detected bridges on the map when debugging is enabled.
+
+    Returns: BOOL
+*/
+
+["markBridges"] call VIC_fnc_debugLog;
+
+if (isNil "STALKER_bridgeMarkers") then { STALKER_bridgeMarkers = [] };
+
+// Remove existing markers if present
+{
+    if (_x != "") then { deleteMarker _x };
+} forEach STALKER_bridgeMarkers;
+STALKER_bridgeMarkers = [];
+
+private _bridges = [] call VIC_fnc_findBridges;
+
+{
+    private _type = typeOf _x;
+    private _pos = getPosATL _x;
+    private _name = format ["bridge_%1_%2", toLower _type, diag_tickTime + random 1000];
+    private _marker = [_name, _pos, "ICON", "mil_dot", "ColorRed"] call VIC_fnc_createGlobalMarker;
+    [_name, _type] remoteExecCall ["setMarkerText", 0, true];
+    STALKER_bridgeMarkers pushBack _marker;
+} forEach _bridges;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -37,6 +37,7 @@ VIC_fnc_markDeathLocation      = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_weightedPick           = compile preprocessFileLineNumbers (_root + "\functions\core\fn_weightedPick.sqf");
 VIC_fnc_selectWeightedBuilding = compile preprocessFileLineNumbers (_root + "\functions\core\fn_selectWeightedBuilding.sqf");
 VIC_fnc_findBridges            = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBridges.sqf");
+VIC_fnc_markBridges            = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markBridges.sqf");
 VIC_fnc_findHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findHiddenPosition.sqf");
 VIC_fnc_markHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markHiddenPosition.sqf");
 VIC_fnc_findBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBuildingCoverSpot.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -107,6 +107,7 @@ player addAction ["Mark Valleys", { [] remoteExec ["VIC_fnc_markValleys", 2] }];
 player addAction ["Mark Building Clusters", { [] remoteExec ["VIC_fnc_markBuildingClusters", 2] }];
 player addAction ["Mark Hidden Spot", { [] remoteExec ["VIC_fnc_markHiddenPosition", 2] }];
 player addAction ["Mark Building Cover", { [] remoteExec ["VIC_fnc_markBuildingCoverSpot", 2] }];
+player addAction ["Mark Bridges", { [] remoteExec ["VIC_fnc_markBridges", 2] }];
 
 ["Debug actions added"] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- add debug command to highlight all bridges on the map
- compile new function in `fn_masterInit`
- expose new action in `fn_setupDebugActions`
- document bridge marking in README

## Testing
- `./scripts/sqflint-hook.sh $(git ls-files '*.sqf')` *(fails: can't interpret statement errors)*

------
https://chatgpt.com/codex/tasks/task_e_685006612888832f98471759a2f28246