### PR TITLE
Add spawnable sniper event

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -86,6 +86,7 @@ class CfgFunctions
             class spawnAmbientStalkers{};
             class spawnStalkerCamp{};
             class spawnStalkerCamps{};
+            class spawnSniper{};
             class manageStalkerCamps{};
         };
 
@@ -241,6 +242,7 @@ class CfgRemoteExec
         class VIC_fnc_spawnAmbientHerds   { allowedTargets = 2; };
         class VIC_fnc_spawnAmbientStalkers { allowedTargets = 2; };
         class VIC_fnc_spawnStalkerCamps   { allowedTargets = 2; };
+        class VIC_fnc_spawnSniper         { allowedTargets = 2; };
         class VIC_fnc_spawnPredatorAttack { allowedTargets = 2; };
         class VIC_fnc_spawnMinefields     { allowedTargets = 2; };
         class VIC_fnc_spawnBoobyTraps     { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -173,6 +173,7 @@ VIC_fnc_findRandomRoadPosition  = compile preprocessFileLineNumbers (_root + "\f
 VIC_fnc_spawnAmbientStalkers   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnAmbientStalkers.sqf");
 VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamp.sqf");
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
+VIC_fnc_spawnSniper           = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnSniper.sqf");
 VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageStalkerCamps.sqf");
 
 VIC_fnc_isAntistasiUltimate  = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_isAntistasiUltimate.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -127,6 +127,13 @@ player addAction ["<t color='#ff0000'>Spawn Stalker Camps</t>", {
         [getPos player, 300] remoteExec ["VIC_fnc_spawnStalkerCamps", 2];
     };
 }];
+player addAction ["<t color='#ff0000'>Spawn Sniper</t>", {
+    if (isServer) then {
+        [getPos player] call VIC_fnc_spawnSniper;
+    } else {
+        [getPos player] remoteExec ["VIC_fnc_spawnSniper", 2];
+    };
+}];
 player addAction ["<t color='#ff0000'>Spawn Predator Attack</t>", {
     if (isServer) then {
         [player] call VIC_fnc_spawnPredatorAttack;

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
@@ -1,0 +1,38 @@
+/*
+    Spawns a single sniper at the nearest detected sniper spot to a position.
+    The unit holds that position using BIS_fnc_taskDefend.
+
+    Params:
+        0: POSITION - center position to search from (default: position of the caller)
+*/
+
+params [["_center", [0,0,0]]];
+
+["spawnSniper"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+if (isNil "STALKER_snipers") then { STALKER_snipers = [] };
+
+private _spots = [] call VIC_fnc_findSniperSpots;
+if (_spots isEqualTo []) exitWith {
+    ["spawnSniper: no sniper spots found"] call VIC_fnc_debugLog;
+};
+
+private _spot = [_spots, _center] call BIS_fnc_nearestPosition;
+if (isNil {_spot}) exitWith {
+    ["spawnSniper: unable to select position"] call VIC_fnc_debugLog;
+};
+
+private _grp = createGroup east;
+_grp createUnit ["O_sniper_F", _spot, [], 0, "FORM"];
+[_grp, _spot] call BIS_fnc_taskDefend;
+
+private _marker = "";
+if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+    _marker = format ["snp_%1", diag_tickTime];
+    [_marker, _spot, "ICON", "mil_triangle", "ColorRed", 0.6, "Sniper"] call VIC_fnc_createGlobalMarker;
+};
+
+STALKER_snipers pushBack [_grp, _spot, _marker];
+


### PR DESCRIPTION
## Summary
- allow spawning a sniper onto the nearest sniper spot
- expose the new function to the engine and debug menu

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/config.cpp addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6851fcfb8090832fb509b3b70a90ae1a