### PR TITLE
Fix bridge detection and blowout debug action

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
@@ -39,7 +39,7 @@ for "_x" from 0 to _size step _step do {
         {
             private _obj = _x;
             private _type = typeOf _obj;
-            private _model = toLower getModelInfo _obj select 0;
+            private _model = toLower ((getModelInfo _obj) select 0);
 
             if (
                 _type in _bridgeClassnames ||

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -21,9 +21,9 @@ player addAction ["Spawn Psy-Storm", {
 }];
 player addAction ["Trigger Blowout", {
     if (isServer) then {
-        [] spawn tts_emission_fnc_startEmission;
+        [] call VIC_fnc_triggerBlowout;
     } else {
-        { [] spawn tts_emission_fnc_startEmission } remoteExec [2];
+        [] remoteExec ["VIC_fnc_triggerBlowout", 2];
     };
 }];
 player addAction ["Spawn Chemical Zone", {


### PR DESCRIPTION
## Summary
- fix model lookup in `fn_findBridges`
- call the compiled blowout routine when triggering via debug actions

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850178a1864832f9926b6b6db112659