### PR TITLE
Fix debug log recursion causing mission freeze

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf
@@ -10,8 +10,8 @@ params ["_msg"];
 // When the settings function isn't available yet (e.g. early in init)
 // assume debug mode is enabled so logging still works
 private _enabled = true;
-if (!isNil "VIC_fnc_getSetting") then {
-    _enabled = ["VSA_debugMode", false] call VIC_fnc_getSetting;
+if (!isNil "CBA_fnc_getSetting") then {
+    _enabled = ["VSA_debugMode", false] call CBA_fnc_getSetting;
 };
 
 if (_enabled) then {


### PR DESCRIPTION
## Summary
- prevent `fn_debugLog` from calling `VIC_fnc_getSetting`
- check CBA setting directly to avoid recursion

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850bb99d438832f8c59fb110d7cb53a