### PR TITLE
Add wreck caching helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    actions will appear automatically.
 6. When debug mode is active, your scroll menu includes options to trigger storms, spawn stable or unstable anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Stable fields will show a randomly generated name on their marker for easy reference.
 7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
+8. **Cache Map Wrecks** to collect all wreck objects placed on the map. This action populates `STALKER_wrecks` for other functions.
 
 ## Usage
 

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -121,6 +121,7 @@ class CfgFunctions
         {
             file = "Viceroys-STALKER-ALife\functions\wrecks";
             class spawnAbandonedVehicles{};
+            class findWrecks{};
         };
 
         class Ambushes

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -120,6 +120,7 @@ VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnBoobyTraps        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnBoobyTraps.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
+VIC_fnc_findWrecks           = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_findWrecks.sqf");
 VIC_fnc_startMinefieldManager  = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_startMinefieldManager.sqf");
 VIC_fnc_spawnAmbushes          = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_spawnAmbushes.sqf");
 VIC_fnc_manageAmbushes         = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_manageAmbushes.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -283,6 +283,13 @@ player addAction ["<t color='#ffff00'>Mark Roads</t>", {
         [] remoteExec ["VIC_fnc_markRoads", 2];
     };
 }];
+player addAction ["<t color='#ffff00'>Cache Map Wrecks</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findWrecks;
+    } else {
+        [] remoteExec ["VIC_fnc_findWrecks", 2];
+    };
+}];
 
 ["Debug actions added"] call VIC_fnc_debugLog;
 

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
@@ -1,0 +1,21 @@
+/*
+    Scans the map for wreck objects and stores them in STALKER_wrecks
+    for use by other functions.
+    Returns: ARRAY of wreck objects found
+*/
+
+["findWrecks"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { [] };
+
+// gather all objects and filter by class name
+private _center = [worldSize / 2, worldSize / 2, 0];
+private _objs = nearestObjects [_center, ["AllVehicles","Static"], worldSize];
+private _found = _objs select { toLower typeOf _x find "wreck" > -1 };
+
+if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
+{ if !(_x in STALKER_wrecks) then { STALKER_wrecks pushBack _x } } forEach _found;
+
+[format ["findWrecks: %1 wrecks cached", count _found]] call VIC_fnc_debugLog;
+
+_found


### PR DESCRIPTION
## Summary
- add `VIC_fnc_findWrecks` to gather map wrecks
- compile new function in master init and register in config
- expose a **Cache Map Wrecks** debug action
- document the new action in the README

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685204ec8f54832fa7c98c48bd71cd8e