### PR TITLE
Fix blowout debug action when hosting locally

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -16,7 +16,11 @@ player addAction ["Spawn Psy-Storm", {
     [_dur, _lStart, _lEnd, _dStart, _dEnd] remoteExec ["VIC_fnc_triggerPsyStorm", 2];
 }];
 player addAction ["Trigger Blowout", {
-    [] remoteExec ["VIC_fnc_triggerBlowout", 2];
+    if (isServer) then {
+        [] call VIC_fnc_triggerBlowout;
+    } else {
+        [] remoteExec ["VIC_fnc_triggerBlowout", 2];
+    };
 }];
 player addAction ["Spawn Chemical Zone", {
     [getPos player, 100] remoteExec ["VIC_fnc_spawnChemicalZone", 2];


### PR DESCRIPTION
## Summary
- ensure the Trigger Blowout debug action runs even when executed by the server itself

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`
- `sqflint -d .`

------
https://chatgpt.com/codex/tasks/task_e_6850067bb460832fb1e4477d672fee13