### PR TITLE
Fix startup lockup by gating range markers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -200,11 +200,9 @@ VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\func
   }] call CBA_fnc_addEventHandler;
 } else {
     ["postInit", {
-        if (hasInterface) then {
+        if (hasInterface && {["VSA_debugMode", false] call VIC_fnc_getSetting}) then {
+            [] call VIC_fnc_setupDebugActions;
             [] call VIC_fnc_markPlayerRanges;
-            if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-                [] call VIC_fnc_setupDebugActions;
-            };
         };
     }] call CBA_fnc_addEventHandler;
 };


### PR DESCRIPTION
## Summary
- run player range marker logic only when VSA_debugMode is enabled

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850adc9dcfc832fbfce4f5953ba824d