### PR TITLE
Fix findLandPosition bounds logic

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -44,10 +44,10 @@ while { _searchRadius <= _maxRadius && {_result isEqualTo []} } do {
         };
 
         if (
-            (_candidate select 0 < 0) ||
-            { _candidate select 1 < 0 } ||
-            { _candidate select 0 > _worldSize } ||
-            { _candidate select 1 > _worldSize }
+            ((_candidate select 0) < 0) ||
+            ((_candidate select 1) < 0) ||
+            ((_candidate select 0) > _worldSize) ||
+            ((_candidate select 1) > _worldSize)
         ) then { continue; };
 
         private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;


### PR DESCRIPTION
## Summary
- fix candidate bounds checks in `findLandPosition`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685351550814832f8dd71cd72a8a8ecd