### PR TITLE
Fix nil checks in core functions

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandAGL.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandAGL.sqf
@@ -12,5 +12,5 @@
 params ["_center", ["_radius",50], ["_attempts",10], ["_excludeTowns", false], ["_maxRadius", -1]];
 
 private _posASL = [_center,_radius,_attempts,_excludeTowns,_maxRadius] call VIC_fnc_findLandASL;
-if (isNil "_posASL" || {_posASL isEqualTo []}) exitWith { [] };
+if (isNil {_posASL} || {_posASL isEqualTo []}) exitWith { [] };
 ASLToAGL _posASL;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandASL.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandASL.sqf
@@ -55,7 +55,7 @@ while {_searchRadius <= _maxRadius && {_found isEqualTo []}} do {
         };
 
         if (
-            isNil "_candidate" ||
+            isNil {_candidate} ||
             {!(_candidate isEqualType [])} ||
             {count _candidate < 2}
         ) then { continue; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
@@ -8,10 +8,10 @@
 */
 params ["_name"];
 
-if (isNil "_name") exitWith { nil };
+if (isNil {_name}) exitWith { nil };
 
 private _data = profileNamespace getVariable [_name, nil];
-if (!isNil "_data") then {
+if (!isNil {_data}) then {
     missionNamespace setVariable [_name, _data];
     private _count = "";
     if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
@@ -9,9 +9,9 @@
 */
 params ["_name", ["_data", nil]];
 
-if (isNil "_name") exitWith { false };
-if (isNil "_data") then { _data = missionNamespace getVariable [_name, nil] };
-if (isNil "_data") exitWith { false };
+if (isNil {_name}) exitWith { false };
+if (isNil {_data}) then { _data = missionNamespace getVariable [_name, nil] };
+if (isNil {_data}) exitWith { false };
 
 profileNamespace setVariable [_name, _data];
 saveProfileNamespace;


### PR DESCRIPTION
## Summary
- fix return logic in `fn_findLandAGL` and `fn_findLandASL`
- correct local variable checks in cache helpers

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_findLandAGL.sqf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852cc6e604c832fb968d72234646dbd