### PR TITLE
Make land search local

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,12 +237,11 @@ shows the mod's branding in the launcher and in-game menus.
 ## Remote Execution
 
 Engine commands like `createMarker` and `setMarkerType` cannot be executed via
-`remoteExecCall` directly. They must run inside a script that you remote execute.
-Functions such as `VIC_fnc_createGlobalMarker` handle this by calling a local
-helper on each machine. To get a return value from the server, use
-`VIC_fnc_callServer`. This helper runs code on the server and sends the result
-back to the requesting client. `VIC_fnc_findLandAGLServer` demonstrates this
-pattern for finding land positions remotely.
+`remoteExecCall` directly. They must run inside a script that you remote
+execute. Functions such as `VIC_fnc_createGlobalMarker` handle this by calling a
+local helper on each machine. When a return value from the server is required,
+use `VIC_fnc_callServer`. Land position searches now run locally so
+`VIC_fnc_findLandAGLServer` is no longer needed.
 
 ## LAMBS Waypoints
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandAGLServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandAGLServer.sqf
@@ -1,8 +1,8 @@
 /*
-    Finds a land position using VIC_fnc_findLandAGL on the server and returns it.
+    Finds a land position using VIC_fnc_findLandAGL locally.
     Params: see VIC_fnc_findLandAGL
     Returns: ARRAY - AGL ground position or [] if none found
 */
 params ["_center", ["_radius",50], ["_attempts",10], ["_excludeTowns", false], ["_maxRadius", -1]];
 
-[VIC_fnc_findLandAGL, [_center, _radius, _attempts, _excludeTowns, _maxRadius]] call VIC_fnc_callServer;
+[_center, _radius, _attempts, _excludeTowns, _maxRadius] call VIC_fnc_findLandAGL;


### PR DESCRIPTION
## Summary
- run land search on the caller instead of using the callServer helper
- update remote execution docs to reflect the new behaviour

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_findLandAGLServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6853375b5db8832fb68b16338ee6264c