### PR TITLE
Fix masterInit hanging when CBA missing

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -7,7 +7,16 @@
 // --- CBA Settings -----------------------------------------------------------
 private _root = "\Viceroys-STALKER-ALife";
 private _settings = _root + "\cba_settings.sqf";
-waitUntil {!isNil "CBA_fnc_addSetting"};
+
+// Wait briefly for CBA to become available so initialization doesn't hang
+private _start = diag_tickTime;
+waitUntil {
+    !isNil "CBA_fnc_addSetting" || {diag_tickTime - _start > 5}
+};
+if (isNil "CBA_fnc_addSetting") exitWith {
+    diag_log "STALKER ALife: CBA not found - skipping initialization";
+};
+
 call compile preprocessFileLineNumbers _settings;
 
 // Compile logging function first so it can be used immediately


### PR DESCRIPTION
## Summary
- avoid indefinite wait for CBA by adding a timeout in `fn_masterInit.sqf`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850b1ffb1cc832f8338e5ebfd05a24b