### PR TITLE
Add wreck model path check

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    actions will appear automatically.
 6. When debug mode is active, your scroll menu includes options to trigger storms, spawn stable or unstable anomaly fields, cycle existing fields, spawn spook zones, generate habitats, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Stable fields will show a randomly generated name on their marker for easy reference.
 7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
-8. **Cache Map Wrecks** to collect all wreck objects placed on the map. This action populates `STALKER_wrecks` for other functions.
+8. **Cache Map Wrecks** to collect all wreck objects placed on the map, including models whose path contains "wrecks". This action populates `STALKER_wrecks` for other functions.
 9. Additional **Cache** actions can store sniper spots, roads, crossroads, bridges, valleys, beach sites and swamps for quick access by other scripts.
 
 ### Debug Mode

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
@@ -8,10 +8,14 @@
 
 if (!isServer) exitWith { [] };
 
-// gather all objects and filter by class name
+// gather all objects and filter by class name or model path
 private _center = [worldSize / 2, worldSize / 2, 0];
 private _objs = nearestObjects [_center, ["AllVehicles","Static"], worldSize];
-private _found = _objs select { toLower typeOf _x find "wreck" > -1 };
+private _found = _objs select {
+    private _type = toLower typeOf _x;
+    private _model = toLower ((getModelInfo _x) select 0);
+    (_type find "wreck" > -1) || { _model find "wrecks" > -1 }
+};
 
 if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
 { STALKER_wrecks pushBackUnique _x } forEach _found;


### PR DESCRIPTION
## Summary
- detect wreck objects using model path checks in `findWrecks`
- document that wreck caching also scans model paths

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68522f08bd10832fbd70ab32ef65ced6