### PR TITLE
Fix findLandZones function

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
@@ -1,6 +1,7 @@
 /*
     Finds mostly evenly distributed land positions across the map using a grid search.
-    Each grid cell tries to locate one valid land position using VIC_fnc_findLandPos.
+    Each grid cell tries to locate one valid land position using
+    VIC_fnc_findLandPosition.
 
     Params:
         0: NUMBER - grid step size in meters (default: 1000)
@@ -19,7 +20,8 @@ private _half = _step / 2;
 for "_x" from 0 to worldSize step _step do {
     for "_y" from 0 to worldSize step _step do {
         private _center = [_x + _half, _y + _half, 0];
-        private _pos = [_center, _half, 10, _excludeTowns, _half] call VIC_fnc_findLandPos;
+        private _pos = [_center, _half, 10, _excludeTowns, _half] call
+            VIC_fnc_findLandPosition;
         if (isNil {_pos}) then { _pos = [] };
         if !(_pos isEqualTo []) then {
             _zones pushBack _pos;


### PR DESCRIPTION
## Summary
- use `VIC_fnc_findLandPosition` in land zone generation

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68535e5b69dc832f8447c462b9a5f0a9