### PR TITLE
Fix final function warning at startup

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -21,7 +21,6 @@ call compile preprocessFileLineNumbers _settings;
 
 // Compile logging function first so it can be used immediately
 VIC_fnc_debugLog                 = compile preprocessFileLineNumbers (_root + "\functions\core\fn_debugLog.sqf");
-VIC_fnc_getSetting               = compile preprocessFileLineNumbers (_root + "\functions\core\fn_getSetting.sqf");
 // Settings helper is required by the logger
 
 ["masterInit"] call VIC_fnc_debugLog;


### PR DESCRIPTION
## Summary
- remove manual compilation of `VIC_fnc_getSetting`

## Testing
- `python3 -m pre_commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850ba0b4c18832fb46bc08684257c21