### PR TITLE
Add regenerate map points debug action

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
 7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
 8. **Cache Map Wrecks** to collect all wreck objects placed on the map, including models whose path contains "wrecks". This action populates `STALKER_wrecks` for other functions.
 9. Additional **Cache** actions can store sniper spots, roads, crossroads, bridges, valleys, beach sites and swamps for quick access by other scripts.
+10. **Regenerate Map Points** to forcibly rescan the entire map and update caches, ignoring any previously saved data.
 
 ### Debug Mode
 Debugging features are controlled by the `VSA_debugMode` setting. When enabled,

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -63,6 +63,7 @@ VIC_fnc_findBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_markBuildingCoverSpot  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_markBuildingCoverSpot.sqf");
 VIC_fnc_radioMessage          = compile preprocessFileLineNumbers (_root + "\functions\core\fn_radioMessage.sqf");
 VIC_fnc_initMap               = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initMap.sqf");
+VIC_fnc_regenMapPoints       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_regenMapPoints.sqf");
 VIC_fnc_initManagers          = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initManagers.sqf");
 
 if (isServer) then {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf
@@ -1,0 +1,27 @@
+/*
+    Rebuilds all map points from scratch and caches the results.
+*/
+
+["regenMapPoints"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { false };
+
+private _roads = [] call VIC_fnc_findRoads;
+["STALKER_roads", _roads] call VIC_fnc_saveCache;
+
+private _zones = [] call VIC_fnc_findLandZones;
+["STALKER_landZones", _zones] call VIC_fnc_saveCache;
+
+[] call VIC_fnc_findRockClusters;
+[] call VIC_fnc_findSniperSpots;
+[] call VIC_fnc_findSwamps;
+[] call VIC_fnc_findBeachesInMap;
+[] call VIC_fnc_findValleys;
+[] call VIC_fnc_findBridges;
+[] call VIC_fnc_findCrossroads;
+[] call VIC_fnc_findBuildingClusters;
+[] call VIC_fnc_findWrecks;
+
+"Map points regenerated" remoteExec ["hint", 0];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -292,6 +292,14 @@ player addAction ["<t color='#ffff00'>Place Cached Markers</t>", {
     };
 }];
 
+player addAction ["<t color='#00ff00'>Regenerate Map Points</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_regenMapPoints;
+    } else {
+        [] remoteExec ["VIC_fnc_regenMapPoints", 2];
+    };
+}];
+
 player addAction ["<t color='#00ff00'>Init Map</t>", {
     if (isServer) then {
         [] call VIC_fnc_initMap;


### PR DESCRIPTION
## Summary
- add `fn_regenMapPoints` for rebuilding cached map data
- compile the new function in `fn_masterInit.sqf`
- expose a new `Regenerate Map Points` action from debug menu
- document the new option in README

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf README.md`

------
https://chatgpt.com/codex/tasks/task_e_685245f70dd4832fa8da7e6964d858e0