### PR TITLE
Improve debug markers using createMarkerLocal

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
@@ -1,5 +1,6 @@
 /*
-    Creates a marker globally on all machines.
+    Creates a marker locally for the requesting client by default.
+    Can optionally create the marker globally on all machines.
 
     Params:
         0: STRING - marker name
@@ -10,6 +11,7 @@
         5: NUMBER - marker alpha  (default 1)
         6: STRING - marker text   (optional)
         7: ARRAY  - marker size   (default [1,1])
+        8: BOOL   - create marker globally (default false)
 
     Returns: STRING - marker name
 */
@@ -21,7 +23,8 @@ params [
     ["_color", "ColorWhite"],
     ["_alpha", 1],
     ["_text", ""],
-    ["_size", [1,1]]
+    ["_size", [1,1]],
+    ["_global", false]
 ];
 
 if (isNil {_name} || { isNil {_pos} }) exitWith {
@@ -33,7 +36,9 @@ if (isNil {_name} || { isNil {_pos} }) exitWith {
 
 if (!isServer) exitWith { _name };
 
-[_name, _pos, _shape, _type, _color, _alpha, _text, _size] remoteExecCall ["VIC_fnc_createLocalMarker", 0, true];
+private _target = if (_global) then { 0 } else { remoteExecutedOwner };
+
+[_name, _pos, _shape, _type, _color, _alpha, _text, _size] remoteExecCall ["VIC_fnc_createLocalMarker", _target, true];
 
 [format ["createGlobalMarker done %1", _name]] call VIC_fnc_debugLog;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createLocalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createLocalMarker.sqf
@@ -29,13 +29,13 @@ if (isNil {_name} || { isNil {_pos} }) exitWith {
     ""
 };
 
-private _marker = createMarker [_name, _pos];
-_marker setMarkerShape _shape;
-_marker setMarkerSize _size;
-_marker setMarkerType _type;
-_marker setMarkerColor _color;
-_marker setMarkerAlpha _alpha;
+private _marker = createMarkerLocal [_name, _pos];
+_marker setMarkerShapeLocal _shape;
+_marker setMarkerSizeLocal _size;
+_marker setMarkerTypeLocal _type;
+_marker setMarkerColorLocal _color;
+_marker setMarkerAlphaLocal _alpha;
 if (_text != "") then {
-    _marker setMarkerText _text;
+    _marker setMarkerTextLocal _text;
 };
 _marker

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markAllBuildings.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markAllBuildings.sqf
@@ -5,6 +5,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markAllBuildings"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_buildingMarkers") then { STALKER_buildingMarkers = [] };
@@ -19,7 +22,7 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
     private _type = typeOf _x;
     private _pos = getPosATL _x;
     private _name = format ["bld_%1_%2", toLower _type, diag_tickTime + random 1000];
-    private _marker = [_name, _pos, "ICON", "mil_dot", "ColorYellow"] call VIC_fnc_createGlobalMarker;
+    private _marker = [_name, _pos, "ICON", "mil_dot", "ColorYellow", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     [_name, _type] remoteExecCall ["setMarkerText", 0, true];
     STALKER_buildingMarkers pushBack _marker;
 } forEach _buildings;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markBridges"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_bridgeMarkers") then { STALKER_bridgeMarkers = [] };
@@ -21,7 +24,7 @@ private _bridges = STALKER_bridges;
     private _type = typeOf _x;
     private _pos = getPosATL _x;
     private _name = format ["bridge_%1_%2", toLower _type, diag_tickTime + random 1000];
-    private _marker = [_name, _pos, "ICON", "mil_dot", "ColorRed"] call VIC_fnc_createGlobalMarker;
+    private _marker = [_name, _pos, "ICON", "mil_dot", "ColorRed", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     [_name, _type] remoteExecCall ["setMarkerText", 0, true];
     STALKER_bridgeMarkers pushBack _marker;
 } forEach _bridges;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markBuildingClusters"] call VIC_fnc_debugLog;
 
 
