### PR TITLE
Add LAMBS camp task support

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -24,7 +24,19 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
             };
             private _new = createGroup _side;
             for "_i" from 1 to _size do { _new createUnit [_class, _pos, [], 0, "FORM"]; };
-            [_new, _pos] call BIS_fnc_taskDefend;
+            if (local _new) then {
+                if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
+                    [_new, _pos, 50] call lambs_wp_fnc_taskCamp;
+                } else {
+                    [_new, _pos] call BIS_fnc_taskDefend;
+                };
+            } else {
+                if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
+                    [_new, _pos, 50] remoteExecCall ["lambs_wp_fnc_taskCamp", groupOwner _new];
+                } else {
+                    [_new, _pos] remoteExecCall ["BIS_fnc_taskDefend", groupOwner _new];
+                };
+            };
             _grp = _new;
         };
     } else {

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -30,7 +30,19 @@ for "_i" from 1 to _size do {
 };
 
 private _campfire = "Campfire_burning_F" createVehicle _pos;
-[_grp, _pos] call BIS_fnc_taskDefend;
+if (local _grp) then {
+    if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
+        [_grp, _pos, 50] call lambs_wp_fnc_taskCamp;
+    } else {
+        [_grp, _pos] call BIS_fnc_taskDefend;
+    };
+} else {
+    if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
+        [_grp, _pos, 50] remoteExecCall ["lambs_wp_fnc_taskCamp", groupOwner _grp];
+    } else {
+        [_grp, _pos] remoteExecCall ["BIS_fnc_taskDefend", groupOwner _grp];
+    };
+};
 
 private _marker = "";
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {


### PR DESCRIPTION
## Summary
- add lambs_danger check when spawing camp groups
- use lambs camp tasks when rebuilding camps
- ensure camp tasks execute on the server owning the group

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68549523f2b4832f8ecafe61d44c6716