### PR TITLE
Fix bracket condition in findLandPosition

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -45,9 +45,9 @@ while { _searchRadius <= _maxRadius && {_result isEqualTo []} } do {
 
         if (
             (_candidate select 0 < 0) ||
-            { _candidate select 1 < 0 } ||
-            { _candidate select 0 > _worldSize } ||
-            { _candidate select 1 > _worldSize }
+            (_candidate select 1 < 0) ||
+            (_candidate select 0 > _worldSize) ||
+            (_candidate select 1 > _worldSize)
         ) then { continue; };
 
         private _surf = [_candidate] call VIC_fnc_getLandSurfacePosition;


### PR DESCRIPTION
## Summary
- standardize bracket use in `fn_findLandPosition.sqf`

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685354311848832fac1fa8658e034bb4