### PR TITLE
Add valley debug markers

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_findValleyPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_findValleyPosition.sqf
@@ -12,6 +12,13 @@ params ["_center", ["_radius",50], ["_step",10]];
 
 ["findValleyPosition"] call VIC_fnc_debugLog;
 
+private _debug = ["VSA_debugMode", false] call VIC_fnc_getSetting;
+if (_debug && {isServer}) then {
+    if (isNil "STALKER_valleySearchMarkers") then { STALKER_valleySearchMarkers = [] };
+    { if (_x != "") then { deleteMarker _x } } forEach STALKER_valleySearchMarkers;
+    STALKER_valleySearchMarkers = [];
+};
+
 private _base = if (_center isEqualType objNull) then { getPos _center } else { _center };
 private _bestPos = [];
 private _bestHeight = 1e9;
@@ -27,6 +34,12 @@ for "_xOff" from -_radius to _radius step _step do {
             _bestHeight = _h;
         };
     };
+};
+
+if (_debug && {isServer && { !(_bestPos isEqualTo []) }}) then {
+    private _name = format ["valleyPos_%1", diag_tickTime + random 1000];
+    private _m = [_name, ASLToAGL _bestPos, "ICON", "mil_triangle", "ColorBlue"] call VIC_fnc_createGlobalMarker;
+    STALKER_valleySearchMarkers pushBack _m;
 };
 
 _bestPos

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
@@ -12,6 +12,13 @@
 */
 params ["_center","_radius", ["_count",-1], ["_duration",-1], ["_clusterSize",3]];
 
+private _debug = ["VSA_debugMode", false] call VIC_fnc_getSetting;
+if (_debug && {isServer}) then {
+    if (isNil "STALKER_valleyBaseMarkers") then { STALKER_valleyBaseMarkers = [] };
+    { if (_x != "") then { deleteMarker _x } } forEach STALKER_valleyBaseMarkers;
+    STALKER_valleyBaseMarkers = [];
+};
+
 ["spawnValleyChemicalZones"] call VIC_fnc_debugLog;
 
 if (["VSA_enableChemicalZones", true] call VIC_fnc_getSetting isEqualTo false) exitWith {
@@ -33,7 +40,17 @@ for "_i" from 1 to _count do {
     private _ang = random 360;
     private _dist = random _radius;
     private _base = [(_centerPos select 0) + _dist * sin _ang, (_centerPos select 1) + _dist * cos _ang, _centerPos select 2];
+    if (_debug && {isServer}) then {
+        private _name = format ["valleyBase_%1", diag_tickTime + random 1000];
+        private _m = [_name, _base, "ICON", "mil_dot", "ColorOrange"] call VIC_fnc_createGlobalMarker;
+        STALKER_valleyBaseMarkers pushBack _m;
+    };
     private _pos = [_base, 30, 10] call VIC_fnc_findValleyPosition;
+    if (_debug && {isServer && { !(_pos isEqualTo []) }}) then {
+        private _name = format ["valleyAnchor_%1", diag_tickTime + random 1000];
+        private _m = [_name, ASLToAGL _pos, "ICON", "mil_triangle", "ColorYellow"] call VIC_fnc_createGlobalMarker;
+        STALKER_valleyBaseMarkers pushBack _m;
+    };
     if (_pos isEqualTo []) then { continue };
 
     for "_j" from 1 to _clusterSize do {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -18,6 +18,13 @@
 
 params [["_step", 250], ["_depthThreshold", 15], ["_maxRadius", 750]];
 
+private _debug = ["VSA_debugMode", false] call VIC_fnc_getSetting;
+if (_debug && {isServer}) then {
+    if (isNil "STALKER_valleySeedMarkers") then { STALKER_valleySeedMarkers = [] };
+    { if (_x != "") then { deleteMarker _x } } forEach STALKER_valleySeedMarkers;
+    STALKER_valleySeedMarkers = [];
+};
+
 ["findValleys"] call VIC_fnc_debugLog;
 
 private _valleys = [];
@@ -77,8 +84,15 @@ for "_gx" from 0 to worldSize step _step do {
 
         if (count _valley > 0) then {
             _valleys pushBack _valley;
+            if (_debug && {isServer}) then {
+                private _name = format ["valleySeed_%1", diag_tickTime + random 1000];
+                private _m = [_name, _lowestPos, "ICON", "mil_dot", "ColorBlue"] call VIC_fnc_createGlobalMarker;
+                STALKER_valleySeedMarkers pushBack _m;
+            };
         };
     };
 };
+
+[format ["findValleys: found %1 valleys", count _valleys]] call VIC_fnc_debugLog;
 
 _valleys

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
@@ -16,6 +16,7 @@ if (isNil "STALKER_valleyMarkers") then { STALKER_valleyMarkers = [] };
 STALKER_valleyMarkers = [];
 
 private _valleys = [] call VIC_fnc_findValleys;
+[format ["markValleys: %1 valleys", count _valleys]] call VIC_fnc_debugLog;
 
 {
     private _area = _x;


### PR DESCRIPTION
## Summary
- show debug markers while scanning for valleys
- visualize valley position search
- mark anchor positions when spawning valley chemical zones
- log number of valleys found

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/chemical/fn_findValleyPosition.sqf addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851f8d83a40832fbe279c2ec019edbf