### PR TITLE
Improve land search behaviour

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -60,7 +60,7 @@ for "_i" from 1 to _fieldCount do {
 
     if (random 100 >= _spawnWeight) then { continue };
 
-    private _pos = [[random worldSize, random worldSize, 0]] call VIC_fnc_findLandPosition;
+    private _pos = [[random worldSize, random worldSize, 0], 50, 10, false, worldSize] call VIC_fnc_findLandPosition;
     if (_pos isEqualTo []) then { continue };
 
     private _fn = selectRandom _types;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -4,10 +4,12 @@
         0: ARRAY or OBJECT - center position
         1: NUMBER - search radius (default 50)
         2: NUMBER - maximum attempts (default 10)
+        3: BOOL   - exclude towns from search results (default false)
+        4: NUMBER - maximum search radius (optional)
     Returns:
         ARRAY - land position or [] if none found
 */
-params ["_center", ["_radius",50], ["_attempts",10], ["_excludeTowns", false]];
+params ["_center", ["_radius",50], ["_attempts",10], ["_excludeTowns", false], ["_maxRadius", -1]];
 
 // fail fast on invalid input
 if (_center isEqualTo [] && { !(_center isEqualType objNull) }) exitWith { [] };
@@ -21,6 +23,9 @@ _base = [_bx,_by,_bz];
 
 // ensure radius is always positive so the search covers an area
 _radius = _radius max 1;
+if (_maxRadius < 0) then {
+    _maxRadius = if (_radius < 200) then { _radius * 1.5 } else { _radius };
+};
 
 for "_i" from 0 to _attempts do {
     private _candidate = if (_i == 0) then {
@@ -31,8 +36,7 @@ for "_i" from 0 to _attempts do {
 
     private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
     if (!(_surf isEqualTo [])) then {
-        private _pos = ASLToAGL _surf;
-        if (!_excludeTowns || { (nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { _pos };
+        if (!_excludeTowns || { (nearestLocations [ASLToAGL _surf,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { ASLToAGL _surf };
     };
 };
 
@@ -44,18 +48,32 @@ for "_i" from 0 to _attempts do {
     private _candidate = [_base, random _radius, random 360] call BIS_fnc_relPos;
     private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
     if (!(_surf isEqualTo [])) then {
-        private _pos = ASLToAGL _surf;
-        if (!_excludeTowns || { (nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { _pos };
+        if (!_excludeTowns || { (nearestLocations [ASLToAGL _surf,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { ASLToAGL _surf };
     };
 };
 
+// widen the search if still nothing found
+private _step = 50;
+private _searchRadius = _radius + _step;
+while {_searchRadius <= _maxRadius} do {
+    for "_i" from 0 to _attempts do {
+        private _candidate = [_base, random _searchRadius, random 360] call BIS_fnc_relPos;
+        private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
+        if (!(_surf isEqualTo [])) then {
+            if (!_excludeTowns || { (nearestLocations [ASLToAGL _surf,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo [] }) exitWith { ASLToAGL _surf };
+        };
+    };
+    _searchRadius = _searchRadius + _step;
+};
+
 // final attempt using BIS_fnc_findSafePos to avoid infinite failures
-private _safePos = [_base, 0, _radius max 50, 5, 0, 0, 0] call BIS_fnc_findSafePos;
+private _safePos = [_base, 0, _maxRadius max 50, 5, 0, 0, 0] call BIS_fnc_findSafePos;
 if (_safePos isEqualType [] && {!(_safePos isEqualTo [0,0,0])}) then {
     private _surf = [_safePos] call VIC_fnc_getLandSurfacePosition;
     if (!(_surf isEqualTo [])) then {
-        private _pos = ASLToAGL _surf;
-        if (!_excludeTowns || {(nearestLocations [_pos,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo []}) exitWith { _pos };
+        if (!_excludeTowns || {(nearestLocations [ASLToAGL _surf,["NameCity","NameVillage","NameCityCapital","NameLocal"],500]) isEqualTo []}) exitWith { ASLToAGL _surf };
     };
 };
+
+[format ["findLandPosition: failed search around %1 up to %2m", _base, _maxRadius]] call VIC_fnc_debugLog;
 []


### PR DESCRIPTION
## Summary
- expand fn_findLandPosition with optional max radius
- search outward in 50m steps when initial attempts fail
- log failure when no land position can be located
- allow spawnAllAnomalyFields to specify a max search radius

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685170d71080832fb05baf6dbef68e54