### PR TITLE
Fix land position errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
 7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
 8. **Cache Map Wrecks** to collect all wreck objects placed on the map. This action populates `STALKER_wrecks` for other functions.
 
+### Debug Mode
+Debugging features are controlled by the `VSA_debugMode` setting. When enabled,
+additional actions appear in the scroll menu and extra markers help visualize
+anomaly placement. Toggle this option through the CBA settings menu or by
+setting the mission variable before initialization.
+
 ## Usage
 
 All functions are contained under the `functions` directory and follow the `TAG_fnc_functionName` convention. Key entry points include:

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -55,6 +55,13 @@ while {_searchRadius <= _maxRadius && {_found isEqualTo []}} do {
         };
 
         if (
+            isNil "_candidate" ||
+            {!(_candidate isEqualType [])} ||
+            {count _candidate < 2}
+        ) then { continue; };
+
+
+        if (
             (_candidate select 0 < 0) ||
             { _candidate select 1 < 0 } ||
             { _candidate select 0 > _worldSize } ||
@@ -62,17 +69,19 @@ while {_searchRadius <= _maxRadius && {_found isEqualTo []}} do {
         ) then { continue; };
 
         if (_debug && {isServer}) then {
-            private _towns = nearestLocations [_candidate, ["NameCity","NameVillage","NameCityCapital","NameLocal"], _townRadius + _townHysteresis];
-            private _dist = if (_towns isEqualTo []) then { 1e9 } else { _candidate distance (locationPosition (_towns select 0)) };
-            private _color = "ColorRed";
-            if (_dist <= _townRadius) then {
-                _color = "ColorBlue";
-            } else {
-                if (_dist <= (_townRadius + _townHysteresis)) then { _color = "ColorOrange"; };
+            if (_candidate isEqualType [] && {count _candidate >= 2}) then {
+                private _towns = nearestLocations [_candidate, ["NameCity","NameVillage","NameCityCapital","NameLocal"], _townRadius + _townHysteresis];
+                private _dist = if (_towns isEqualTo []) then { 1e9 } else { _candidate distance (locationPosition (_towns select 0)) };
+                private _color = "ColorRed";
+                if (_dist <= _townRadius) then {
+                    _color = "ColorBlue";
+                } else {
+                    if (_dist <= (_townRadius + _townHysteresis)) then { _color = "ColorOrange"; };
+                };
+                private _name = format ["land_%1", diag_tickTime + random 1000];
+                private _marker = [_name, _candidate, "ICON", "mil_dot", _color, 0.2] call VIC_fnc_createGlobalMarker;
+                STALKER_findLandMarkers pushBack _marker;
             };
-            private _name = format ["land_%1", diag_tickTime + random 1000];
-            private _marker = [_name, _candidate, "ICON", "mil_dot", _color, 0.2] call VIC_fnc_createGlobalMarker;
-            STALKER_findLandMarkers pushBack _marker;
         };
 
         private _from = AGLToASL (_candidate vectorAdd [0,0,1000]);


### PR DESCRIPTION
## Summary
- avoid passing invalid `_candidate` when searching for land
- skip marker creation unless candidate is valid
- document debug mode setting

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685203cf0ac4832fa2f54ef8523788b8