### PR TITLE
Implement cached map markers and new init commands

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
@@ -47,4 +47,8 @@ for "_px" from 0 to worldSize step _step do {
     };
 };
 
+// Cache results for later use
+if (isNil "STALKER_buildingClusters") then { STALKER_buildingClusters = [] };
+{ if !(_x in STALKER_buildingClusters) then { STALKER_buildingClusters pushBack _x } } forEach _clusters;
+
 _clusters

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRockClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRockClusters.sqf
@@ -58,4 +58,8 @@ while {count _remaining > 0} do {
     };
 };
 
+// Cache results for later use
+if (isNil "STALKER_rockClusters") then { STALKER_rockClusters = [] };
+{ if !(_x in STALKER_rockClusters) then { STALKER_rockClusters pushBack _x } } forEach _clusters;
+
 _clusters

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -1,0 +1,21 @@
+/*
+    Starts background manager systems for STALKER ALife.
+*/
+
+["initManagers"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { false };
+
+[] call VIC_fnc_startMinefieldManager;
+[] call VIC_fnc_startAmbushManager;
+[
+    {
+        while { true } do {
+            [] call VIC_fnc_updateProximity;
+            private _delay = ["VSA_proximityCheckInterval", 5] call VIC_fnc_getSetting;
+            sleep _delay;
+        };
+    }, [], 8
+] call CBA_fnc_waitAndExecute;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -1,0 +1,20 @@
+/*
+    Caches all map positions required by STALKER ALife systems.
+*/
+
+["initMap"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { false };
+
+[] call VIC_fnc_findRockClusters;
+[] call VIC_fnc_findSniperSpots;
+[] call VIC_fnc_findSwamps;
+[] call VIC_fnc_findBeachesInMap;
+[] call VIC_fnc_findValleys;
+[] call VIC_fnc_findBridges;
+[] call VIC_fnc_findRoads;
+[] call VIC_fnc_findCrossroads;
+[] call VIC_fnc_findBuildingClusters;
+[] call VIC_fnc_findWrecks;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBeaches.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBeaches.sqf
@@ -16,7 +16,8 @@ if (isNil "STALKER_beachMarkers") then { STALKER_beachMarkers = [] };
 } forEach STALKER_beachMarkers;
 STALKER_beachMarkers = [];
 
-private _beachSpots = [] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\core\fn_findBeachesInMap.sqf";
+if (isNil "STALKER_beachSpots") exitWith { false };
+private _beachSpots = STALKER_beachSpots;
 
 {
     private _mkr = createMarkerLocal [format ["beach_%1", diag_tickTime], _x];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf
@@ -14,7 +14,8 @@ if (isNil "STALKER_bridgeMarkers") then { STALKER_bridgeMarkers = [] };
 } forEach STALKER_bridgeMarkers;
 STALKER_bridgeMarkers = [];
 
-private _bridges = [] call VIC_fnc_findBridges;
+if (isNil "STALKER_bridges") exitWith { false };
+private _bridges = STALKER_bridges;
 
 {
     private _type = typeOf _x;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
@@ -15,7 +15,8 @@ if (isNil "STALKER_buildingClusterMarkers") then { STALKER_buildingClusterMarker
 } forEach STALKER_buildingClusterMarkers;
 STALKER_buildingClusterMarkers = [];
 
-private _clusters = [] call VIC_fnc_findBuildingClusters;
+if (isNil "STALKER_buildingClusters") exitWith { false };
+private _clusters = STALKER_buildingClusters;
 
 {
     {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf
@@ -17,8 +17,10 @@ STALKER_roadMarkers = [];
 { if (_x != "") then { deleteMarker _x }; } forEach STALKER_crossroadMarkers;
 STALKER_crossroadMarkers = [];
 
-private _roads = [] call VIC_fnc_findRoads;
-private _crossroads = [_roads] call VIC_fnc_findCrossroads;
+if (isNil "STALKER_roads") exitWith { false };
+private _roads = STALKER_roads;
+private _crossroads = [];
+if (!isNil "STALKER_crossroads") then { _crossroads = STALKER_crossroads; };
 
 {
     private _name = format ["road_%1_%2", diag_tickTime, _forEachIndex];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf
@@ -4,6 +4,7 @@
     Returns: BOOL
 */
 
+
 ["markRockClusters"] call VIC_fnc_debugLog;
 
 
@@ -15,7 +16,8 @@ if (isNil "STALKER_rockClusterMarkers") then { STALKER_rockClusterMarkers = [] }
 } forEach STALKER_rockClusterMarkers;
 STALKER_rockClusterMarkers = [];
 
-private _clusters = [] call VIC_fnc_findRockClusters;
+if (isNil "STALKER_rockClusters") exitWith { false };
+private _clusters = STALKER_rockClusters;
 
 {
     {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf
@@ -15,7 +15,8 @@ if (isNil "STALKER_sniperSpotMarkers") then { STALKER_sniperSpotMarkers = [] };
 } forEach STALKER_sniperSpotMarkers;
 STALKER_sniperSpotMarkers = [];
 
-private _spots = [] call VIC_fnc_findSniperSpots;
+if (isNil "STALKER_sniperSpots") exitWith { false };
+private _spots = STALKER_sniperSpots;
 
 {
     private _name = format ["sniper_%1_%2", diag_tickTime, _forEachIndex];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf
@@ -15,7 +15,8 @@ if (isNil "STALKER_swampMarkers") then { STALKER_swampMarkers = [] };
 } forEach STALKER_swampMarkers;
 STALKER_swampMarkers = [];
 
-private _swamps = [] call VIC_fnc_findSwamps;
+if (isNil "STALKER_swamps") exitWith { false };
+private _swamps = STALKER_swamps;
 
 {
     private _pos = _x;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
@@ -15,7 +15,8 @@ if (isNil "STALKER_valleyMarkers") then { STALKER_valleyMarkers = [] };
 } forEach STALKER_valleyMarkers;
 STALKER_valleyMarkers = [];
 
-private _valleys = [] call VIC_fnc_findValleys;
+if (isNil "STALKER_valleys") exitWith { false };
+private _valleys = STALKER_valleys;
 [format ["markValleys: %1 valleys", count _valleys]] call VIC_fnc_debugLog;
 
 {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -57,6 +57,8 @@ VIC_fnc_markHiddenPosition     = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_findBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBuildingCoverSpot.sqf");
 VIC_fnc_markBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markBuildingCoverSpot.sqf");
 VIC_fnc_radioMessage          = compile preprocessFileLineNumbers (_root + "\functions\core\fn_radioMessage.sqf");
+VIC_fnc_initMap               = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initMap.sqf");
+VIC_fnc_initManagers          = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initManagers.sqf");
 
 if (isServer) then {
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -356,6 +356,21 @@ player addAction ["<t color='#ffff00'>Cache Swamps</t>", {
     };
 }];
 
+player addAction ["<t color='#00ff00'>Init Map</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_initMap;
+    } else {
+        [] remoteExec ["VIC_fnc_initMap", 2];
+    };
+}];
+player addAction ["<t color='#00ff00'>Init Managers</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_initManagers;
+    } else {
+        [] remoteExec ["VIC_fnc_initManagers", 2];
+    };
+}];
+
 ["Debug actions added"] call VIC_fnc_debugLog;
 
 true


### PR DESCRIPTION
## Summary
- draw markers from cached arrays rather than recalc each time
- cache results inside `findRockClusters` and `findBuildingClusters`
- add `initMap` and `initManagers` helper functions
- compile and expose new helpers through debug actions

## Testing
- `bash scripts/sqflint-hook.sh` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_68521201d768832f9011ed76478dfd0a