### PR TITLE
Fix candidate variable in findLandPosition

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -43,11 +43,12 @@ private _step = _radius max 1;
 private _searchRadius = 0;
 
 private _found = [];
+private _candidate = [];
 
 scopeName "findLand";
 while {_searchRadius <= _maxRadius && {_found isEqualTo []}} do {
     for "_i" from 0 to _attempts do {
-        private _candidate = if (_searchRadius == 0 && {_i == 0}) then {
+        _candidate = if (_searchRadius == 0 && {_i == 0}) then {
             _base
         } else {
             [_base, random _searchRadius, random 360] call BIS_fnc_relPos


### PR DESCRIPTION
## Summary
- declare `_candidate` variable outside search loop so it's scoped to the whole function
- assign to `_candidate` inside the loop

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851fb3e3920832fb88a8fd49725e035