### PR TITLE
Fix zombie spawn and player detection

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
@@ -11,4 +11,8 @@
 params ["_pos", "_radius"];
 
 // Search all players on the server and return true when one is close
-(allPlayers findIf { alive _x && {_x distance2D _pos <= _radius} }) >= 0
+private _nearby = false;
+{
+    if (alive _x && { _x distance2D _pos <= _radius }) exitWith { _nearby = true };
+} forEach allPlayers;
+_nearby;

--- a/addons/Viceroys-STALKER-ALife/functions/zombification/fn_spawnZombiesFromQueue.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/zombification/fn_spawnZombiesFromQueue.sqf
@@ -23,8 +23,9 @@ private _zClasses = [
         deleteVehicle _corpse;
 
         private _class = selectRandom _zClasses;
-        private _zombie = createVehicle [_class, _pos, [], 0, "NONE"];
+        private _zombie = createAgent [_class, _pos, [], 0, "NONE"];
         _zombie setDir _dir;
+        [_zombie] call VIC_fnc_initMutantUnit;
     };
 } forEach _queue;
 


### PR DESCRIPTION
## Summary
- spawn zombification agents using `createAgent`
- ensure new zombies have mutant initialization
- improve player proximity check logic

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf addons/Viceroys-STALKER-ALife/functions/zombification/fn_spawnZombiesFromQueue.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850381f8f8c832f94d497b58b4eef82