### PR TITLE
Use unique insert for map caches

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
@@ -58,7 +58,7 @@ for "_x" from 0 to _size step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_beachSpots") then { STALKER_beachSpots = [] };
-{ if !(_x in STALKER_beachSpots) then { STALKER_beachSpots pushBack _x } } forEach _spots;
+{ STALKER_beachSpots pushBackUnique _x } forEach _spots;
 
 [] call VIC_fnc_markBeaches;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
@@ -56,7 +56,7 @@ for "_x" from 0 to _size step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_bridges") then { STALKER_bridges = [] };
-{ if !(_x in STALKER_bridges) then { STALKER_bridges pushBack _x } } forEach _found;
+{ STALKER_bridges pushBackUnique _x } forEach _found;
 
 [] call VIC_fnc_markBridges;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
@@ -49,7 +49,7 @@ for "_px" from 0 to worldSize step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_buildingClusters") then { STALKER_buildingClusters = [] };
-{ if !(_x in STALKER_buildingClusters) then { STALKER_buildingClusters pushBack _x } } forEach _clusters;
+{ STALKER_buildingClusters pushBackUnique _x } forEach _clusters;
 
 [] call VIC_fnc_markBuildingClusters;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
@@ -27,11 +27,9 @@ private _crossroads = [];
         private _connections = roadsConnectedTo _roadObj;
         if ((count _connections) >= 3) then {
             private _pos = getPosATL _roadObj;
-            private _dup = false;
-            {
-                if (_x distance _pos < 5) exitWith { _dup = true };
-            } forEach _crossroads;
-            if (!_dup) then { _crossroads pushBack _pos; };
+            if ((count (_crossroads select { _x distance _pos < 5 })) == 0) then {
+                _crossroads pushBack _pos;
+            };
         };
     };
 } forEach _roads;
@@ -40,7 +38,7 @@ private _crossroads = [];
 
 // Cache results for later use
 if (isNil "STALKER_crossroads") then { STALKER_crossroads = [] };
-{ if !(_x in STALKER_crossroads) then { STALKER_crossroads pushBack _x } } forEach _crossroads;
+{ STALKER_crossroads pushBackUnique _x } forEach _crossroads;
 
 [] call VIC_fnc_markRoads;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
@@ -29,7 +29,7 @@ for "_x" from 0 to worldSize step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_landZones") then { STALKER_landZones = [] };
-{ if !(_x in STALKER_landZones) then { STALKER_landZones pushBack _x } } forEach _zones;
+{ STALKER_landZones pushBackUnique _x } forEach _zones;
 
 // Mark cached zones when debugging
 [] call VIC_fnc_markLandZones;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
@@ -27,7 +27,7 @@ for "_xCoord" from 0 to worldSize step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_roads") then { STALKER_roads = [] };
-{ if !(_x in STALKER_roads) then { STALKER_roads pushBack _x } } forEach _roads;
+{ STALKER_roads pushBackUnique _x } forEach _roads;
 
 [] call VIC_fnc_markRoads;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRockClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRockClusters.sqf
@@ -11,6 +11,7 @@
 */
 
 params [["_minRocks", 4], ["_radius", 20], ["_step", 500]];
+_step = _step; // parameter kept for backwards compatibility
 
 ["findRockClusters"] call VIC_fnc_debugLog;
 
@@ -60,7 +61,7 @@ while {count _remaining > 0} do {
 
 // Cache results for later use
 if (isNil "STALKER_rockClusters") then { STALKER_rockClusters = [] };
-{ if !(_x in STALKER_rockClusters) then { STALKER_rockClusters pushBack _x } } forEach _clusters;
+{ STALKER_rockClusters pushBackUnique _x } forEach _clusters;
 
 [] call VIC_fnc_markRockClusters;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf
@@ -52,7 +52,7 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
 
 // Cache results for later use
 if (isNil "STALKER_sniperSpots") then { STALKER_sniperSpots = [] };
-{ if !(_x in STALKER_sniperSpots) then { STALKER_sniperSpots pushBack _x } } forEach _sniperSpots;
+{ STALKER_sniperSpots pushBackUnique _x } forEach _sniperSpots;
 
 [] call VIC_fnc_markSniperSpots;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
@@ -56,7 +56,7 @@ for "_x" from 0 to worldSize step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_swamps") then { STALKER_swamps = [] };
-{ if !(_x in STALKER_swamps) then { STALKER_swamps pushBack _x } } forEach _swamps;
+{ STALKER_swamps pushBackUnique _x } forEach _swamps;
 
 [] call VIC_fnc_markSwamps;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -97,7 +97,7 @@ for "_gx" from 0 to worldSize step _step do {
 
 // Cache results for later use
 if (isNil "STALKER_valleys") then { STALKER_valleys = [] };
-{ if !(_x in STALKER_valleys) then { STALKER_valleys pushBack _x } } forEach _valleys;
+{ STALKER_valleys pushBackUnique _x } forEach _valleys;
 
 [] call VIC_fnc_markValleys;
 

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
@@ -14,7 +14,7 @@ private _objs = nearestObjects [_center, ["AllVehicles","Static"], worldSize];
 private _found = _objs select { toLower typeOf _x find "wreck" > -1 };
 
 if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
-{ if !(_x in STALKER_wrecks) then { STALKER_wrecks pushBack _x } } forEach _found;
+{ STALKER_wrecks pushBackUnique _x } forEach _found;
 
 [] call VIC_fnc_markWrecks;
 


### PR DESCRIPTION
## Summary
- deduplicate crossroads positions via `select`-based check

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685228a8cd74832fbf6963967d61bef6