### PR TITLE
Limit startup managers for debugging

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -173,14 +173,6 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
 ["postInit", {
     [] call VIC_fnc_registerEmissionHooks;
     if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {
-        [] call VIC_fnc_schedulePsyStorms;
-        [] call VIC_fnc_scheduleBlowouts;
-        [] call VIC_fnc_scheduleNecroplague;
-        [] call VIC_fnc_placeTownSirens;
-        [] call VIC_fnc_setupAnomalyFields;
-        [] call VIC_fnc_setupMutantHabitats;
-        [] call VIC_fnc_spawnAmbientStalkers;
-        [] call VIC_fnc_spawnStalkerCamps;
     [
         {
             while {true} do {
@@ -190,99 +182,8 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
             };
         }, [], 8
     ] call CBA_fnc_waitAndExecute;
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageHerds;
-                sleep 60;
-            };
-        }, [], 10
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageChemicalZones;
-                sleep 60;
-            };
-        }, [], 13
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageHostiles;
-                sleep 60;
-            };
-        }, [], 15
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_avoidAnomalies;
-                sleep 30;
-            };
-        }, [], 16
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_avoidAnomalyFields;
-                sleep 30;
-            };
-        }, [], 17
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageAnomalyFields;
-                sleep 60;
-            };
-        }, [], 18
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageNests;
-                sleep 300;
-            };
-        }, [], 20
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_managePredators;
-                private _day   = ["VSA_predatorCheckIntervalDay", 300] call VIC_fnc_getSetting;
-                private _night = ["VSA_predatorCheckIntervalNight", 300] call VIC_fnc_getSetting;
-                private _delay = if (daytime > 5 && daytime < 20) then {_day} else {_night};
-                sleep _delay;
-            };
-        }, [], 23
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageHabitats;
-                private _delay = ["VSA_habitatCheckInterval", 5] call VIC_fnc_getSetting;
-                sleep _delay;
-            };
-        }, [], 25
-    ] call CBA_fnc_waitAndExecute;
-
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_manageStalkerCamps;
-                sleep 60;
-            };
-        }, [], 29
-    ] call CBA_fnc_waitAndExecute;
+    // Additional managers have been disabled for quicker startup and can be
+    // invoked via debug actions when needed.
     };
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         [] call VIC_fnc_setupDebugActions;

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -25,17 +25,11 @@ STALKER_anomalyFields = [];
 STALKER_minefields = [];
 STALKER_panicGroups = [];
 
-// Prepare spook zone locations
-[] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\spooks\fn_setupSpookZones.sqf";
+// Prepare spook zone locations via debug action when needed
+// [] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\spooks\fn_setupSpookZones.sqf";
 
-// Generate anomaly fields across the map
-[] call VIC_fnc_setupAnomalyFields;
-
-// Generate chemical zones across the map
-for "_i" from 1 to 100 do {
-    private _pos = [random worldSize, random worldSize, 0];
-    [_pos, 1000] call VIC_fnc_spawnValleyChemicalZones;
-};
+// Anomaly fields, chemical zones and wrecks are now spawned through debug
+// actions rather than during startup to speed up initialization.
 
 // Minefields can be spawned via the debug action
 // for "_i" from 1 to 50 do {
@@ -43,9 +37,9 @@ for "_i" from 1 to 100 do {
 //     [_pos, 1000] call VIC_fnc_spawnMinefields;
 // };
 
-// Generate wrecks
-private _wreckCount = ["VSA_wreckCount", 10] call VIC_fnc_getSetting;
-[_wreckCount] call VIC_fnc_spawnAbandonedVehicles;
+// Generate wrecks via debug action instead of automatically
+// private _wreckCount = ["VSA_wreckCount", 10] call VIC_fnc_getSetting;
+// [_wreckCount] call VIC_fnc_spawnAbandonedVehicles;
 
 
 // Ambushes can be spawned via the debug action


### PR DESCRIPTION
## Summary
- keep only the proximity manager in `fn_masterInit.sqf`
- comment out heavy startup logic in `initServer.sqf`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/initServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685060c7484c832fa2ebc9d2afe9ccf2