### PR TITLE
Add cached marker action and init hint

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBeachesInMap.sqf
@@ -60,7 +60,5 @@ for "_x" from 0 to _size step _step do {
 if (isNil "STALKER_beachSpots") then { STALKER_beachSpots = [] };
 { STALKER_beachSpots pushBackUnique _x } forEach _spots;
 
-[] call VIC_fnc_markBeaches;
-
 _spots
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
@@ -58,6 +58,4 @@ for "_x" from 0 to _size step _step do {
 if (isNil "STALKER_bridges") then { STALKER_bridges = [] };
 { STALKER_bridges pushBackUnique _x } forEach _found;
 
-[] call VIC_fnc_markBridges;
-
 _found

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
@@ -51,6 +51,4 @@ for "_px" from 0 to worldSize step _step do {
 if (isNil "STALKER_buildingClusters") then { STALKER_buildingClusters = [] };
 { STALKER_buildingClusters pushBackUnique _x } forEach _clusters;
 
-[] call VIC_fnc_markBuildingClusters;
-
 _clusters

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
@@ -40,7 +40,5 @@ private _crossroads = [];
 if (isNil "STALKER_crossroads") then { STALKER_crossroads = [] };
 { STALKER_crossroads pushBackUnique _x } forEach _crossroads;
 
-[] call VIC_fnc_markRoads;
-
 _crossroads
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
@@ -31,7 +31,4 @@ for "_x" from 0 to worldSize step _step do {
 if (isNil "STALKER_landZones") then { STALKER_landZones = [] };
 { STALKER_landZones pushBackUnique _x } forEach _zones;
 
-// Mark cached zones when debugging
-[] call VIC_fnc_markLandZones;
-
 _zones

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
@@ -29,7 +29,5 @@ for "_xCoord" from 0 to worldSize step _step do {
 if (isNil "STALKER_roads") then { STALKER_roads = [] };
 { STALKER_roads pushBackUnique _x } forEach _roads;
 
-[] call VIC_fnc_markRoads;
-
 _roads
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRockClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRockClusters.sqf
@@ -63,6 +63,4 @@ while {count _remaining > 0} do {
 if (isNil "STALKER_rockClusters") then { STALKER_rockClusters = [] };
 { STALKER_rockClusters pushBackUnique _x } forEach _clusters;
 
-[] call VIC_fnc_markRockClusters;
-
 _clusters

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSniperSpots.sqf
@@ -54,7 +54,5 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
 if (isNil "STALKER_sniperSpots") then { STALKER_sniperSpots = [] };
 { STALKER_sniperSpots pushBackUnique _x } forEach _sniperSpots;
 
-[] call VIC_fnc_markSniperSpots;
-
 _sniperSpots
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findSwamps.sqf
@@ -58,7 +58,5 @@ for "_x" from 0 to worldSize step _step do {
 if (isNil "STALKER_swamps") then { STALKER_swamps = [] };
 { STALKER_swamps pushBackUnique _x } forEach _swamps;
 
-[] call VIC_fnc_markSwamps;
-
 _swamps
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -99,7 +99,5 @@ for "_gx" from 0 to worldSize step _step do {
 if (isNil "STALKER_valleys") then { STALKER_valleys = [] };
 { STALKER_valleys pushBackUnique _x } forEach _valleys;
 
-[] call VIC_fnc_markValleys;
-
 _valleys
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -27,4 +27,6 @@ if (isNil {_roads}) then {
 [] call VIC_fnc_findBuildingClusters;
 [] call VIC_fnc_findWrecks;
 
+"STALKER ALife initialization complete" remoteExec ["hint", 0];
+
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -56,6 +56,7 @@ VIC_fnc_findRoads             = compile preprocessFileLineNumbers (_root + "\fun
 VIC_fnc_findCrossroads        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findCrossroads.sqf");
 VIC_fnc_markRoads             = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markRoads.sqf");
 VIC_fnc_markWrecks            = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_markWrecks.sqf");
+VIC_fnc_placeCachedMarkers    = compile preprocessFileLineNumbers (_root + "\functions\core\fn_placeCachedMarkers.sqf");
 VIC_fnc_findHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findHiddenPosition.sqf");
 VIC_fnc_markHiddenPosition     = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markHiddenPosition.sqf");
 VIC_fnc_findBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findBuildingCoverSpot.sqf");
@@ -214,7 +215,6 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
     };
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         [] call VIC_fnc_setupDebugActions;
-        [] call VIC_fnc_markPlayerRanges;
     };
 }] call CBA_fnc_addEventHandler;
 
@@ -229,7 +229,6 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
     ["postInit", {
         if (hasInterface && {["VSA_debugMode", false] call VIC_fnc_getSetting}) then {
             [] call VIC_fnc_setupDebugActions;
-            [] call VIC_fnc_markPlayerRanges;
         };
     }] call CBA_fnc_addEventHandler;
 };
@@ -239,6 +238,5 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
     params ["_setting", "_value"];
     if (hasInterface && {_setting isEqualTo "VSA_debugMode" && {_value}}) then {
         [] call VIC_fnc_setupDebugActions;
-        [] call VIC_fnc_markPlayerRanges;
     };
 }] call CBA_fnc_addEventHandler;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_placeCachedMarkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_placeCachedMarkers.sqf
@@ -1,0 +1,18 @@
+/*
+    Places debug markers for all cached map data.
+*/
+
+["placeCachedMarkers"] call VIC_fnc_debugLog;
+
+[] call VIC_fnc_markRockClusters;
+[] call VIC_fnc_markSniperSpots;
+[] call VIC_fnc_markSwamps;
+[] call VIC_fnc_markBeaches;
+[] call VIC_fnc_markValleys;
+[] call VIC_fnc_markLandZones;
+[] call VIC_fnc_markBuildingClusters;
+[] call VIC_fnc_markBridges;
+[] call VIC_fnc_markRoads;
+[] call VIC_fnc_markWrecks;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -211,101 +211,19 @@ player addAction ["<t color='#0000ff'>Toggle Field Avoidance</t>", {
         [] remoteExec ["VIC_fnc_toggleFieldAvoid", 2];
     };
 }];
-// --- Marking Actions ---
-player addAction ["<t color='#ffff00'>Mark All Buildings</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markAllBuildings;
-    } else {
-        [] remoteExec ["VIC_fnc_markAllBuildings", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Rock Clusters</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markRockClusters;
-    } else {
-        [] remoteExec ["VIC_fnc_markRockClusters", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Sniper Spots</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markSniperSpots;
-    } else {
-        [] remoteExec ["VIC_fnc_markSniperSpots", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Swamps</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markSwamps;
-    } else {
-        [] remoteExec ["VIC_fnc_markSwamps", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Beach Spots</t>", { [] call VIC_fnc_markBeaches }];
-player addAction ["<t color='#ffff00'>Mark Valleys</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markValleys;
-    } else {
-        [] remoteExec ["VIC_fnc_markValleys", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Land Zones</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markLandZones;
-    } else {
-        [] remoteExec ["VIC_fnc_markLandZones", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Building Clusters</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markBuildingClusters;
-    } else {
-        [] remoteExec ["VIC_fnc_markBuildingClusters", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Hidden Spot</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markHiddenPosition;
-    } else {
-        [] remoteExec ["VIC_fnc_markHiddenPosition", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Building Cover</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markBuildingCoverSpot;
-    } else {
-        [] remoteExec ["VIC_fnc_markBuildingCoverSpot", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Bridges</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markBridges;
-    } else {
-        [] remoteExec ["VIC_fnc_markBridges", 2];
-    };
-}];
-player addAction ["<t color='#ffff00'>Mark Roads</t>", {
-    if (isServer) then {
-        [] call VIC_fnc_markRoads;
-    } else {
-        [] remoteExec ["VIC_fnc_markRoads", 2];
-    };
-}];
+// --- Cache Actions ---
 player addAction ["<t color='#ffff00'>Cache Map Wrecks</t>", {
     if (isServer) then {
         [] call VIC_fnc_findWrecks;
-        [] call VIC_fnc_markWrecks;
     } else {
         [] remoteExec ["VIC_fnc_findWrecks", 2];
-        [] remoteExec ["VIC_fnc_markWrecks", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Sniper Spots</t>", {
     if (isServer) then {
         [] call VIC_fnc_findSniperSpots;
-        [] call VIC_fnc_markSniperSpots;
     } else {
         [] remoteExec ["VIC_fnc_findSniperSpots", 2];
-        [] remoteExec ["VIC_fnc_markSniperSpots", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Roads</t>", {
@@ -315,55 +233,43 @@ player addAction ["<t color='#ffff00'>Cache Roads</t>", {
             _data = [] call VIC_fnc_findRoads;
             ["STALKER_roads", _data] call VIC_fnc_saveCache;
         };
-        [] call VIC_fnc_markRoads;
     } else {
         [] remoteExec ["VIC_fnc_findRoads", 2];
-        [] remoteExec ["VIC_fnc_markRoads", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Crossroads</t>", {
     if (isServer) then {
         [] call VIC_fnc_findCrossroads;
-        [] call VIC_fnc_markRoads;
     } else {
         [] remoteExec ["VIC_fnc_findCrossroads", 2];
-        [] remoteExec ["VIC_fnc_markRoads", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Bridges</t>", {
     if (isServer) then {
         [] call VIC_fnc_findBridges;
-        [] call VIC_fnc_markBridges;
     } else {
         [] remoteExec ["VIC_fnc_findBridges", 2];
-        [] remoteExec ["VIC_fnc_markBridges", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Valleys</t>", {
     if (isServer) then {
         [] call VIC_fnc_findValleys;
-        [] call VIC_fnc_markValleys;
     } else {
         [] remoteExec ["VIC_fnc_findValleys", 2];
-        [] remoteExec ["VIC_fnc_markValleys", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Beach Spots</t>", {
     if (isServer) then {
         [] call VIC_fnc_findBeachesInMap;
-        [] call VIC_fnc_markBeaches;
     } else {
         [] remoteExec ["VIC_fnc_findBeachesInMap", 2];
-        [] remoteExec ["VIC_fnc_markBeaches", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Swamps</t>", {
     if (isServer) then {
         [] call VIC_fnc_findSwamps;
-        [] call VIC_fnc_markSwamps;
     } else {
         [] remoteExec ["VIC_fnc_findSwamps", 2];
-        [] remoteExec ["VIC_fnc_markSwamps", 2];
     };
 }];
 player addAction ["<t color='#ffff00'>Cache Land Zones</t>", {
@@ -373,10 +279,16 @@ player addAction ["<t color='#ffff00'>Cache Land Zones</t>", {
             _data = [] call VIC_fnc_findLandZones;
             ["STALKER_landZones", _data] call VIC_fnc_saveCache;
         };
-        [] call VIC_fnc_markLandZones;
     } else {
         [] remoteExec ["VIC_fnc_findLandZones", 2];
-        [] remoteExec ["VIC_fnc_markLandZones", 2];
+    };
+}];
+
+player addAction ["<t color='#ffff00'>Place Cached Markers</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_placeCachedMarkers;
+    } else {
+        [] remoteExec ["VIC_fnc_placeCachedMarkers", 2];
     };
 }];
 

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
@@ -20,8 +20,6 @@ private _found = _objs select {
 if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
 { STALKER_wrecks pushBackUnique _x } forEach _found;
 
-[] call VIC_fnc_markWrecks;
-
 [format ["findWrecks: %1 wrecks cached", count _found]] call VIC_fnc_debugLog;
 
 _found


### PR DESCRIPTION
## Summary
- add `fn_placeCachedMarkers` to centralize debug markers
- stop placing markers during cache functions and actions
- show a hint when map initialization completes
- add new "Place Cached Markers" debug action
- don't mark player ranges automatically

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685236326424832f96059fe5b038160e