### PR TITLE
Fix emission debug action

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -17,9 +17,9 @@ player addAction ["Spawn Psy-Storm", {
 }];
 player addAction ["Trigger Blowout", {
     if (isServer) then {
-        [] call VIC_fnc_triggerBlowout;
+        [] spawn tts_emission_fnc_startEmission;
     } else {
-        [] remoteExec ["VIC_fnc_triggerBlowout", 2];
+        { [] spawn tts_emission_fnc_startEmission } remoteExec [2];
     };
 }];
 player addAction ["Spawn Chemical Zone", {


### PR DESCRIPTION
## Summary
- tweak the Trigger Blowout debug action to run `spawn tts_emission_fnc_startEmission`

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685010c790d8832f91b26ba8b3d05e18