### PR TITLE
Fix land zone markers and improve cache debug logging

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
@@ -15,9 +15,9 @@ if (!isNil {_data}) then {
     missionNamespace setVariable [_name, _data];
     private _count = "";
     if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };
-    ["loadCache: data found"] call VIC_fnc_debugLog;
+    [format ["loadCache %1%2", _name, _count]] call VIC_fnc_debugLog;
 } else {
-    ["loadCache: no data"] call VIC_fnc_debugLog;
+    [format ["loadCache %1: none", _name]] call VIC_fnc_debugLog;
 };
 
 _data

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf
@@ -17,7 +17,10 @@ if (isNil "STALKER_landZoneMarkers") then { STALKER_landZoneMarkers = [] };
 } forEach STALKER_landZoneMarkers;
 STALKER_landZoneMarkers = [];
 
-if (isNil "STALKER_landZones") exitWith { false };
+if (isNil "STALKER_landZones") then {
+    private _cached = ["STALKER_landZones"] call VIC_fnc_loadCache;
+    if (isNil {_cached}) exitWith { false };
+};
 private _zones = STALKER_landZones;
 
 {
@@ -25,5 +28,7 @@ private _zones = STALKER_landZones;
     private _mkr = [_name, _x, "ICON", "mil_triangle", "ColorYellow", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
     STALKER_landZoneMarkers pushBack _mkr;
 } forEach _zones;
+
+[format ["markLandZones: placed %1 markers", count _zones]] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
@@ -18,6 +18,6 @@ saveProfileNamespace;
 
 private _count = "";
 if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };
-["saveCache"] call VIC_fnc_debugLog;
+[format ["saveCache %1%2", _name, _count]] call VIC_fnc_debugLog;
 
 true


### PR DESCRIPTION
## Summary
- load land zone cache if missing when marking land zones
- log marker count when marking land zones
- include item counts in saveCache and loadCache debug messages

## Testing
- `make --version`

------
https://chatgpt.com/codex/tasks/task_e_685484af5f94832f9dc299454f457714