### PR TITLE
Remove debug logging from getSetting

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf
@@ -12,5 +12,5 @@
 params ["_name", "_default"];
 
 private _value = missionNamespace getVariable [_name, _default];
-[format ["getSetting: %1", _name]] call VIC_fnc_debugLog;
 _value
+


### PR DESCRIPTION
## Summary
- stop logging when retrieving settings

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_getSetting.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68534d3ce6a4832f9870e14b64ce0909