### PR TITLE
Add caching for map feature positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
 6. When debug mode is active, your scroll menu includes options to trigger storms, spawn stable or unstable anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Stable fields will show a randomly generated name on their marker for easy reference.
 7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
 8. **Cache Map Wrecks** to collect all wreck objects placed on the map. This action populates `STALKER_wrecks` for other functions.
+9. Additional **Cache** actions can store sniper spots, roads, crossroads, bridges, valleys, beach sites and swamps for quick access by other scripts.
 
 ## Usage
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
@@ -56,4 +56,9 @@ for "_x" from 0 to _size step _step do {
 
 ["fn_findBeachesInMap completed"] call VIC_fnc_debugLog;
 
+// Cache results for later use
+if (isNil "STALKER_beachSpots") then { STALKER_beachSpots = [] };
+{ if !(_x in STALKER_beachSpots) then { STALKER_beachSpots pushBack _x } } forEach _spots;
+
 _spots
+

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
@@ -54,4 +54,8 @@ for "_x" from 0 to _size step _step do {
     };
 };
 
+// Cache results for later use
+if (isNil "STALKER_bridges") then { STALKER_bridges = [] };
+{ if !(_x in STALKER_bridges) then { STALKER_bridges pushBack _x } } forEach _found;
+
 _found

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
@@ -38,4 +38,9 @@ private _crossroads = [];
 
 [format ["findCrossroads found %1 crossroads", count _crossroads]] call VIC_fnc_debugLog;
 
+// Cache results for later use
+if (isNil "STALKER_crossroads") then { STALKER_crossroads = [] };
+{ if !(_x in STALKER_crossroads) then { STALKER_crossroads pushBack _x } } forEach _crossroads;
+
 _crossroads
+

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
@@ -25,4 +25,9 @@ for "_xCoord" from 0 to worldSize step _step do {
 
 ["findRoads completed"] call VIC_fnc_debugLog;
 
+// Cache results for later use
+if (isNil "STALKER_roads") then { STALKER_roads = [] };
+{ if !(_x in STALKER_roads) then { STALKER_roads pushBack _x } } forEach _roads;
+
 _roads
+

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf
@@ -50,4 +50,9 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
     };
 } forEach _buildings;
 
+// Cache results for later use
+if (isNil "STALKER_sniperSpots") then { STALKER_sniperSpots = [] };
+{ if !(_x in STALKER_sniperSpots) then { STALKER_sniperSpots pushBack _x } } forEach _sniperSpots;
+
 _sniperSpots
+

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
@@ -54,4 +54,9 @@ for "_x" from 0 to worldSize step _step do {
     };
 };
 
+// Cache results for later use
+if (isNil "STALKER_swamps") then { STALKER_swamps = [] };
+{ if !(_x in STALKER_swamps) then { STALKER_swamps pushBack _x } } forEach _swamps;
+
 _swamps
+

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -95,4 +95,9 @@ for "_gx" from 0 to worldSize step _step do {
 
 [format ["findValleys: found %1 valleys", count _valleys]] call VIC_fnc_debugLog;
 
+// Cache results for later use
+if (isNil "STALKER_valleys") then { STALKER_valleys = [] };
+{ if !(_x in STALKER_valleys) then { STALKER_valleys pushBack _x } } forEach _valleys;
+
 _valleys
+

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -290,6 +290,55 @@ player addAction ["<t color='#ffff00'>Cache Map Wrecks</t>", {
         [] remoteExec ["VIC_fnc_findWrecks", 2];
     };
 }];
+player addAction ["<t color='#ffff00'>Cache Sniper Spots</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findSniperSpots;
+    } else {
+        [] remoteExec ["VIC_fnc_findSniperSpots", 2];
+    };
+}];
+player addAction ["<t color='#ffff00'>Cache Roads</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findRoads;
+    } else {
+        [] remoteExec ["VIC_fnc_findRoads", 2];
+    };
+}];
+player addAction ["<t color='#ffff00'>Cache Crossroads</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findCrossroads;
+    } else {
+        [] remoteExec ["VIC_fnc_findCrossroads", 2];
+    };
+}];
+player addAction ["<t color='#ffff00'>Cache Bridges</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findBridges;
+    } else {
+        [] remoteExec ["VIC_fnc_findBridges", 2];
+    };
+}];
+player addAction ["<t color='#ffff00'>Cache Valleys</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findValleys;
+    } else {
+        [] remoteExec ["VIC_fnc_findValleys", 2];
+    };
+}];
+player addAction ["<t color='#ffff00'>Cache Beach Spots</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findBeachesInMap;
+    } else {
+        [] remoteExec ["VIC_fnc_findBeachesInMap", 2];
+    };
+}];
+player addAction ["<t color='#ffff00'>Cache Swamps</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_findSwamps;
+    } else {
+        [] remoteExec ["VIC_fnc_findSwamps", 2];
+    };
+}];
 
 ["Debug actions added"] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- store results from `findRoads`, `findCrossroads`, `findSniperSpots`, `findValleys`, `findBeachesInMap`, `findSwamps` and `findBridges`
- expose debug actions for caching these map features
- document new cache actions in README

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf >/tmp/sqflint.log && tail -n 20 /tmp/sqflint.log`

------
https://chatgpt.com/codex/tasks/task_e_685207158fac832f8584e20667980401