### PR TITLE
Garrison spawned snipers and add tripwire perimeter

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -114,6 +114,7 @@ class CfgFunctions
             class spawnAPERSField{};
             class spawnIED{};
             class spawnBoobyTraps{};
+            class spawnTripwirePerimeter{};
             class manageMinefields{};
             class startMinefieldManager{};
         };
@@ -247,6 +248,7 @@ class CfgRemoteExec
         class VIC_fnc_spawnPredatorAttack { allowedTargets = 2; };
         class VIC_fnc_spawnMinefields     { allowedTargets = 2; };
         class VIC_fnc_spawnBoobyTraps     { allowedTargets = 2; };
+        class VIC_fnc_spawnTripwirePerimeter { allowedTargets = 2; };
         class VIC_fnc_startMinefieldManager { allowedTargets = 2; };
         class VIC_fnc_spawnAmbushes       { allowedTargets = 2; };
         class VIC_fnc_startAmbushManager  { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -121,6 +121,7 @@ VIC_fnc_spawnMinefields        = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnAPERSField        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnAPERSField.sqf");
 VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnIED.sqf");
 VIC_fnc_spawnBoobyTraps        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnBoobyTraps.sqf");
+VIC_fnc_spawnTripwirePerimeter = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnTripwirePerimeter.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
 VIC_fnc_findWrecks           = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_findWrecks.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
@@ -1,0 +1,32 @@
+/*
+    Spawns tripwire mines in a circular perimeter around a position.
+    Params:
+        0: POSITION - center position
+        1: NUMBER   - radius of the perimeter (default 25)
+        2: NUMBER   - number of mines to spawn (default 6)
+    Returns:
+        ARRAY - spawned mine objects
+*/
+params ["_center", ["_radius",25], ["_count",6]];
+
+["spawnTripwirePerimeter"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { [] };
+
+private _objs = [];
+
+for "_i" from 1 to _count do {
+    private _dist = _radius - random 5;
+    private _pos = _center getPos [_dist, random 360];
+    _pos = [_pos] call VIC_fnc_findLandPosition;
+    if (_pos isEqualTo []) then { continue };
+    private _mine = createMine ["APERSTripMine_Wire", _pos, [], 0];
+    _objs pushBack _mine;
+
+    if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
+        private _marker = format ["tw_%1", diag_tickTime + _i];
+        [_marker, _pos, "ICON", "mil_triangle", "ColorOrange", 0.2, "Tripwire"] call VIC_fnc_createGlobalMarker;
+    };
+};
+
+_objs

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
@@ -1,6 +1,6 @@
 /*
     Spawns a single sniper at the nearest detected sniper spot to a position.
-    The unit holds that position using BIS_fnc_taskDefend.
+    The unit garrisons that position using lambs_wp_fnc_taskGarrison.
 
     Params:
         0: POSITION - center position to search from (default: position of the caller)
@@ -26,7 +26,8 @@ if (isNil {_spot}) exitWith {
 
 private _grp = createGroup east;
 _grp createUnit ["O_sniper_F", _spot, [], 0, "FORM"];
-[_grp, _spot] call BIS_fnc_taskDefend;
+[_grp, _spot, 50, [], true, true, 0, false] call lambs_wp_fnc_taskGarrison;
+[_spot, 25, 6] call VIC_fnc_spawnTripwirePerimeter;
 
 private _marker = "";
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {


### PR DESCRIPTION
## Summary
- use lambs to garrison spawned snipers
- drop tripwire mines around sniper spots
- expose new `spawnTripwirePerimeter` function

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6852177005dc832fb7cb56820de80a2f