### PR TITLE
Fix findLandPos argument mismatch

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_bridge.sqf
@@ -22,4 +22,4 @@ if (_candidates isEqualTo []) then { [] };
 
 private _bridge = selectRandom _candidates;
 private _pos = getPosATL _bridge;
-[_pos, 0, 10, false] call VIC_fnc_findLandPos
+[_pos, 0, 10] call VIC_fnc_findLandPos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf
@@ -11,6 +11,6 @@ params ["_center", "_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_clicker.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_comet.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_electra.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_fruitpunch.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _pos = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _pos = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_pos} || {count _pos == 0}) then { [] };
 _pos

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_gravi.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_launchpad.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_leech.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_meatgrinder.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_springboard.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_trapdoor.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_whirligig.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_zapper.sqf
@@ -11,6 +11,6 @@ params ["_center","_radius"];
 private _posCenter = if (_center isEqualType objNull) then { getPos _center } else { _center };
 
 // Pick a random land position within the search radius
-private _site = [_posCenter, _radius, 10, false] call VIC_fnc_findLandPos;
+private _site = [_posCenter, _radius, 10] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) then { [] };
 _site

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -60,7 +60,7 @@ for "_i" from 1 to _fieldCount do {
 
     if (random 100 >= _spawnWeight) then { continue };
 
-    private _pos = [[random worldSize, random worldSize, 0], 50, 10, false, worldSize] call VIC_fnc_findLandPos;
+    private _pos = [[random worldSize, random worldSize, 0], worldSize, 10] call VIC_fnc_findLandPos;
     if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
 
     private _fn = selectRandom _types;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandZones.sqf
@@ -4,12 +4,11 @@
 
     Params:
         0: NUMBER - grid step size in meters (default: 1000)
-        1: BOOL   - exclude towns when sampling (default: true)
 
     Returns:
         ARRAY of POSITIONs - Land positions in AGL coordinates
 */
-params [["_step", 1000], ["_excludeTowns", true]];
+params [["_step", 1000]];
 
 ["findLandZones"] call VIC_fnc_debugLog;
 
@@ -19,7 +18,7 @@ private _half = _step / 2;
 for "_x" from 0 to worldSize step _step do {
     for "_y" from 0 to worldSize step _step do {
         private _center = [_x + _half, _y + _half, 0];
-        private _pos = [_center, _half, 10, _excludeTowns, _half] call VIC_fnc_findLandPos;
+        private _pos = [_center, _half, 10] call VIC_fnc_findLandPos;
         if (isNil {_pos}) then { _pos = [] };
         if !(_pos isEqualTo []) then {
             _zones pushBack _pos;


### PR DESCRIPTION
## Summary
- correct `VIC_fnc_findLandPos` calls that passed a bool instead of max slope
- adjust land zone generator parameter list
- search fields with proper radius across map

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/anomalies/find_sites/fn_findSite_burner.sqf && echo OK`
- `bash scripts/sqflint-hook.sh $changed_files && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68536462773c832f836fc6f3c212772a