### PR TITLE
Add grid-based player proximity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
   also receive thematic names on their map markers. When no towns are nearby the
   names fall back to generic locations like the coast, a hill or a forest based
   on the surrounding terrain.
-* Anomalies only activate when players are nearby and go dormant when no one is in range.
+* Anomalies only activate when players are nearby and go dormant when no one is in range. The activity grid system now checks map squares around players to toggle fields efficiently.
 
 ### Mutants
 * Spawns roaming mutant packs and ambient herds.
@@ -47,6 +47,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Systems rely on **fn_hasPlayersNearby.sqf** so habitats sleep and despawn when players are farther than the configured nearby range (default 1500m).
 * Habitats now spawn empty and gain one mutant each habitat cycle when no players are nearby.
 * Player proximity is checked continuously by default via `VSA_proximityCheckInterval`.
+* A grid-based proximity system activates habitats only when their map square is within range of any player.
 * Habitat updates run on their own timer via `VSA_habitatCheckInterval`.
 * Habitat and herd counts update immediately when mutants are killed.
 * Habitat placement now selects random buildings, forests and swamps with weighted preferences.
@@ -72,6 +73,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Generates APERS minefields on town outskirts and single IEDs on roads.
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way.
+* When debug mode is enabled the activity grid is drawn on the map with yellow dashed blocks for active squares and black dashed blocks for inactive ones.
 * Abandoned and damaged vehicles may appear on or near roads.
 * Tripwires and booby traps can spawn inside buildings around towns.
 * Fallen players leave a red X marker that vanishes once the body is removed.

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
@@ -10,7 +10,21 @@
 
 params ["_pos", "_radius"];
 