@@ -22,7 +25,7 @@ private _clusters = STALKER_buildingClusters;
     {
         private _pos = getPosATL _x;
         private _name = format ["bcl_%1", diag_tickTime + random 1000];
-        private _marker = [_name, _pos, "ICON", "mil_dot", "ColorBlue"] call VIC_fnc_createGlobalMarker;
+        private _marker = [_name, _pos, "ICON", "mil_dot", "ColorBlue", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
         STALKER_buildingClusterMarkers pushBack _marker;
     } forEach _x;
 } forEach _clusters;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingCoverSpot.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingCoverSpot.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markBuildingCoverSpot"] call VIC_fnc_debugLog;
 
 
@@ -16,7 +19,7 @@ private _pos = [player] call VIC_fnc_findBuildingCoverSpot;
 if (isNil {_pos}) exitWith { false };
 
 private _name = format ["cover_%1", diag_tickTime + random 1000];
-private _marker = [_name, _pos, "ICON", "mil_dot", "ColorGreen"] call VIC_fnc_createGlobalMarker;
+private _marker = [_name, _pos, "ICON", "mil_dot", "ColorGreen", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
 STALKER_coverMarkers pushBack _marker;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markDeathLocation.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markDeathLocation.sqf
@@ -3,9 +3,10 @@
     The marker is removed automatically once the corpse is deleted.
 */
 
-["markDeathLocation"] call VIC_fnc_debugLog;
 
-params ["_unit"];
+params ["_unit", ["_global", false]];
+
+["markDeathLocation"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNull _unit || {!isPlayer _unit}) exitWith {};
@@ -13,7 +14,7 @@ if (isNull _unit || {!isPlayer _unit}) exitWith {};
 private _pos = getPosATL _unit;
 private _name = format ["death_%1", diag_tickTime];
 
-private _marker = [_name, _pos, "ICON", "hd_destroy", "ColorRed", 1] call VIC_fnc_createGlobalMarker;
+private _marker = [_name, _pos, "ICON", "hd_destroy", "ColorRed", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
 
 if (isNil "STALKER_deathMarkers") then { STALKER_deathMarkers = [] };
 STALKER_deathMarkers pushBack [_unit, _marker];
@@ -23,7 +24,7 @@ STALKER_deathMarkers pushBack [_unit, _marker];
     waitUntil { isNull _corpse };
     if (_markerName != "") then { deleteMarker _markerName; };
     if (!isNil "STALKER_deathMarkers") then {
-        STALKER_deathMarkers = STALKER_deathMarkers select { _x#1 != _markerName };
+        STALKER_deathMarkers = STALKER_deathMarkers select { (_x select 1) != _markerName };
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markHiddenPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markHiddenPosition.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markHiddenPosition"] call VIC_fnc_debugLog;
 
 
@@ -19,7 +22,7 @@ private _pos = [] call VIC_fnc_findHiddenPosition;
 if (isNil {_pos}) exitWith { false };
 
 private _name = format ["hidden_%1", diag_tickTime + random 1000];
-private _marker = [_name, _pos, "ICON", "mil_dot", "ColorGreen"] call VIC_fnc_createGlobalMarker;
+private _marker = [_name, _pos, "ICON", "mil_dot", "ColorGreen", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
 STALKER_hiddenMarkers pushBack _marker;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markLandZones"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_landZoneMarkers") then { STALKER_landZoneMarkers = [] };
@@ -19,7 +22,7 @@ private _zones = STALKER_landZones;
 
 {
     private _name = format ["landzone_%1", diag_tickTime + random 1000];
-    private _mkr = [_name, _x, "ICON", "mil_triangle", "ColorYellow"] call VIC_fnc_createGlobalMarker;
+    private _mkr = [_name, _x, "ICON", "mil_triangle", "ColorYellow", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_landZoneMarkers pushBack _mkr;
 } forEach _zones;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markRoads"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_roadMarkers") then { STALKER_roadMarkers = [] };
@@ -24,13 +27,13 @@ if (!isNil "STALKER_crossroads") then { _crossroads = STALKER_crossroads; };
 
 {
     private _name = format ["road_%1_%2", diag_tickTime, _forEachIndex];
-    private _mkr = [_name, _x, "ICON", "mil_dot", "ColorOrange"] call VIC_fnc_createGlobalMarker;
+    private _mkr = [_name, _x, "ICON", "mil_dot", "ColorOrange", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_roadMarkers pushBack _mkr;
 } forEach _roads;
 
 {
     private _name = format ["crossroad_%1_%2", diag_tickTime, _forEachIndex];
-    private _mkr = [_name, _x, "ICON", "mil_triangle", "ColorRed"] call VIC_fnc_createGlobalMarker;
+    private _mkr = [_name, _x, "ICON", "mil_triangle", "ColorRed", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_crossroadMarkers pushBack _mkr;
 } forEach _crossroads;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf
@@ -5,6 +5,9 @@
 */
 
 
+
+params [["_global", false]];
+
 ["markRockClusters"] call VIC_fnc_debugLog;
 
 
@@ -23,7 +26,7 @@ private _clusters = STALKER_rockClusters;
     {
         private _pos = getPosATL _x;
         private _name = format ["rock_%1", diag_tickTime + random 1000];
-        private _marker = [_name, _pos, "ICON", "mil_dot", "ColorBlack"] call VIC_fnc_createGlobalMarker;
+        private _marker = [_name, _pos, "ICON", "mil_dot", "ColorBlack", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
         STALKER_rockClusterMarkers pushBack _marker;
     } forEach _x;
 } forEach _clusters;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markSniperSpots"] call VIC_fnc_debugLog;
 
 
@@ -20,7 +23,7 @@ private _spots = STALKER_sniperSpots;
 
 {
     private _name = format ["sniper_%1_%2", diag_tickTime, _forEachIndex];
-    private _marker = [_name, _x, "ICON", "mil_dot", "ColorBlue"] call VIC_fnc_createGlobalMarker;
+    private _marker = [_name, _x, "ICON", "mil_dot", "ColorBlue", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_sniperSpotMarkers pushBack _marker;
 } forEach _spots;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markSwamps"] call VIC_fnc_debugLog;
 
 
@@ -21,7 +24,7 @@ private _swamps = STALKER_swamps;
 {
     private _pos = _x;
     private _name = format ["swamp_%1", diag_tickTime + random 1000];
-    private _marker = [_name, _pos, "ICON", "mil_triangle", "ColorGreen"] call VIC_fnc_createGlobalMarker;
+    private _marker = [_name, _pos, "ICON", "mil_triangle", "ColorGreen", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_swampMarkers pushBack _marker;
 } forEach _swamps;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markValleys"] call VIC_fnc_debugLog;
 
 
@@ -24,7 +27,7 @@ private _valleys = STALKER_valleys;
     {
         private _pos = _x;
         private _name = format ["valley_%1", diag_tickTime + random 1000];
-        private _marker = [_name, _pos, "ICON", "mil_triangle", "ColorBlue"] call VIC_fnc_createGlobalMarker;
+        private _marker = [_name, _pos, "ICON", "mil_triangle", "ColorBlue", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
         STALKER_valleyMarkers pushBack _marker;
     } forEach _area;
 } forEach _valleys;

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_markWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_markWrecks.sqf
@@ -4,6 +4,9 @@
     Returns: BOOL
 */
 
+
+params [["_global", false]];
+
 ["markWrecks"] call VIC_fnc_debugLog;
 
 if (isNil "STALKER_wreckMarkers") then { STALKER_wreckMarkers = [] };
@@ -19,7 +22,7 @@ if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
 {
     private _pos = getPosATL _x;
     private _name = format ["wreck_%1_%2", diag_tickTime, _forEachIndex];
-    private _marker = [_name, _pos, "ICON", "mil_warning", "ColorBlack"] call VIC_fnc_createGlobalMarker;
+    private _marker = [_name, _pos, "ICON", "mil_warning", "ColorBlack", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_wreckMarkers pushBack _marker;
 } forEach STALKER_wrecks;
 


### PR DESCRIPTION
## Summary
- improve `fn_createLocalMarker` to use `createMarkerLocal`
- allow `fn_createGlobalMarker` to target only the requesting client
- update debug marker helpers to accept a `_global` parameter
- fix sqflint warning in `fn_markDeathLocation.sqf`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_createLocalMarker.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markAllBuildings.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markBridges.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingCoverSpot.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markDeathLocation.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markHiddenPosition.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markRoads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markRockClusters.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markSniperSpots.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markSwamps.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf addons/Viceroys-STALKER-ALife/functions/wrecks/fn_markWrecks.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685228b7ced4832f836871e2f5368f15