### PR TITLE
Trim debug output

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf
@@ -8,7 +8,7 @@
 */
 params ["_type", ["_pos", [0,0,0]]];
 
-[format ["generateFieldName type %1 pos %2", _type, _pos]] call VIC_fnc_debugLog;
+["generateFieldName"] call VIC_fnc_debugLog;
 
 private _stalkers = [
     "Flynn","Artyom","Kolya","Strelok","Vasya","Boris","Petya","Fang","Ghost","Viktor",
@@ -162,5 +162,5 @@ private _patterns = [
 ];
 
 private _name = selectRandom _patterns;
-[format ["generateFieldName result %1", _name]] call VIC_fnc_debugLog;
+["generateFieldName result"] call VIC_fnc_debugLog;
 _name

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
@@ -32,7 +32,7 @@ if (isNil {_name} || { isNil {_pos} }) exitWith {
     ""
 };
 
-[format ["createGlobalMarker %1 @ %2", _name, _pos]] call VIC_fnc_debugLog;
+["createGlobalMarker"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith { _name };
 
@@ -40,6 +40,6 @@ private _target = if (_global) then { 0 } else { remoteExecutedOwner };
 
 [_name, _pos, _shape, _type, _color, _alpha, _text, _size] remoteExecCall ["VIC_fnc_createLocalMarker", _target, true];
 
-[format ["createGlobalMarker done %1", _name]] call VIC_fnc_debugLog;
+["createGlobalMarker done"] call VIC_fnc_debugLog;
 
 _name

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
@@ -12,5 +12,5 @@
 params ["_name", "_default"];
 
 private _value = missionNamespace getVariable [_name, _default];
-[format ["getSetting: %1 -> %2", _name, _value]] call VIC_fnc_debugLog;
+[format ["getSetting: %1", _name]] call VIC_fnc_debugLog;
 _value

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
@@ -15,9 +15,9 @@ if (!isNil {_data}) then {
     missionNamespace setVariable [_name, _data];
     private _count = "";
     if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };
-    [format ["loadCache: %1%2", _name, _count]] call VIC_fnc_debugLog;
+    ["loadCache: data found"] call VIC_fnc_debugLog;
 } else {
-    [format ["loadCache: no data for %1", _name]] call VIC_fnc_debugLog;
+    ["loadCache: no data"] call VIC_fnc_debugLog;
 };
 
 _data

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
@@ -18,6 +18,6 @@ saveProfileNamespace;
 
 private _count = "";
 if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };
-[format ["saveCache: %1%2", _name, _count]] call VIC_fnc_debugLog;
+["saveCache"] call VIC_fnc_debugLog;
 
 true


### PR DESCRIPTION
## Summary
- avoid leaking variable values in debug logs

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_generateFieldName.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685349d3e364832f9c03feac99478b8d