### PR TITLE
Fix nil return in land zone search

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
@@ -20,6 +20,7 @@ for "_x" from 0 to worldSize step _step do {
     for "_y" from 0 to worldSize step _step do {
         private _center = [_x + _half, _y + _half, 0];
         private _pos = [_center, _half, 10, _excludeTowns, _half] call VIC_fnc_findLandPosition;
+        if (isNil "_pos") then { _pos = [] };
         if !(_pos isEqualTo []) then {
             _zones pushBack _pos;
         };


### PR DESCRIPTION
## Summary
- account for nil return from VIC_fnc_findLandPosition in land zone logic

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68521e126d64832fa41f5c34ab313528