### PR TITLE
Rename anomaly field types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Supports common anomaly types like burners, electras, fruit punches and springboards.
 * Relies on **Diwako’s Anomalies** for the core anomaly logic.
 * Fields are distributed randomly across the entire map but avoid towns by 500 meters.
-* Fields can be **Permanent** or **Temporary**. Permanent fields remain in place
-  and only reshuffle their anomalies during an emission. Temporary fields are
+* Fields can be **Stable** or **Unstable**. Stable fields remain in place
+  and only reshuffle their anomalies during an emission. Unstable fields are
   deleted after an emission and respawn at new random positions. The ratio of
-  permanent fields is controlled by `VSA_permanentFieldChance`. Permanent fields
+  stable fields is controlled by `VSA_stableFieldChance`. Stable fields
   also receive thematic names on their map markers. When no towns are nearby the
   names fall back to generic locations like the coast, a hill or a forest based
   on the surrounding terrain.
@@ -175,7 +175,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
 5. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    This option can now be toggled while a mission is running and the debug
    actions will appear automatically.
-6. When debug mode is active, your scroll menu includes options to trigger storms, spawn permanent or temporary anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Permanent fields will show a randomly generated name on their marker for easy reference.
+6. When debug mode is active, your scroll menu includes options to trigger storms, spawn stable or unstable anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Stable fields will show a randomly generated name on their marker for easy reference.
 7. Use the **Mark All Buildings** and **Mark Bridges** actions from this menu if you need to visualize these objects. Buildings are no longer marked automatically when debug mode is enabled.
 
 ## Usage
