### PR TITLE
Fix marker parameter checks

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
@@ -24,6 +24,11 @@ params [
     ["_size", [1,1]]
 ];
 
+if (isNil {_name} || { isNil {_pos} }) exitWith {
+    ["createGlobalMarker: missing name or position"] call VIC_fnc_debugLog;
+    ""
+};
+
 [format ["createGlobalMarker %1 @ %2", _name, _pos]] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith { _name };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createLocalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createLocalMarker.sqf
@@ -24,6 +24,11 @@ params [
     ["_size", [1,1]]
 ];
 
+if (isNil {_name} || { isNil {_pos} }) exitWith {
+    ["createLocalMarker: missing name or position"] call VIC_fnc_debugLog;
+    ""
+};
+
 private _marker = createMarker [_name, _pos];
 _marker setMarkerShape _shape;
 _marker setMarkerSize _size;


### PR DESCRIPTION
## Summary
- make sure marker creation functions fail early when `nil` params are passed

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_createLocalMarker.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851fb0bd840832f94d40bc3a3ad3f4a