### PR TITLE
Fix land position check using getSurfacePosition

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
@@ -13,5 +13,5 @@ if ((count _pos) < 2) exitWith { false };
 
 _pos params [["_x",0],["_y",0],["_z",0]];
 
-private _asl = AGLToASL [_x,_y,_z];
-(surfaceIsWater _asl)
+private _surf = [_x,_y,_z] call VIC_fnc_getSurfacePosition;
+(ASLToAGL _surf select 2) <= 0


### PR DESCRIPTION
## Summary
- use `getSurfacePosition` for candidate land positions
- update water checks to rely on altitude rather than `surfaceIsWater`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68536192e33c832fa02958e947b8ee5f