### PR TITLE
Fix water detection helper

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf
@@ -13,5 +13,5 @@ if ((count _pos) < 2) exitWith { false };
 
 _pos params [["_x",0],["_y",0],["_z",0]];
 
-private _surf = [_x,_y,_z] call VIC_fnc_getSurfacePosition;
+private _surf = [[_x,_y,_z]] call VIC_fnc_getSurfacePosition;
 (ASLToAGL _surf select 2) <= 0


### PR DESCRIPTION
## Summary
- fix parameter passing for `VIC_fnc_isWaterPosition`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_isWaterPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68537451c9a4832f9e687800a8c428f8