### PR TITLE
Clarify remoteExecCall behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,16 @@ use `VIC_fnc_callServer`. Land position searches now run locally using
 `VIC_fnc_findLandPosition`. For more control you can call
 `VIC_fnc_findLandPos` which walks the map until it finds safe, dry land.
 
+Calling `VIC_fnc_findLandPos` (or any other function) with `remoteExecCall`
+will only return `true` or `false` because the command reports the remote
+execution status. To obtain the position returned by the function, wrap it with
+`VIC_fnc_callServer`:
+
+```sqf
+private _spot = [{ [getPos player, 800] call VIC_fnc_findLandPos }] call
+    VIC_fnc_callServer;
+```
+
 ```sqf
 private _spot = [getPos player, 800] call VIC_fnc_findLandPos;
 ```


### PR DESCRIPTION
## Summary
- explain that `remoteExecCall` only returns a boolean
- add example showing how to use `VIC_fnc_callServer` to get a land position

## Testing
- `scripts/sqflint-hook.sh $(git ls-files "*.sqf")` *(fails: various sqflint warnings about unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68536462773c832f836fc6f3c212772a