### PR TITLE
Improve land position search

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -1,29 +1,68 @@
 /*
-    Finds a nearby land position using simple random sampling.
+    Attempts to locate a nearby land position. The search gradually expands
+    outwards until a valid spot is found or the maximum radius is reached.
+
     Params:
-        0: POSITION - center position
-        1: NUMBER   - search radius (default 300)
-        2: NUMBER   - max attempts (default 20)
+        0: POSITION or OBJECT - center position
+        1: NUMBER            - initial search radius (default 50)
+        2: NUMBER            - attempts per radius step (default 10)
+        3: BOOL              - exclude towns from results (default false)
+        4: NUMBER            - maximum search radius (default: radius * 1.5)
+
     Returns:
         ARRAY - ground position AGL or nil if none found
 */
-params ["_centerPos", ["_radius", 300], ["_maxTries", 20]];
 
-private _attempt = 0;
+params [
+    "_centerPos",
+    ["_radius", 50],
+    ["_maxTries", 10],
+    ["_excludeTowns", false],
+    ["_maxRadius", -1]
+];
 
-while { _attempt < _maxTries } do {
-    private _angle = random 360;
-    private _dist  = random _radius;
-    private _candidate = _centerPos vectorAdd [
-        _dist * cos _angle,
-        _dist * sin _angle,
-        0
-    ];
+private _base = if (_centerPos isEqualType objNull) then { getPos _centerPos } else { _centerPos };
+if !(_base isEqualType []) exitWith { nil };
 
-    private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
-    if !(_surf isEqualTo []) exitWith { ASLToAGL _surf };
-
-    _attempt = _attempt + 1;
+_radius = _radius max 1;
+if (_maxRadius < 0) then {
+    _maxRadius = if (_radius < 200) then { _radius * 1.5 } else { _radius };
 };
 
-nil
+private _townRadius = ["VSA_townRadius", 500] call VIC_fnc_getSetting;
+private _worldSize  = worldSize;
+
+private _searchRadius = 0;
+private _result = [];
+
+scopeName "findLand";
+while { _searchRadius <= _maxRadius && {_result isEqualTo []} } do {
+    for "_i" from 0 to (_maxTries - 1) do {
+        private _candidate = if (_searchRadius == 0 && {_i == 0}) then {
+            _base
+        } else {
+            [_base, random _searchRadius, random 360] call BIS_fnc_relPos
+        };
+
+        if (
+            (_candidate select 0 < 0) ||
+            { _candidate select 1 < 0 } ||
+            { _candidate select 0 > _worldSize } ||
+            { _candidate select 1 > _worldSize }
+        ) then { continue; };
+
+        private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;
+        if (_surf isEqualTo []) then { continue; };
+
+        if (_excludeTowns) then {
+            private _towns = nearestLocations [ASLToAGL _surf, ["NameCity","NameVillage","NameCityCapital","NameLocal"], _townRadius];
+            if !(_towns isEqualTo []) then { continue; };
+        };
+
+        _result = ASLToAGL _surf;
+        breakOut "findLand";
+    };
+    _searchRadius = _searchRadius + _radius;
+};
+
+if (_result isEqualTo []) then { nil } else { _result }


### PR DESCRIPTION
## Summary
- enhance `VIC_fnc_findLandPosition` to expand search radius and avoid towns

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68533fd95fdc832f946e93705377f5c0