@@ -187,8 +187,8 @@ All functions are contained under the `functions` directory and follow the `TAG_
 * **VIC_fnc_spawnAllAnomalyFields** – Spawns anomaly fields at random positions
   across the map, marks them and tracks their lifetime. Missions must call this
   function (or use the provided `initServer.sqf`) to populate the world.
-* **VIC_fnc_cycleAnomalyFields** – Reshuffles permanent fields and relocates temporary ones. Useful for testing without a full emission.
-* **VIC_fnc_generateFieldName** – Produces themed names for permanent anomaly field markers using local town names when possible.
+* **VIC_fnc_cycleAnomalyFields** – Reshuffles stable fields and relocates unstable ones. Useful for testing without a full emission.
+* **VIC_fnc_generateFieldName** – Produces themed names for stable anomaly field markers using local town names when possible.
 
 Mission makers can tweak or remove individual systems as needed. Most features are script-only and do not require placing special modules in the editor, though some settings may be exposed through CBA.
 

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -79,9 +79,9 @@
 ] call CBA_fnc_addSetting;
 
 [
-    "VSA_permanentFieldChance",
+    "VSA_stableFieldChance",
     "SLIDER",
-    ["Permanent Field Chance", "Percentage of fields that are permanent"],
+    ["Stable Field Chance", "Percentage of fields that are stable"],
     "Viceroy's STALKER ALife - Anomalies",
     [0, 100, 50, 0]
 ] call CBA_fnc_addSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf
@@ -1,5 +1,5 @@
 /*
-    Reshuffles permanent anomaly fields and relocates temporary ones.
+    Reshuffles stable anomaly fields and relocates unstable ones.
     Called when an emission ends or via debug action.
 */
 
@@ -9,7 +9,7 @@ if (isServer && !isNil "STALKER_anomalyFields") then {
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     for [{_i = 0}, {_i < count STALKER_anomalyFields}, {_i = _i + 1}] do {
         private _entry = STALKER_anomalyFields select _i;
-        _entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_perm"];
+        _entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
         { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
         if (_marker != "") then {
             deleteMarker _marker;
@@ -19,7 +19,7 @@ if (isServer && !isNil "STALKER_anomalyFields") then {
             };
         };
         _objs = [];
-        if (!_perm) then {
+        if (!_stable) then {
             _center = [random worldSize, random worldSize, 0];
             _site = [];
         };
@@ -28,7 +28,7 @@ if (isServer && !isNil "STALKER_anomalyFields") then {
             _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
             _site = getMarkerPos _marker;
             _objs = _spawned;
-            if (_perm && {_marker != ""}) then {
+            if (_stable && {_marker != ""}) then {
                 private _type = switch (_fn) do {
                     case VIC_fnc_createField_burner: {"burner"};
                     case VIC_fnc_createField_electra: {"electra"};
@@ -49,7 +49,7 @@ if (isServer && !isNil "STALKER_anomalyFields") then {
             };
         };
         _exp = diag_tickTime + (_dur * 60);
-        STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_perm]];
+        STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
@@ -2,7 +2,7 @@
     Activates or deactivates anomaly fields based on player proximity and
     removes expired entries.
     STALKER_anomalyFields entries:
-        [center, radius, fn, count, objects, marker, site, expires, permanent]
+        [center, radius, fn, count, objects, marker, site, expires, stable]
 */
 ["manageAnomalyFields"] call VIC_fnc_debugLog;
 
@@ -11,7 +11,7 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 
 for [{_i = (count STALKER_anomalyFields) - 1}, {_i >= 0}, {_i = _i - 1}] do {
     private _entry = STALKER_anomalyFields select _i;
-    _entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_perm"];
+    _entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
 
     if (_exp >= 0 && {diag_tickTime > _exp}) then {
         { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
@@ -47,7 +47,7 @@ for [{_i = (count STALKER_anomalyFields) - 1}, {_i >= 0}, {_i = _i - 1}] do {
         };
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
-    STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_perm]];
+    STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
 };
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -6,7 +6,7 @@
     Params:
         0: POSITION or OBJECT - (ignored) kept for backward compatibility
         1: NUMBER             - (ignored) kept for backward compatibility
-        2: NUMBER             - forces permanent (1) or temporary (0) fields
+        2: NUMBER             - forces stable (1) or unstable (0) fields
 */
 params ["_center","_radius", ["_type", -1]];
 
@@ -27,7 +27,7 @@ private _maxFields = ["VSA_maxAnomalyFields", 20] call VIC_fnc_getSetting;
 
 private _fieldCount = ["VSA_anomalyFieldCount", 3] call VIC_fnc_getSetting;
 private _spawnWeight = ["VSA_anomalySpawnWeight", 50] call VIC_fnc_getSetting;
-private _permChance  = ["VSA_permanentFieldChance", 50] call VIC_fnc_getSetting;
+private _stableChance  = ["VSA_stableFieldChance", 50] call VIC_fnc_getSetting;
 private _nightOnly   = ["VSA_anomalyNightOnly", false] call VIC_fnc_getSetting;
 
 if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {
@@ -83,7 +83,7 @@ for "_i" from 1 to _fieldCount do {
     };
 
     [format ["spawnAllAnomalyFields: attempting %1", _typeName]] call VIC_fnc_debugLog;
-    private _permanent = if (_type == -1) then { (random 100) < _permChance } else { _type == 1 };
+    private _stable = if (_type == -1) then { (random 100) < _stableChance } else { _type == 1 };
 
     private _spawned = [_pos, 75] call _fn;
     if (_spawned isEqualTo []) then {
@@ -95,14 +95,14 @@ for "_i" from 1 to _fieldCount do {
     private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
     if (_marker != "") then {
         _marker setMarkerAlpha 0.2;
-        if (_permanent) then {
+        if (_stable) then {
             _marker setMarkerText ([_typeName, _site] call VIC_fnc_generateFieldName);
         };
     };
 
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
-    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_site,_exp,_permanent];
+    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_site,_exp,_stable];
     [format ["spawnAllAnomalyFields: spawned %1 %2", count _spawned, _typeName]] call VIC_fnc_debugLog;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -48,7 +48,7 @@ player addAction ["<t color='#ff0000'>Spawn Valley Chemicals</t>", {
         [getPos player, 200] remoteExec ["VIC_fnc_spawnValleyChemicalZones", 2];
     };
 }];
-player addAction ["<t color='#ff0000'>Spawn Permanent Fields</t>", {
+player addAction ["<t color='#ff0000'>Spawn Stable Fields</t>", {
     for "_i" from 1 to 100 do {
         private _pos = [random worldSize, random worldSize, 0];
         if (isServer) then {
@@ -58,7 +58,7 @@ player addAction ["<t color='#ff0000'>Spawn Permanent Fields</t>", {
         };
     };
 }];
-player addAction ["<t color='#ff0000'>Spawn Temporary Fields</t>", {
+player addAction ["<t color='#ff0000'>Spawn Unstable Fields</t>", {
     for "_i" from 1 to 100 do {
         private _pos = [random worldSize, random worldSize, 0];
         if (isServer) then {


### PR DESCRIPTION
## Summary
- rename Permanent and Temporary fields to Stable and Unstable
- adjust CBA setting name and description
- update debug actions for spawning fields
- update anomaly field management scripts
- revise docs for new terminology

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/cba_settings.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851b273563c832f9990672f5b3fbe08