### PR TITLE
Read settings from mission namespace

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf
@@ -1,18 +1,14 @@
 /*
     Logs a debug message to the RPT and as a system chat message when
-    VSA_debugMode is enabled via CBA settings.
+    VSA_debugMode is enabled. Debug mode defaults to enabled during
+    testing.
 
     Params:
         0: STRING - message to display
 */
 params ["_msg"];
 
-// When the settings function isn't available yet (e.g. early in init)
-// assume debug mode is enabled so logging still works
-private _enabled = true;
-if (!isNil "CBA_fnc_getSetting") then {
-    _enabled = ["VSA_debugMode", false] call CBA_fnc_getSetting;
-};
+private _enabled = missionNamespace getVariable ["VSA_debugMode", true];
 
 if (_enabled) then {
     diag_log str _msg;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
@@ -1,5 +1,6 @@
 /*
-    Wrapper for retrieving a CBA setting with a fallback value.
+    Retrieves a setting directly from the mission namespace with a
+    fallback value.
 
     Params:
         0: STRING - setting variable name
@@ -10,11 +11,6 @@
 */
 params ["_name", "_default"];
 
-if (isNil "CBA_fnc_getSetting") exitWith {
-    [format ["getSetting: CBA missing for %1", _name]] call VIC_fnc_debugLog;
-    _default
-};
-
-private _value = [_name, _default] call CBA_fnc_getSetting;
+private _value = missionNamespace getVariable [_name, _default];
 [format ["getSetting: %1 -> %2", _name, _value]] call VIC_fnc_debugLog;
 _value


### PR DESCRIPTION
## Summary
- remove CBA dependency in `fn_getSetting` and read values from `missionNamespace`
- update `fn_debugLog` to use mission settings and default to enabled

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_debugLog.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850c1256f18832f82c6dbd7dbfb2e04