### PR TITLE
Clamp radius when searching for land positions

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -19,6 +19,9 @@ if !(_base isEqualType []) exitWith { [] };
 _base params [["_bx",0],["_by",0],["_bz",0]];
 _base = [_bx,_by,_bz];
 
+// ensure radius is always positive so the search covers an area
+_radius = _radius max 1;
+
 for "_i" from 0 to _attempts do {
     private _candidate = if (_i == 0) then {
         _base


### PR DESCRIPTION
## Summary
- prevent zero search radius in `fn_findLandPosition`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6850d2e16150832fbd676601bc4c760e