### PR TITLE
Fix early return in anomaly field scripts

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_bridge;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_bridgeElectra: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_bridgeElectra: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_bridgeElectra: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -13,7 +13,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_burner;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_burner: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -21,7 +21,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_burner: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_burner: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_clicker;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_clicker: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_clicker: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_clicker: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -13,7 +13,7 @@ params ["_center","_radius", ["_count",1], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_comet;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_comet: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -21,7 +21,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_comet: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_comet: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_electra;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_electra: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_electra: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_electra: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_fruitpunch;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_fruitpunch: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_fruitpunch: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_fruitpunch: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_gravi;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_gravi: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_gravi: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_gravi: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_launchpad;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_launchpad: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_launchpad: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_launchpad: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_leech;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_leech: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_leech: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (count _site == 0) then {
+if (count _site == 0) exitWith {
     ["createField_leech: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_meatgrinder;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_meatgrinder: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_meatgrinder: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_meatgrinder: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_springboard;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_springboard: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_springboard: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_springboard: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_trapdoor;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_trapdoor: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_trapdoor: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_trapdoor: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_whirligig;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_whirligig: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_whirligig: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_whirligig: land position failed"] call VIC_fnc_debugLog;
     []
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -12,7 +12,7 @@ params ["_center","_radius", ["_count",5], ["_site", []]];
 
 if (isNil {_site} || {count _site == 0}) then {
     _site = [_center,_radius] call VIC_fnc_findSite_zapper;
-    if (count _site == 0) then {
+    if (count _site == 0) exitWith {
         ["createField_zapper: no site"] call VIC_fnc_debugLog;
         []
     };
@@ -20,7 +20,7 @@ if (isNil {_site} || {count _site == 0}) then {
     [format ["createField_zapper: using site %1", _site]] call VIC_fnc_debugLog;
 };
 _site = [_site] call VIC_fnc_findLandPos;
-if (isNil {_site} || {count _site == 0}) then {
+if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_zapper: land position failed"] call VIC_fnc_debugLog;
     []
 };


### PR DESCRIPTION
## Summary
- ensure anomaly field creation exits on invalid site
- update all anomaly field functions to exit properly

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68541f6b4de4832f9149d583926b9400