### PR TITLE
Fix land position search

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -38,9 +38,9 @@ while {_searchRadius <= _maxRadius} do {
             [_base, random _searchRadius, random 360] call BIS_fnc_relPos
         };
 
-        private _from = _candidate vectorAdd [0,0,1000];
-        private _to   = _candidate vectorAdd [0,0,-1000];
-        private _hit  = lineIntersectsSurfaces [_from,_to,objNull,objNull,true,1,"GEOM","NONE"];
+        private _from = AGLToASL (_candidate vectorAdd [0,0,1000]);
+        private _to   = AGLToASL (_candidate vectorAdd [0,0,-1000]);
+        private _hit  = lineIntersectsSurfaces [_from, _to, objNull, objNull, true, 1, "GEOM", "NONE"];
         if (!(_hit isEqualTo [])) then {
             private _surf = (_hit select 0) select 0;
             if (!((ASLToAGL _surf) call VIC_fnc_isWaterPosition)) then {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getSurfacePosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getSurfacePosition.sqf
@@ -12,8 +12,8 @@ _pos params ["_x","_y",["_z",0]];
 
 // Cast a vertical ray well above and below the target to ensure we hit any
 // surface such as rooftops or raised platforms.
-private _from = [_x, _y, 1000];
-private _to   = [_x, _y, -1000];
+private _from = AGLToASL [_x, _y, 1000];
+private _to   = AGLToASL [_x, _y, -1000];
 
 private _hit = lineIntersectsSurfaces [_from, _to, objNull, objNull, true, 1, "GEOM", "NONE"];
 if (_hit isEqualTo []) exitWith { AGLToASL [_x, _y, 0] };


### PR DESCRIPTION
## Summary
- fix vertical raycasts not using ASL coordinates

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_getSurfacePosition.sqf` *(warnings only)*

------
https://chatgpt.com/codex/tasks/task_e_6851e547e584832f9402ec8afdaea20d