### PR TITLE
Fix nil checks for land position

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_bridgeElectra: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_bridgeElectra: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -21,7 +21,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_burner: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_burner: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_clicker: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_clicker: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -21,7 +21,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_comet: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_comet: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_electra: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_electra: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_fruitpunch: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_fruitpunch: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_gravi: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_gravi: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_launchpad: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_launchpad: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_meatgrinder: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_meatgrinder: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_springboard: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_springboard: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_trapdoor: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_trapdoor: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_whirligig: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_whirligig: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_zapper: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (isNil {_site} || {_site isEqualTo []}) exitWith {
     ["createField_zapper: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _pos = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_pos isEqualTo []) exitWith { [] };
+if (isNil {_pos} || {_pos isEqualTo []}) exitWith { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith { [] };
+if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -61,7 +61,7 @@ for "_i" from 1 to _fieldCount do {
     if (random 100 >= _spawnWeight) then { continue };
 
     private _pos = [[random worldSize, random worldSize, 0], 50, 10, false, worldSize] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue };
+    if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
 
     private _fn = selectRandom _types;
     private _typeName = switch (_fn) do {

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnRandomChemicalZones.sqf
@@ -32,7 +32,7 @@ for "_i" from 1 to _count do {
     private _dist = random _radius;
     private _base = [(_centerPos select 0) + _dist * sin _ang, (_centerPos select 1) + _dist * cos _ang, _centerPos select 2];
     private _pos = [_base] call VIC_fnc_findLandPosition;
-    if !(_pos isEqualTo []) then {
+    if !(isNil {_pos} || {_pos isEqualTo []}) then {
         [_pos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnValleyChemicalZones.sqf
@@ -58,7 +58,7 @@ for "_i" from 1 to _count do {
         private _offDist = random (_zoneRadius / 2);
         private _zonePos = [(_pos select 0) + _offDist * sin _offAng, (_pos select 1) + _offDist * cos _offAng, _pos select 2];
         _zonePos = [_zonePos] call VIC_fnc_findLandPosition;
-        if !(_zonePos isEqualTo []) then {
+        if !(isNil {_zonePos} || {_zonePos isEqualTo []}) then {
             [_zonePos, _zoneRadius, _duration] call VIC_fnc_spawnChemicalZone;
         };
     };

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf
@@ -20,7 +20,7 @@ for "_xOff" from -_half to _half step _spacing do {
     for "_yOff" from -_half to _half step _spacing do {
         private _pos = [(_center select 0) + _xOff, (_center select 1) + _yOff, 0];
         _pos = [_pos] call VIC_fnc_findLandPosition;
-        if (_pos isEqualTo []) then { continue; };
+        if (isNil {_pos} || {_pos isEqualTo []}) then { continue; };
         private _mine = createMine ["APERSMine", _pos, [], 0];
         _objs pushBack _mine;
     };

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
@@ -23,7 +23,7 @@ for "_i" from 0 to (_count - 1) do {
     private _angle = _offset + (360 / _count) * _i;
     private _pos = _center getPos [_dist, _angle];
     _pos = [_pos] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue };
+    if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
     _positions pushBack _pos;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHerds.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHerds.sqf
@@ -18,7 +18,7 @@ private _chance = ["VSA_mutantSpawnWeight",50] call VIC_fnc_getSetting;
     if (isNull _leader || {!alive _leader}) then {
         private _pos = if (!isNull _leader) then { getPos _leader } else { [random worldSize, random worldSize, 0] };
         _pos = [_pos] call VIC_fnc_findLandPosition;
-        if (_pos isEqualTo []) then { continue };
+        if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
         if ({ alive _x } count units _grp > 0) then {
             _leader = selectRandom (units _grp);
         } else {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAmbientHerds.sqf
@@ -26,7 +26,7 @@ if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {};
 for "_i" from 1 to _herdCount do {
     private _pos = [random worldSize, random worldSize, 0];
     _pos = [_pos] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue };
+    if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
     private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
     if (!([_pos, _dist] call VIC_fnc_hasPlayersNearby)) then { continue };
     private _grp = createGroup civilian;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantGroup.sqf
@@ -33,7 +33,7 @@ for "_i" from 1 to _groupCount do {
     if (random 100 >= _spawnWeight) then { continue }; 
     private _spawnPos = _centerPos getPos [100 + random 100, random 360];
     _spawnPos = [_spawnPos] call VIC_fnc_findLandPosition;
-    if (_spawnPos isEqualTo []) then { continue };
+    if (isNil {_spawnPos} || {_spawnPos isEqualTo []}) then { continue };
     private _grp = createGroup east;
     for "_j" from 1 to _threat do {
         private _u = _grp createUnit ["O_ALF_Mutant", _spawnPos, [], 0, "FORM"];

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantNest.sqf
@@ -8,7 +8,7 @@ params ["_pos", "_class"];
 ["spawnMutantNest"] call VIC_fnc_debugLog;
 
 _pos = [_pos] call VIC_fnc_findLandPosition;
-if (_pos isEqualTo []) exitWith {
+if (isNil {_pos} || {_pos isEqualTo []}) exitWith {
     ["spawnMutantNest exit: invalid position"] call VIC_fnc_debugLog;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -23,7 +23,7 @@ if (isNil "STALKER_activePredators") then { STALKER_activePredators = []; };
 private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
 private _spawnPos = _player getPos [_range, random 360];
 _spawnPos = [_spawnPos] call VIC_fnc_findLandPosition;
-if (_spawnPos isEqualTo []) exitWith {
+if (isNil {_spawnPos} || {_spawnPos isEqualTo []}) exitWith {
     ["spawnPredatorAttack exit: invalid position"] call VIC_fnc_debugLog;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/necroplague/fn_triggerNecroplague.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/necroplague/fn_triggerNecroplague.sqf
@@ -24,7 +24,7 @@ private _classes = ["WBK_Zombie1","WBK_Zombie2","WBK_Zombie3"];
         private _angle = (_h - 1) * _angleStep;
         private _pos = _player getPos [600, _angle];
         _pos = [_pos] call VIC_fnc_findLandPosition;
-        if (_pos isEqualTo []) then { continue };
+        if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
         if (_mark) then {
             private _markerName = format ["necro_%1", diag_tickTime + random 1000];
             [_markerName, _pos, "ICON", "mil_dot", "ColorRed", 1, "Necro Spawn"] call VIC_fnc_createGlobalMarker;

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -29,7 +29,7 @@ for "_i" from 1 to _groupCount do {
     private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
     private _pos = _center getPos [ random (_dist * 0.75), random 360 ];
     _pos = [_pos] call VIC_fnc_findLandPosition;
-    if (_pos isEqualTo []) then { continue };
+    if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
     if (!([_pos, _dist] call VIC_fnc_hasPlayersNearby)) then { continue };
 
     private _grp = createGroup independent;

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamps.sqf
@@ -31,6 +31,6 @@ for "_i" from 1 to _count do {
         };
         _attempts = _attempts + 1;
     };
-    if (_campPos isEqualTo []) then { continue };
+    if (isNil {_campPos} || {_campPos isEqualTo []}) then { continue };
     [_campPos] call VIC_fnc_spawnStalkerCamp;
 };


### PR DESCRIPTION
## Summary
- handle `nil` returns from `VIC_fnc_findLandPosition`
- update anomaly site/field spawns to check for `nil` positions
- update chemical zone and stalker/mutant spawn scripts

## Testing
- `bash scripts/sqflint-hook.sh $(git ls-files "*.sqf")`

------
https://chatgpt.com/codex/tasks/task_e_6852407b7cd0832f860b3515aaecf209