### PR TITLE
Fix breakout error in land position search

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -44,6 +44,7 @@ private _searchRadius = 0;
 
 private _found = [];
 
+scopeName "findLand";
 while {_searchRadius <= _maxRadius && {_found isEqualTo []}} do {
     for "_i" from 0 to _attempts do {
         private _candidate = if (_searchRadius == 0 && {_i == 0}) then {
@@ -86,7 +87,7 @@ while {_searchRadius <= _maxRadius && {_found isEqualTo []}} do {
                         STALKER_findLandMarkers pushBack _marker;
                     };
                     _found = ASLToAGL _surf;
-                    breakOut 2;
+                    breakOut "findLand";
                 };
             };
         };


### PR DESCRIPTION
## Summary
- label the loop scope in `fn_findLandPosition.sqf`
- use `breakOut "findLand"` to exit the search loops

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851f3c53aa0832f997dbb1be3c124cc