### PR TITLE
Improve debug logs for spawn helpers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -9,9 +9,13 @@ params ["_center", ["_radius",500], ["_count",-1]];
 
 ["spawnAmbushes"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["spawnAmbushes: server only"] call VIC_fnc_debugLog;
+};
 
-if (["VSA_enableAmbushes", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableAmbushes", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["spawnAmbushes: disabled"] call VIC_fnc_debugLog;
+};
 
 if (isNil "STALKER_ambushes") then { STALKER_ambushes = []; };
 

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
@@ -10,7 +10,9 @@ params ["_center","_radius", ["_count", -1], ["_duration", -1]];
 
 ["spawnRandomChemicalZones"] call VIC_fnc_debugLog;
 
-if (["VSA_enableChemicalZones", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableChemicalZones", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["spawnRandomChemicalZones: disabled"] call VIC_fnc_debugLog;
+};
 
 if (_count < 0) then {
     _count = ["VSA_chemicalZoneCount", 2] call VIC_fnc_getSetting;
@@ -19,7 +21,9 @@ private _weight = ["VSA_chemicalSpawnWeight", 50] call VIC_fnc_getSetting;
 private _nightOnly = ["VSA_chemicalNightOnly", false] call VIC_fnc_getSetting;
 private _zoneRadius = ["VSA_chemicalZoneRadius", 50] call VIC_fnc_getSetting;
 
-if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
+if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {
+    ["spawnRandomChemicalZones: night only"] call VIC_fnc_debugLog;
+};
 
 for "_i" from 1 to _count do {
     if (random 100 >= _weight) then { continue };

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
@@ -14,7 +14,9 @@ params ["_center","_radius", ["_count",-1], ["_duration",-1], ["_clusterSize",3]
 
 ["spawnValleyChemicalZones"] call VIC_fnc_debugLog;
 
-if (["VSA_enableChemicalZones", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableChemicalZones", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["spawnValleyChemicalZones: disabled"] call VIC_fnc_debugLog;
+};
 
 if (isNil "STALKER_chemicalZones") then { STALKER_chemicalZones = []; };
 
@@ -22,7 +24,9 @@ if (_count < 0) then { _count = ["VSA_chemicalZoneCount", 2] call VIC_fnc_getSet
 private _nightOnly  = ["VSA_chemicalNightOnly", false] call VIC_fnc_getSetting;
 private _zoneRadius = ["VSA_chemicalZoneRadius", 50] call VIC_fnc_getSetting;
 
-if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
+if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {
+    ["spawnValleyChemicalZones: night only"] call VIC_fnc_debugLog;
+};
 
 for "_i" from 1 to _count do {
     private _centerPos = if (_center isEqualType objNull) then { getPos _center } else { _center };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
@@ -10,6 +10,11 @@
 */
 params ["_name", "_default"];
 
-if (isNil "CBA_fnc_getSetting") exitWith { _default };
+if (isNil "CBA_fnc_getSetting") exitWith {
+    [format ["getSetting: CBA missing for %1", _name]] call VIC_fnc_debugLog;
+    _default
+};
 
-[_name, _default] call CBA_fnc_getSetting
+private _value = [_name, _default] call CBA_fnc_getSetting;
+[format ["getSetting: %1 -> %2", _name, _value]] call VIC_fnc_debugLog;
+_value

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -10,9 +10,13 @@ params ["_center", ["_radius",500], ["_fieldCount",-1], ["_iedCount",-1]];
 
 ["spawnMinefields"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith {};
+if (!isServer) exitWith {
+    ["spawnMinefields: server only"] call VIC_fnc_debugLog;
+};
 
-if (["VSA_enableMinefields", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
+if (["VSA_enableMinefields", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
+    ["spawnMinefields: disabled"] call VIC_fnc_debugLog;
+};
 
 if (isNil "STALKER_minefields") then { STALKER_minefields = []; };
 
@@ -23,7 +27,9 @@ private _size = ["VSA_minefieldSize",30] call VIC_fnc_getSetting;
 private _towns = nearestLocations [_center, ["NameVillage","NameCity","NameCityCapital","NameLocal"], _radius];
 
 for "_i" from 1 to _fieldCount do {
-    if (_towns isEqualTo []) exitWith {};
+    if (_towns isEqualTo []) exitWith {
+        ["spawnMinefields: no towns found"] call VIC_fnc_debugLog;
+    };
     private _town = selectRandom _towns;
     private _tPos = locationPosition _town;
     private _pos = _tPos getPos [150 + random 200, random 360];
@@ -40,7 +46,9 @@ for "_i" from 1 to _fieldCount do {
 };
 
 for "_i" from 1 to _iedCount do {
-    if (_towns isEqualTo []) exitWith {};
+    if (_towns isEqualTo []) exitWith {
+        ["spawnMinefields: no towns found"] call VIC_fnc_debugLog;
+    };
     private _town = selectRandom _towns;
     private _tPos = locationPosition _town;
     private _pos = [_tPos, 200, 10] call VIC_fnc_findRoadPosition;


### PR DESCRIPTION
## Summary
- log CBA setting retrieval
- note why spawns exit early

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850344351e8832fb3a11f63db7ca9ed