-// Search all players on the server and return true when one is close
+// Use the activity grid when available for quick lookups
+if (!isNil "STALKER_activityGrid") exitWith {
+    private _size = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+    private _gx = floor ((_pos select 0) / _size);
+    private _gy = floor ((_pos select 1) / _size);
+    private _key = format ["%1_%2", _gx, _gy];
+    private _near = false;
+    {
+        _x params ["_cell","_state"];
+        if (_cell == _key) exitWith { _near = _state; };
+    } forEach STALKER_activityGrid;
+    _near
+};
+
+// Fallback radial search
 private _nearby = false;
 {
     if (alive _x && { _x distance2D _pos <= _radius }) exitWith { _nearby = true };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -12,7 +12,8 @@ if (!isServer) exitWith { false };
     {
         while { true } do {
             [] call VIC_fnc_updateProximity;
-            private _delay = ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting;
+            [] call VIC_fnc_updateActivityGrid;
+            private _delay = if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {5} else { ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting };
             sleep _delay;
         };
     }, [], 8

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -163,6 +163,7 @@ VIC_fnc_manageHostiles           = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_manageNests              = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageNests.sqf");
 VIC_fnc_manageHabitats           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageHabitats.sqf");
 VIC_fnc_updateProximity          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_updateProximity.sqf");
+VIC_fnc_updateActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_updateActivityGrid.sqf");
 VIC_fnc_onMutantKilled           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_onMutantKilled.sqf");
 VIC_fnc_initMutantUnit          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_initMutantUnit.sqf");
 panic_fnc_onEmissionBuildUp  = compile preprocessFileLineNumbers (_root + "\functions\panic\fn_onEmissionBuildUp.sqf");
@@ -201,6 +202,7 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
 
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
+    missionNamespace setVariable ["STALKER_activityGridSize", 500];
     [] call VIC_fnc_registerEmissionHooks;
     if (call VIC_fnc_isAntistasiUltimate && { ["VSA_disableA3UWeather", false] call VIC_fnc_getSetting }) then {
         [] call VIC_fnc_disableA3UWeather;
@@ -210,7 +212,8 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
         {
             while {true} do {
                 [] call VIC_fnc_updateProximity;
-                private _delay = ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting;
+                [] call VIC_fnc_updateActivityGrid;
+                private _delay = if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {5} else { ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting };
                 sleep _delay;
             };
         }, [], 8

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
@@ -1,0 +1,90 @@
+/*
+    Updates the grid-based activity map around players and draws debug markers.
+    Uses simple arrays for compatibility with sqflint.
+
+    Returns: BOOL
+*/
+
+["updateActivityGrid"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {false};
+
+if (isNil "STALKER_activityGrid") then { STALKER_activityGrid = [] };
+if (isNil "STALKER_activityMarkers") then { STALKER_activityMarkers = [] };
+
+private _size = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+private _diag  = sqrt 2 * (_size / 2);
+private _half  = _size / 2;
+
+private _cells = [];
+
+{
+    if (!alive _x) then { continue };
+    private _pos = getPos _x;
+    private _gx = floor ((_pos select 0) / _size);
+    private _gy = floor ((_pos select 1) / _size);
+    private _rad = ceil((_range + _diag) / _size);
+    for "_ix" from (_gx - _rad) to (_gx + _rad) do {
+        for "_iy" from (_gy - _rad) to (_gy + _rad) do {
+            private _cx = _ix * _size + _half;
+            private _cy = _iy * _size + _half;
+            if (_pos distance2D [_cx,_cy,0] <= (_range + _diag)) then {
+                private _key = format ["%1_%2", _ix, _iy];
+                if (_cells find _key < 0) then { _cells pushBack _key; };
+            };
+        };
+    };
+} forEach allPlayers;
+
+// Update grid states
+for [{_i=0},{_i < count STALKER_activityGrid},{_i=_i+1}] do {
+    private _entry = STALKER_activityGrid select _i;
+    private _key = _entry select 0;
+    private _isActive = (_cells find _key) > -1;
+    STALKER_activityGrid set [_i, [_key, _isActive]];
+};
+
+// Add new active cells
+{
+    private _key = _x;
+    private _exists = false;
+    for [{_i=0},{_i < count STALKER_activityGrid},{_i=_i+1}] do {
+        if ((STALKER_activityGrid select _i) select 0 == _key) exitWith { _exists = true; };
+    };
+    if (!_exists) then { STALKER_activityGrid pushBack [_key, true]; };
+} forEach _cells;
+
+private _debug = ["VSA_debugMode", false] call VIC_fnc_getSetting;
+
+if (_debug) then {
+    {
+        _x params ["_key","_active"];
+        private _idx = -1;
+        for [{_j=0},{_j < count STALKER_activityMarkers},{_j=_j+1}] do {
+            if ((STALKER_activityMarkers select _j) select 0 == _key) exitWith { _idx = _j; };
+        };
+        private _marker = "";
+        if (_idx >= 0) then {
+            _marker = STALKER_activityMarkers select _idx select 1;
+        } else {
+            private _parts = _key splitString "_";
+            private _mx = (parseNumber (_parts select 0)) * _size + _half;
+            private _my = (parseNumber (_parts select 1)) * _size + _half;
+            private _name = format ["grid_%1", _key];
+            _marker = [_name, [_mx, _my, 0], "RECTANGLE", "", "ColorBlack", 0.1, "", [_size, _size], true] call VIC_fnc_createGlobalMarker;
+            _marker setMarkerBrush "Border";
+            STALKER_activityMarkers pushBack [_key, _marker];
+        };
+        _marker setMarkerColor (if (_active) then {"ColorYellow"} else {"ColorBlack"});
+        _marker setMarkerAlpha 0.1;
+    } forEach STALKER_activityGrid;
+} else {
+    {
+        _x params ["_key","_marker"];
+        if (_marker != "") then { deleteMarker _marker; };
+    } forEach STALKER_activityMarkers;
+    STALKER_activityMarkers = [];
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf
@@ -1,7 +1,10 @@
 /*
     Periodically updates player proximity for mutant habitats and herds.
 */
+
 ["updateProximity"] call VIC_fnc_debugLog;
+
+[] call VIC_fnc_updateActivityGrid;
 
 if (!isServer) exitWith {};
 


### PR DESCRIPTION
## Summary
- build a grid-based activity tracking system
- update player proximity checks to use the grid
- run proximity loop every 5s when autoinit is enabled
- show active/inactive grid blocks when debugging
- document new system in README

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685425c847e4832f8f88b6c7d29b373a