### PR TITLE
Add land position finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,15 @@ Engine commands like `createMarker` and `setMarkerType` cannot be executed via
 execute. Functions such as `VIC_fnc_createGlobalMarker` handle this by calling a
 local helper on each machine. When a return value from the server is required,
 use `VIC_fnc_callServer`. Land position searches now run locally using
-`VIC_fnc_findLandPosition`.
+`VIC_fnc_findLandPosition`. For more control you can call
+`VIC_fnc_findLandPos` which walks the map until it finds safe, dry land.
+
+```sqf
+private _spot = [getPos player, 800] call VIC_fnc_findLandPos;
+```
+
+Modules that scatter mines, tripwires, anomaly fields and land zones rely on
+this helper to choose valid positions.
 
 ## LAMBS Waypoints
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_bridgeElectra: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_bridgeElectra: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_burner: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_burner: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_clicker: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_clicker: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_comet: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_comet: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_electra: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_electra: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_fruitpunch: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_fruitpunch: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_gravi: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_gravi: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_launchpad: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_launchpad: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_leech: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (count _site == 0) then {
     ["createField_leech: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_meatgrinder: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_meatgrinder: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_springboard: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_springboard: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_trapdoor: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_trapdoor: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_whirligig: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_whirligig: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -19,7 +19,7 @@ if (isNil {_site} || {count _site == 0}) then {
 } else {
     [format ["createField_zapper: using site %1", _site]] call VIC_fnc_debugLog;
 };
-_site = [_site] call VIC_fnc_findLandPosition;
+_site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then {
     ["createField_zapper: land position failed"] call VIC_fnc_debugLog;
     []

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
@@ -22,4 +22,4 @@ if (_candidates isEqualTo []) then { [] };
 
 private _bridge = selectRandom _candidates;
 private _pos = getPosATL _bridge;
-[_pos, 0, 10, false] call VIC_fnc_findLandPosition
+[_pos, 0, 10, false] call VIC_fnc_findLandPos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
@@ -11,6 +11,6 @@ params ["_center", "_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _pos = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _pos = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_pos} || {count _pos == 0}) then { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPosition;
+private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -60,7 +60,7 @@ for "_i" from 1 to _fieldCount do {
 
     if (random 100 >= _spawnWeight) then { continue };
 
-    private _pos = [[random worldSize, random worldSize, 0], 50, 10, false, worldSize] call VIC_fnc_findLandPosition;
+    private _pos = [[random worldSize, random worldSize, 0], 50, 10, false, worldSize] call VIC_fnc_findLandPos;
     if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
 
     private _fn = selectRandom _types;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf
@@ -1,0 +1,68 @@
+/*
+    Finds and returns the FIRST valid land position that meets the
+    supplied constraints.
+
+    Params
+    ──────────────────────────────────────────────────────────────
+      0: ARRAY centrePos        – centre of search area (ASL or ATL)
+      1: NUMBER searchRadius    – metres (default 1000)
+      2: NUMBER minWaterDist    – metres from shoreline/water (30)
+      3: NUMBER maxSlopeDeg     – maximum ground slope in degrees (30)
+      4: ARRAY  blacklistPos    – array of positions to avoid (default [])
+      5: NUMBER clearanceRad    – empty space radius for BIS_fnc_isPosEmpty (5)
+      6: NUMBER maxAttempts     – failsafe loop guard (200)
+
+    Returns
+    ──────────────────────────────────────────────────────────────
+      ARRAY positionATL         – the first good position
+      []                        – if none found within attempt budget
+*/
+params [
+    ["_centrePos",   [0,0,0],   [[]]  ],
+    ["_radius",         1000,   [0]   ],
+    ["_minWaterDist",     30,   [0]   ],
+    ["_maxSlope",         30,   [0]   ],
+    ["_blacklist",        [],   [[]]  ],
+    ["_clearanceRad",      5,   [0]   ],
+    ["_maxAttempts",     200,   [0]   ]
+];
+
+private _degToSlope = {
+    /* converts a surfaceNormal vector into slope-angle in degrees   */
+    90 - acos (_this vectorDotProduct [0,0,1])
+};
+
+scopeName "findLand";
+private _result = [];
+for "_i" from 1 to _maxAttempts do {
+
+    /* ─ generate a random candidate in the search circle ───────── */
+    private _p = _centrePos getPos [random _radius, random 360];
+
+    /* ─ REJECT #1: water cell? ─────────────────────────────────── */
+    if (surfaceIsWater _p) then { continue };
+
+    /* ─ REJECT #2: coastline / lake edge too close? ────────────── */
+    private _nearWater = false;
+    for "_a" from 0 to 315 step 45 do {
+        if (surfaceIsWater (_p getPos [_minWaterDist, _a])) exitWith { _nearWater = true };
+    };
+    if (_nearWater) then { continue };
+
+    /* ─ REJECT #3: slope too steep? ────────────────────────────── */
+    if ([surfaceNormal _p] call _degToSlope > _maxSlope) then { continue };
+
+    /* ─ REJECT #4: inside map clutter or other objects? ───────── */
+    if !([ _p, _clearanceRad, [], 0, "CAN_COLLIDE" ] call BIS_fnc_isPosEmpty) then { continue };
+
+    /* ─ REJECT #5: user black-list check (25 m radius) ────────── */
+    private _nearBlk = {
+        _p distance2D _x < 25
+    } count _blacklist > 0;
+    if (_nearBlk) then { continue };
+
+    _result = _p;
+    breakOut "findLand";
+};
+
+_result

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
@@ -1,6 +1,6 @@
 /*
     Finds mostly evenly distributed land positions across the map using a grid search.
-    Each grid cell tries to locate one valid land position using VIC_fnc_findLandPosition.
+    Each grid cell tries to locate one valid land position using VIC_fnc_findLandPos.
 
     Params:
         0: NUMBER - grid step size in meters (default: 1000)
@@ -19,7 +19,7 @@ private _half = _step / 2;
 for "_x" from 0 to worldSize step _step do {
     for "_y" from 0 to worldSize step _step do {
         private _center = [_x + _half, _y + _half, 0];
-        private _pos = [_center, _half, 10, _excludeTowns, _half] call VIC_fnc_findLandPosition;
+        private _pos = [_center, _half, 10, _excludeTowns, _half] call VIC_fnc_findLandPos;
         if (isNil {_pos}) then { _pos = [] };
         if !(_pos isEqualTo []) then {
             _zones pushBack _pos;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -181,6 +181,7 @@ VIC_fnc_registerEmissionHooks    = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_getSurfacePosition       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_getSurfacePosition.sqf");
 VIC_fnc_isWaterPosition         = compile preprocessFileLineNumbers (_root + "\functions\core\fn_isWaterPosition.sqf");
 VIC_fnc_findLandPosition       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findLandPosition.sqf");
+VIC_fnc_findLandPos = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findLandPos.sqf");
 VIC_fnc_getLandSurfacePosition  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_getLandSurfacePosition.sqf");
 VIC_fnc_findRoadPosition        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRoadPosition.sqf");
 VIC_fnc_findRandomRoadPosition  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRandomRoadPosition.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf
@@ -19,7 +19,7 @@ private _spacing = 5;
 for "_xOff" from -_half to _half step _spacing do {
     for "_yOff" from -_half to _half step _spacing do {
         private _pos = [(_center select 0) + _xOff, (_center select 1) + _yOff, 0];
-        _pos = [_pos] call VIC_fnc_findLandPosition;
+        _pos = [_pos] call VIC_fnc_findLandPos;
         if (isNil {_pos} || {_pos isEqualTo []}) then { continue; };
         private _mine = createMine ["APERSMine", _pos, [], 0];
         _objs pushBack _mine;

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -40,7 +40,7 @@ for "_i" from 1 to _fieldCount do {
         private _town = selectRandom _towns;
         private _tPos = locationPosition _town;
         _pos = _tPos getPos [150 + random 200, random 360];
-        _pos = [_pos] call VIC_fnc_findLandPosition;
+        _pos = [_pos] call VIC_fnc_findLandPos;
     };
     if (isNil {_pos} || { _pos isEqualTo [] }) then { continue; };
     private _marker = "";

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
@@ -22,7 +22,7 @@ for "_i" from 0 to (_count - 1) do {
     private _dist = _radius - random 5;
     private _angle = _offset + (360 / _count) * _i;
     private _pos = _center getPos [_dist, _angle];
-    _pos = [_pos] call VIC_fnc_findLandPosition;
+    _pos = [_pos] call VIC_fnc_findLandPos;
     if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
     _positions pushBack _pos;
 };


### PR DESCRIPTION
## Summary
- add VIC_fnc_findLandPos for locating safe land
- compile the helper during masterInit
- document land search helper in README
- use VIC_fnc_findLandPos when spawning mines, tripwires, anomalies and land zones

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf $(ls addons/Viceroys-STALKER-ALife/functions/anomalies/fields/*.sqf) $(ls addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/*.sqf)`


------
https://chatgpt.com/codex/tasks/task_e_68535942e7e0832f847858b99b602354