### PR TITLE
Adjust proximity update rate and marker opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Each habitat now uses an ellipse marker to show its bounds and a labeled icon displaying the current population (e.g. `Bloodsucker Habitat: 4/12`).
 * Systems rely on **fn_hasPlayersNearby.sqf** so habitats sleep and despawn when players are farther than the configured nearby range (default 1500m).
 * Habitats now spawn empty and gain one mutant each habitat cycle when no players are nearby.
-* Player proximity is checked every 5 seconds via `VSA_proximityCheckInterval`.
+* Player proximity is checked continuously by default via `VSA_proximityCheckInterval`.
 * Habitat updates run on their own timer via `VSA_habitatCheckInterval`.
 * Habitat and herd counts update immediately when mutants are killed.
 * Habitat placement now selects random buildings, forests and swamps with weighted preferences.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -629,7 +629,7 @@ true
 ["VSA_predatorRange","SLIDER",["Predator Range","Distance from players to spawn predators"],"Viceroy's STALKER ALife - Mutants",[0, 7500, 1500, 0]] call CBA_fnc_addSetting;
 ["VSA_predatorCheckIntervalDay","SLIDER",["Predator Check (Day)","Seconds between predator attack checks during daylight"],"Viceroy's STALKER ALife - Mutants",[60, 900, 600, 0]] call CBA_fnc_addSetting;
 ["VSA_predatorCheckIntervalNight","SLIDER",["Predator Check (Night)","Seconds between predator attack checks at night"],"Viceroy's STALKER ALife - Mutants",[60, 900, 300, 0]] call CBA_fnc_addSetting;
-["VSA_proximityCheckInterval","SLIDER",["Proximity Check Interval","Seconds between player distance checks"],"Viceroy's STALKER ALife - Mutants",[10, 300, 5, 0]] call CBA_fnc_addSetting;
+["VSA_proximityCheckInterval","SLIDER",["Proximity Check Interval","Seconds between player distance checks (0 for constant)"],"Viceroy's STALKER ALife - Mutants",[0, 300, 0, 0]] call CBA_fnc_addSetting;
 ["VSA_habitatCheckInterval","SLIDER",["Habitat Check Interval","Seconds between habitat updates"],"Viceroy's STALKER ALife - Mutants",[1, 60, 5, 0]] call CBA_fnc_addSetting;
 
 [

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -12,7 +12,7 @@ if (!isServer) exitWith { false };
     {
         while { true } do {
             [] call VIC_fnc_updateProximity;
-            private _delay = ["VSA_proximityCheckInterval", 5] call VIC_fnc_getSetting;
+            private _delay = ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting;
             sleep _delay;
         };
     }, [], 8

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
@@ -21,7 +21,7 @@ if (isNil "STALKER_playerRangeMarker") then { STALKER_playerRangeMarker = "" };
             STALKER_playerRangeMarker = createMarkerLocal [_name, position player];
             STALKER_playerRangeMarker setMarkerShape "ELLIPSE";
             STALKER_playerRangeMarker setMarkerColor "ColorBlue";
-            STALKER_playerRangeMarker setMarkerAlphaLocal 0.05;
+            STALKER_playerRangeMarker setMarkerAlphaLocal 0.15;
         };
         STALKER_playerRangeMarker setMarkerPosLocal position player;
         STALKER_playerRangeMarker setMarkerSizeLocal [_range, _range];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -210,7 +210,7 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
         {
             while {true} do {
                 [] call VIC_fnc_updateProximity;
-                private _delay = ["VSA_proximityCheckInterval", 5] call VIC_fnc_getSetting;
+                private _delay = ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting;
                 sleep _delay;
             };
         }, [], 8


### PR DESCRIPTION
## Summary
- run constant proximity updates in background managers
- make player range markers easier to see
- allow 0-second proximity interval via settings
- document new default proximity behavior

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68542195a3c8832fac70549fe63425a3