### PR TITLE
Add option to disable Antistasi weather

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ When Antistasi Ultimate is detected, several helper functions can create side mi
 * **VIC_fnc_startMutantHunt** – awards money for each mutant killed during the hunt period.
 * **VIC_fnc_startArtefactHunt** – places an artefact in an existing anomaly field and tasks players to retrieve it.
 * **VIC_fnc_startChemSample** – chooses a chemical zone and requires players to stay inside for 90 seconds to collect samples.
+* The CBA setting **VSA_disableA3UWeather** stops Antistasi's `AU_persistentWeather` script when enabled.
 
 These helpers do nothing if Antistasi Ultimate is not loaded.
 

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -737,6 +737,17 @@ true
     "Viceroy's STALKER ALife - Wrecks",
     [0, 50, 10, 0]
 ] call CBA_fnc_addSetting;
+
+// -----------------------------------------------------------------------------
+// Antistasi Integration
+// -----------------------------------------------------------------------------
+[
+    "VSA_disableA3UWeather",
+    "CHECKBOX",
+    ["Disable Antistasi Weather", "Stop Antistasi persistent weather script"],
+    "Viceroy's STALKER ALife - Antistasi",
+    false
+] call CBA_fnc_addSetting;
 // -----------------------------------------------------------------------------
 // Debug
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -216,6 +216,7 @@ class CfgFunctions
             class startChemSample{};
             class completeArtefactHunt{};
             class completeChemSample{};
+            class disableWeather{};
         };
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_disableWeather.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/antistasi/fn_disableWeather.sqf
@@ -1,0 +1,21 @@
+/*
+    Disables the Antistasi persistent weather script when the mod is loaded.
+
+    Returns:
+        BOOL - true if any weather scripts were disabled
+*/
+
+if !(call VIC_fnc_isAntistasiUltimate) exitWith {false};
+if (!isServer) exitWith {false};
+
+["Disabling Antistasi persistent weather"] call VIC_fnc_debugLog;
+
+private _changed = false;
+
+// Disable Antistasi persistent weather script if present
+if (!isNil "AU_persistentWeather") then {
+    missionNamespace setVariable ["AU_persistentWeather", nil];
+    _changed = true;
+};
+
+_changed

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -178,10 +178,14 @@ VIC_fnc_startArtefactHunt    = compile preprocessFileLineNumbers (_root + "\func
 VIC_fnc_startChemSample      = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_startChemSample.sqf");
 VIC_fnc_completeArtefactHunt = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_completeArtefactHunt.sqf");
 VIC_fnc_completeChemSample   = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_completeChemSample.sqf");
+VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_disableWeather.sqf");
 
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
     [] call VIC_fnc_registerEmissionHooks;
+    if (call VIC_fnc_isAntistasiUltimate && { ["VSA_disableA3UWeather", false] call VIC_fnc_getSetting }) then {
+        [] call VIC_fnc_disableA3UWeather;
+    };
     if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {
     [
         {


### PR DESCRIPTION
## Summary
- disable Antistasi persistent weather when `VSA_disableA3UWeather` is enabled

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/cba_settings.sqf addons/Viceroys-STALKER-ALife/functions/antistasi/fn_disableWeather.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851e10f7538832f83f848ab1d62d29a