### PR TITLE
Enable markers for cache actions

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -51,6 +51,7 @@ VIC_fnc_markBridges            = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_findRoads             = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRoads.sqf");
 VIC_fnc_findCrossroads        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findCrossroads.sqf");
 VIC_fnc_markRoads             = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markRoads.sqf");
+VIC_fnc_markWrecks            = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_markWrecks.sqf");
 VIC_fnc_findHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findHiddenPosition.sqf");
 VIC_fnc_markHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markHiddenPosition.sqf");
 VIC_fnc_findBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBuildingCoverSpot.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -286,57 +286,73 @@ player addAction ["<t color='#ffff00'>Mark Roads</t>", {
 player addAction ["<t color='#ffff00'>Cache Map Wrecks</t>", {
     if (isServer) then {
         [] call VIC_fnc_findWrecks;
+        [] call VIC_fnc_markWrecks;
     } else {
         [] remoteExec ["VIC_fnc_findWrecks", 2];
+        [] remoteExec ["VIC_fnc_markWrecks", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Sniper Spots</t>", {
     if (isServer) then {
         [] call VIC_fnc_findSniperSpots;
+        [] call VIC_fnc_markSniperSpots;
     } else {
         [] remoteExec ["VIC_fnc_findSniperSpots", 2];
+        [] remoteExec ["VIC_fnc_markSniperSpots", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Roads</t>", {
     if (isServer) then {
         [] call VIC_fnc_findRoads;
+        [] call VIC_fnc_markRoads;
     } else {
         [] remoteExec ["VIC_fnc_findRoads", 2];
+        [] remoteExec ["VIC_fnc_markRoads", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Crossroads</t>", {
     if (isServer) then {
         [] call VIC_fnc_findCrossroads;
+        [] call VIC_fnc_markRoads;
     } else {
         [] remoteExec ["VIC_fnc_findCrossroads", 2];
+        [] remoteExec ["VIC_fnc_markRoads", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Bridges</t>", {
     if (isServer) then {
         [] call VIC_fnc_findBridges;
+        [] call VIC_fnc_markBridges;
     } else {
         [] remoteExec ["VIC_fnc_findBridges", 2];
+        [] remoteExec ["VIC_fnc_markBridges", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Valleys</t>", {
     if (isServer) then {
         [] call VIC_fnc_findValleys;
+        [] call VIC_fnc_markValleys;
     } else {
         [] remoteExec ["VIC_fnc_findValleys", 2];
+        [] remoteExec ["VIC_fnc_markValleys", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Beach Spots</t>", {
     if (isServer) then {
         [] call VIC_fnc_findBeachesInMap;
+        [] call VIC_fnc_markBeaches;
     } else {
         [] remoteExec ["VIC_fnc_findBeachesInMap", 2];
+        [] remoteExec ["VIC_fnc_markBeaches", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Swamps</t>", {
     if (isServer) then {
         [] call VIC_fnc_findSwamps;
+        [] call VIC_fnc_markSwamps;
     } else {
         [] remoteExec ["VIC_fnc_findSwamps", 2];
+        [] remoteExec ["VIC_fnc_markSwamps", 2];
     };
 }];
 

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_markWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_markWrecks.sqf
@@ -1,0 +1,27 @@
+/*
+    Marks cached wreck positions on the map when debugging is enabled.
+
+    Returns: BOOL
+*/
+
+["markWrecks"] call VIC_fnc_debugLog;
+
+if (isNil "STALKER_wreckMarkers") then { STALKER_wreckMarkers = [] };
+
+// Remove any existing markers
+{
+    if (_x != "") then { deleteMarker _x };
+} forEach STALKER_wreckMarkers;
+STALKER_wreckMarkers = [];
+
+if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
+
+{
+    private _pos = getPosATL _x;
+    private _name = format ["wreck_%1_%2", diag_tickTime, _forEachIndex];
+    private _marker = [_name, _pos, "ICON", "mil_warning", "ColorBlack"] call VIC_fnc_createGlobalMarker;
+    STALKER_wreckMarkers pushBack _marker;
+} forEach STALKER_wrecks;
+
+true
+


### PR DESCRIPTION
## Summary
- create a function to mark cached wrecks
- load the new marker function during init
- show markers after running caching debug actions

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/wrecks/fn_markWrecks.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68520cc36874832facc85451e590babc