### PR TITLE
Fix debug log output and missing discharge check

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -35,7 +35,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createElectra;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createElectra", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_bridgeElectra: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -37,7 +37,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createBurner;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createBurner", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_burner: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -36,7 +36,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createClicker;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createClicker", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_clicker: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -36,7 +36,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createElectra;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createElectra", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_electra: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -36,7 +36,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createFruitPunch;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createFruitPunch", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_fruitpunch: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -36,7 +36,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createMeatgrinder;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createMeatgrinder", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_meatgrinder: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -36,7 +36,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createSpringboard;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createSpringboard", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_springboard: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -36,7 +36,12 @@ for "_i" from 1 to _count do {
     private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
-    private _anom = [_surf] call diwako_anomalies_main_fnc_createWhirligig;
+    private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createWhirligig", {}];
+    if (_create isEqualTo {}) then {
+        ["createField_whirligig: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        continue;
+    };
+    private _anom = [_surf] call _create;
     _anom setVariable ["zoneMarker", _marker];
     _spawned pushBack _anom;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -54,8 +54,12 @@ private _agl = ASLToAGL _position;
 
 // Spawn the mist cloud across all machines
 // Spawn the mist across all clients
-[_agl, _radius, _duration, _chemType, _verticleSpread, _thickness]
-    remoteExec ["CBRN_fnc_spawnMist", 0];
+if (isNil "CBRN_fnc_spawnMist") then {
+    ["spawnChemicalZone: CBRN mod missing"] call VIC_fnc_debugLog;
+} else {
+    [_agl, _radius, _duration, _chemType, _verticleSpread, _thickness]
+        remoteExec ["CBRN_fnc_spawnMist", 0];
+};
 
 // Create and configure a map marker for this chemical zone
 private _markerName = format ["chem_%1", diag_tickTime];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf
@@ -7,10 +7,17 @@
 */
 params ["_msg"];
 
-if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-    diag_log _msg;
+// When the settings function isn't available yet (e.g. early in init)
+// assume debug mode is enabled so logging still works
+private _enabled = true;
+if (!isNil "VIC_fnc_getSetting") then {
+    _enabled = ["VSA_debugMode", false] call VIC_fnc_getSetting;
+};
+
+if (_enabled) then {
+    diag_log str _msg;
     if (hasInterface) then {
-        systemChat _msg;
+        systemChat str _msg;
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf
@@ -76,7 +76,11 @@ for "_i" from 1 to _ticks do {
         private _surf = [_pos] call VIC_fnc_getSurfacePosition;
         private _module = "diwako_anomalies_main_modulePsyDischarge" createVehicleLocal _surf;
         private _fncDischarge = missionNamespace getVariable ["diwako_anomalies_main_fnc_modulePsyDischarge", {}];
-        ["init", _module] call _fncDischarge;
+        if (_fncDischarge isEqualTo {}) then {
+            ["triggerPsyStorm: Diwako Anomalies missing"] call VIC_fnc_debugLog;
+        } else {
+            ["init", _module] call _fncDischarge;
+        };
         if (_gasEnabled) then {
             // Spawn a Nova mist after the discharge finishes using CBA settings
             private _radius  = ["VSA_stormGasRadius", 20] call VIC_fnc_getSetting;
@@ -85,10 +89,14 @@ for "_i" from 1 to _ticks do {
 
             // Convert the surface position from ASL to AGL so the gas spawns on the ground
             private _agl = ASLToAGL _surf;
-            [_agl, _radius, 20, 4, _vertical, _density] spawn {
-                params ["_pos", "_r", "_dur", "_chem", "_vert", "_dens"];
-                sleep 5;
-                [_pos, _r, _dur, _chem, _vert, _dens] remoteExec ["CBRN_fnc_spawnMist", 0];
+            if (isNil "CBRN_fnc_spawnMist") then {
+                ["triggerPsyStorm: CBRN mod missing"] call VIC_fnc_debugLog;
+            } else {
+                [_agl, _radius, 20, 4, _vertical, _density] spawn {
+                    params ["_pos", "_r", "_dur", "_chem", "_vert", "_dens"];
+                    sleep 5;
+                    [_pos, _r, _dur, _chem, _vert, _dens] remoteExec ["CBRN_fnc_spawnMist", 0];
+                };
             };
         };
     };


### PR DESCRIPTION
## Summary
- ensure debug messages always log string values
- warn when psy-storm discharge function is missing

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf addons/Viceroys-STALKER-ALife/functions/storms/fn_triggerPsyStorm.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68503835b7e4832fa066ff051dfda1b0