### PR TITLE
Fix findLand bounds and add town radius setting

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -31,6 +31,22 @@
     false
 ] call CBA_fnc_addSetting;
 
+[
+    "VSA_townRadius",
+    "SLIDER",
+    ["Town Radius", "Distance considered inside a town"],
+    "Viceroy's STALKER ALife - Core",
+    [0, 1500, 500, 0]
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_townHysteresis",
+    "SLIDER",
+    ["Town Hysteresis", "Extra distance beyond town radius for debug markers"],
+    "Viceroy's STALKER ALife - Core",
+    [0, 1000, 200, 0]
+] call CBA_fnc_addSetting;
+
 
 
 


### PR DESCRIPTION
## Summary
- prevent `findLandPosition` from searching outside map boundaries
- show debug markers near towns using blue and orange markers
- expose configurable `VSA_townHysteresis` CBA setting
- add `VSA_townRadius` CBA setting and use it in `findLandPosition`

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/cba_settings.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6851ee6e97f4832fa656484aa0609858