### PR TITLE
Stop overriding Diwako emission settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Severe emission waves triggered via the included functions.
 * AI and players caught outside of shelter are lethal casualties by default.
 * Behaviour can be toggled through the `VSA_killAIEmission` CBA setting.
+* Emission timing and direction are now controlled entirely by
+  **Diwako's Anomalies** via the
+  `diwako_anomalies_main_startBlowout` server event.
 
 ### Zombification
 * Tracks dead units and may reanimate them as zombies after a delay.

--- a/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_scheduleBlowouts.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_scheduleBlowouts.sqf
@@ -16,20 +16,15 @@ if (["VSA_enableBlowouts", true] call VIC_fnc_getSetting isEqualTo false) exitWi
 
 private _minDelay = ["VSA_blowoutMinDelay",12] call VIC_fnc_getSetting; // hours
 private _maxDelay = ["VSA_blowoutMaxDelay",72] call VIC_fnc_getSetting; // hours
-private _minDur   = ["VSA_blowoutDurationMin",300] call VIC_fnc_getSetting;
-private _maxDur   = ["VSA_blowoutDurationMax",900] call VIC_fnc_getSetting;
-private _dir      = ["VSA_blowoutDirection",0] call VIC_fnc_getSetting;
-private _speedMin = ["VSA_blowoutSpeedMin",125] call VIC_fnc_getSetting;
-private _speedMax = ["VSA_blowoutSpeedMax",125] call VIC_fnc_getSetting;
 
 if (_maxDelay < _minDelay) then { _maxDelay = _minDelay; };
 
-[_minDelay,_maxDelay,_minDur,_maxDur,_dir,_speedMin,_speedMax] spawn {
-    params ["_minH","_maxH","_dMin","_dMax","_dir","_sMin","_sMax"];
+[_minDelay,_maxDelay] spawn {
+    params ["_minH","_maxH"];
     private _next = time + (_minH + random (_maxH - _minH)) * 3600;
     while {true} do {
         if (time >= _next) then {
-            [_dMin,_dMax,_dir,_sMin,_sMax] call VIC_fnc_triggerBlowout;
+            [] call VIC_fnc_triggerBlowout;
             _next = time + (_minH + random (_maxH - _minH)) * 3600;
         };
         sleep 60;

--- a/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_triggerBlowout.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/blowouts/fn_triggerBlowout.sqf
@@ -1,44 +1,17 @@
 /*
     Trigger a single blowout using Diwako's Anomalies.
-    Params:
-        0: NUMBER - minimum duration in seconds (default 300)
-        1: NUMBER - maximum duration in seconds (default 900)
-        2: NUMBER - approach direction in degrees (default 0)
-        3: NUMBER - minimum wave speed in m/s (default 125)
-        4: NUMBER - maximum wave speed in m/s (default 125)
+    Params: None. All emission settings are handled by
+    Diwako's Anomalies and should not be modified here.
 */
-params [
-    ["_minDur",300],
-    ["_maxDur",900],
-    ["_dir",0],
-    ["_speedMin",125],
-    ["_speedMax",125]
-];
+params [];
 
-_minDur   = ["VSA_blowoutDurationMin", _minDur] call VIC_fnc_getSetting;
-_maxDur   = ["VSA_blowoutDurationMax", _maxDur] call VIC_fnc_getSetting;
-_dir      = ["VSA_blowoutDirection", _dir] call VIC_fnc_getSetting;
-_speedMin = ["VSA_blowoutSpeedMin", _speedMin] call VIC_fnc_getSetting;
-_speedMax = ["VSA_blowoutSpeedMax", _speedMax] call VIC_fnc_getSetting;
+["triggerBlowout"] call VIC_fnc_debugLog;
 
+if (!isServer) exitWith {
+    ["triggerBlowout exit: not server"] call VIC_fnc_debugLog;
+};
 
-    ["triggerBlowout"] call VIC_fnc_debugLog;
-
-    if (!isServer) exitWith {
-        ["triggerBlowout exit: not server"] call VIC_fnc_debugLog;
-    };
-
-    private _duration = _minDur + random (_maxDur - _minDur);
-
-    private _blowoutModule = "diwako_anomalies_main_moduleBlowout" createVehicleLocal [0,0,0];
-    _blowoutModule setVariable ["diwako_anomalies_main_wavetime", _duration];
-    _blowoutModule setVariable ["diwako_anomalies_main_direction", _dir];
-    _blowoutModule setVariable ["diwako_anomalies_main_sirens", true];
-    _blowoutModule setVariable ["diwako_anomalies_main_onlyPlayers", true];
-    _blowoutModule setVariable ["diwako_anomalies_main_isLethal", true];
-    _blowoutModule setVariable ["diwako_anomalies_main_environmentParticleEffects", true];
-
-    private _fncBlowout = missionNamespace getVariable ["diwako_anomalies_main_fnc_moduleBlowout", {}];
-    ["init", _blowoutModule] call _fncBlowout;
+// Start blowout using Diwako's server event with default parameters
+["diwako_anomalies_main_startBlowout", []] call CBA_fnc_serverEvent;
 
 ["triggerBlowout completed"] call VIC_fnc_debugLog;


### PR DESCRIPTION
## Summary
- avoid modifying blowout parameters so Diwako's mod controls them via server event
- document using `diwako_anomalies_main_startBlowout`

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/blowouts/fn_triggerBlowout.sqf addons/Viceroys-STALKER-ALife/functions/blowouts/fn_scheduleBlowouts.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850c95d0bd0832fb2b3c6d0953a2c69