### PR TITLE
Add crossroad markers for road finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    This option can now be toggled while a mission is running and the debug
    actions will appear automatically.
 6. When debug mode is active, your scroll menu includes options to trigger storms, spawn stable or unstable anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Stable fields will show a randomly generated name on their marker for easy reference.
-7. Use the **Mark All Buildings** and **Mark Bridges** actions from this menu if you need to visualize these objects. Buildings are no longer marked automatically when debug mode is enabled.
+7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
 
 ## Usage
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
@@ -1,0 +1,41 @@
+/*
+    Identifies road positions that connect to three or more other road segments.
+
+    Params:
+        0: ARRAY - List of road positions. If empty, uses VIC_fnc_findRoads.
+
+    Returns:
+        ARRAY of positions on crossroads in AGL coordinates
+*/
+params [["_roads", []]];
+
+if (_roads isEqualTo []) then {
+    _roads = [] call VIC_fnc_findRoads;
+};
+
+[format ["findCrossroads scanning %1 points", count _roads]] call VIC_fnc_debugLog;
+
+private _crossroads = [];
+
+{
+    private _roadObj = roadAt _x;
+    if (isNull _roadObj) then {
+        private _near = _x nearRoads 5;
+        if ((count _near) > 0) then { _roadObj = _near select 0; };
+    };
+    if (!isNull _roadObj) then {
+        private _connections = roadsConnectedTo _roadObj;
+        if ((count _connections) >= 3) then {
+            private _pos = getPosATL _roadObj;
+            private _dup = false;
+            {
+                if (_x distance _pos < 5) exitWith { _dup = true };
+            } forEach _crossroads;
+            if (!_dup) then { _crossroads pushBack _pos; };
+        };
+    };
+} forEach _roads;
+
+[format ["findCrossroads found %1 crossroads", count _crossroads]] call VIC_fnc_debugLog;
+
+_crossroads

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf
@@ -7,19 +7,29 @@
 ["markRoads"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_roadMarkers") then { STALKER_roadMarkers = [] };
+if (isNil "STALKER_crossroadMarkers") then { STALKER_crossroadMarkers = [] };
 
 // Remove any existing markers
 {
     if (_x != "") then { deleteMarker _x };
 } forEach STALKER_roadMarkers;
 STALKER_roadMarkers = [];
+{ if (_x != "") then { deleteMarker _x }; } forEach STALKER_crossroadMarkers;
+STALKER_crossroadMarkers = [];
 
 private _roads = [] call VIC_fnc_findRoads;
+private _crossroads = [_roads] call VIC_fnc_findCrossroads;
 
 {
     private _name = format ["road_%1_%2", diag_tickTime, _forEachIndex];
     private _mkr = [_name, _x, "ICON", "mil_dot", "ColorOrange"] call VIC_fnc_createGlobalMarker;
     STALKER_roadMarkers pushBack _mkr;
 } forEach _roads;
+
+{
+    private _name = format ["crossroad_%1_%2", diag_tickTime, _forEachIndex];
+    private _mkr = [_name, _x, "ICON", "mil_triangle", "ColorRed"] call VIC_fnc_createGlobalMarker;
+    STALKER_crossroadMarkers pushBack _mkr;
+} forEach _crossroads;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -49,6 +49,7 @@ VIC_fnc_selectWeightedBuilding = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_findBridges            = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBridges.sqf");
 VIC_fnc_markBridges            = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markBridges.sqf");
 VIC_fnc_findRoads             = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRoads.sqf");
+VIC_fnc_findCrossroads        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findCrossroads.sqf");
 VIC_fnc_markRoads             = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markRoads.sqf");
 VIC_fnc_findHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findHiddenPosition.sqf");
 VIC_fnc_markHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markHiddenPosition.sqf");


### PR DESCRIPTION
## Summary
- support crossroad detection
- mark crossroads when marking roads
- expose new finder in master init
- document new debug action usage

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851f03040fc832fbc018f084eac8170