### PR TITLE
Remove early exits on nil

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_bridgeElectra"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_bridge;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_bridgeElectra: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_bridgeElectra: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_bridgeElectra: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -11,9 +11,9 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 ["createField_burner"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_burner;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_burner: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -21,7 +21,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_burner: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_burner: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_clicker"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_clicker;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_clicker: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_clicker: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_clicker: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -11,9 +11,9 @@ params ["_center","_radius", ["_count",1], ["_site", []]];
 
 ["fn_createField_comet"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_comet;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_comet: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -21,7 +21,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_comet: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_comet: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_electra"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_electra;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_electra: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_electra: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_electra: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_fruitpunch"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_fruitpunch;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_fruitpunch: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_fruitpunch: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_fruitpunch: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_gravi"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_gravi;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_gravi: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_gravi: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_gravi: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_launchpad"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_launchpad;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_launchpad: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_launchpad: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_launchpad: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_leech"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_leech;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_leech: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_leech: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (_site isEqualTo []) exitWith {
+if (count _site == 0) then {
     ["createField_leech: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_meatgrinder"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_meatgrinder;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_meatgrinder: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_meatgrinder: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_meatgrinder: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_springboard"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_springboard;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_springboard: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_springboard: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_springboard: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_trapdoor"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_trapdoor;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_trapdoor: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_trapdoor: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_trapdoor: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_whirligig"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_whirligig;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_whirligig: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_whirligig: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_whirligig: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -10,9 +10,9 @@
 params ["_center","_radius", ["_count",5], ["_site", []]];
 ["fn_createField_zapper"] call VIC_fnc_debugLog;
 
-if (isNil {_site} || {_site isEqualTo []}) then {
+if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_zapper;
-    if (_site isEqualTo []) exitWith {
+    if (count _site == 0) then {
         ["createField_zapper: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {_site isEqualTo []}) then {
     [format ["createField_zapper: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith {
+if (isNil {_site} || {count _site == 0}) then {
     ["createField_zapper: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
@@ -18,7 +18,7 @@ if (_bridges isEqualTo []) then {
 };
 
 private _candidates = _bridges select { _posCenter distance2D _x <= _radius };
-if (_candidates isEqualTo []) exitWith { [] };
+if (_candidates isEqualTo []) then { [] };
 
 private _bridge = selectRandom _candidates;
 private _pos = getPosATL _bridge;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _pos = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_pos} || {_pos isEqualTo []}) exitWith { [] };
+if (isNil {_pos} || {count _pos == 0}) then { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
@@ -12,5 +12,5 @@ private _posCenter = if (_center isEqualType objNull) then { getPos _center } el
 
 // Pick a random land position within the search radius
 private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
-if (isNil {_site} || {_site isEqualTo []}) exitWith { [] };
+if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -22,7 +22,6 @@ params [
 ];
 
 private _base = if (_centerPos isEqualType objNull) then { getPos _centerPos } else { _centerPos };
-if !(_base isEqualType []) exitWith { nil };
 
 _radius = _radius max 1;
 if (_maxRadius < 0) then {


### PR DESCRIPTION
## Summary
- keep `fn_findLandPosition` from exiting early
- drop early exits in anomaly fields
- drop early exits in anomaly site selection
- check land site arrays using `count site == 0`

## Testing
- `pre-commit run --files $(git status --short | awk '{print $2}')` *(fails: pre-commit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853453a01a4832f92794b44ef413cb6