### PR TITLE
Simplify land position search

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,11 @@ Engine commands like `createMarker` and `setMarkerType` cannot be executed via
 `remoteExecCall` directly. They must run inside a script that you remote
 execute. Functions such as `VIC_fnc_createGlobalMarker` handle this by calling a
 local helper on each machine. When a return value from the server is required,
-use `VIC_fnc_callServer`. Land position searches now run locally using
-`VIC_fnc_findLandPosition`. For more control you can call
-`VIC_fnc_findLandPos` which walks the map until it finds safe, dry land. It
-leverages `BIS_fnc_randomPos` to generate land-safe candidate spots.
+use `VIC_fnc_callServer`. Land position searches now rely directly on
+`BIS_fnc_randomPos` to pick a dry location.
 
 ```sqf
-private _spot = [getPos player, 800] call VIC_fnc_findLandPos;
+private _spot = [[[getPos player, 800]], ["water"]] call BIS_fnc_randomPos;
 ```
 
 Modules that scatter mines, tripwires, anomaly fields and land zones rely on

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf
@@ -1,21 +1,21 @@
 /*
-    Finds and returns the FIRST valid land position that meets the
-    supplied constraints.
+    Returns a land position around the given centre using BIS_fnc_randomPos.
+    The original search logic has been replaced entirely by the BIS helper.
 
     Params
     ──────────────────────────────────────────────────────────────
       0: ARRAY centrePos        – centre of search area (ASL or ATL)
       1: NUMBER searchRadius    – metres (default 1000)
-      2: NUMBER minWaterDist    – metres from shoreline/water (30)
-      3: NUMBER maxSlopeDeg     – maximum ground slope in degrees (30)
-      4: ARRAY  blacklistPos    – array of positions to avoid (default [])
-      5: NUMBER clearanceRad    – empty space radius for BIS_fnc_isPosEmpty (5)
-      6: NUMBER maxAttempts     – failsafe loop guard (200)
+      2: NUMBER minWaterDist    – unused, kept for API compatibility
+      3: NUMBER maxSlopeDeg     – unused, kept for API compatibility
+      4: ARRAY  blacklistPos    – unused, kept for API compatibility
+      5: NUMBER clearanceRad    – unused, kept for API compatibility
+      6: NUMBER maxAttempts     – unused, kept for API compatibility
 
     Returns
     ──────────────────────────────────────────────────────────────
-      ARRAY positionATL         – the first good position
-      []                        – if none found within attempt budget
+      ARRAY positionATL         – random land position
+      []                        – if none found
 */
 params [
     ["_centrePos",   [0,0,0],   [[]]  ],
@@ -27,51 +27,5 @@ params [
     ["_maxAttempts",     200,   [0]   ]
 ];
 
-private _degToSlope = {
-    /* converts a surfaceNormal vector into slope-angle in degrees   */
-    90 - acos (_this vectorDotProduct [0,0,1])
-};
-
-private _isPosClear = {
-    /* simple fallback check when BIS_fnc_isPosEmpty isn't available */
-    params ["_posATL", "_radius"];
-    (nearestObjects [_posATL, [], _radius]) isEqualTo []
-};
-
-scopeName "findLand";
-private _result = [];
-for "_i" from 1 to _maxAttempts do {
-
-    /* ─ generate a random candidate in the search circle ───────── */
-    private _p = [[[ _centrePos, _radius ]], ["water"]] call BIS_fnc_randomPos;
-    if ((_p isEqualTo [0,0]) || { _p isEqualTo [0,0,0] }) then { continue };
-    private _surf = [_p] call VIC_fnc_getSurfacePosition;
-
-    /* ─ REJECT #1: below sea level implies water ──────────────── */
-    if ((ASLToAGL _surf select 2) <= 0) then { continue };
-
-    /* ─ REJECT #2: coastline / lake edge too close? ────────────── */
-    private _nearWater = false;
-    for "_a" from 0 to 315 step 45 do {
-        private _edgeSurf = [_p getPos [_minWaterDist, _a]] call VIC_fnc_getSurfacePosition;
-        if ((ASLToAGL _edgeSurf select 2) <= 0) exitWith { _nearWater = true };
-    };
-    if (_nearWater) then { continue };
-
-    /* ─ REJECT #3: slope too steep? ────────────────────────────── */
-    if ((surfaceNormal ASLToATL _surf) call _degToSlope > _maxSlope) then { continue };
-
-    /* ─ REJECT #4: inside map clutter or other objects? ───────── */
-    if !([ASLToATL _surf, _clearanceRad] call _isPosClear) then { continue };
-
-    /* ─ REJECT #5: user black-list check (25 m radius) ────────── */
-    private _nearBlk = {
-        _surf distance2D _x < 25
-    } count _blacklist > 0;
-    if (_nearBlk) then { continue };
-
-    _result = ASLToATL _surf;
-    breakOut "findLand";
-};
-
-_result
+private _p = [[[ _centrePos, _radius ]], ["water"]] call BIS_fnc_randomPos;
+if ((_p isEqualTo [0,0]) || { _p isEqualTo [0,0,0] }) then { [] } else { _p }


### PR DESCRIPTION
## Summary
- use BIS_fnc_randomPos for all land position searches
- update README for new usage

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68536e441c94832fb9251682d95717a9