### PR TITLE
Fix comet path with waypoint objects

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -46,7 +46,15 @@ for "_i" from 1 to _count do {
         private _off = [_site, 20 + random 10, _j * 90] call BIS_fnc_relPos;
         private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
         if (_surf isEqualTo []) then { continue };
-        _path pushBack _surf;
+
+        // Create an invisible logic object for the waypoint so the comet has
+        // an actual entity to follow.
+        private _name = format ["comet_%1_%2", _i, _j];
+        private _wp = createVehicle ["Logic", ASLToATL _surf, [], 0, "NONE"];
+        _wp setVehicleVarName _name;
+        missionNamespace setVariable [_name, _wp];
+
+        _path pushBack _wp;
     };
     if (_path isEqualTo []) then { continue };
     private _anom = [_path] call _create;


### PR DESCRIPTION
## Summary
- spawn invisible logic objects for comet path waypoints and name them

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685483ea1f4c832fb1730eae2784a3ec