### PR TITLE
Add adjustable activity zone depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
   also receive thematic names on their map markers. When no towns are nearby the
   names fall back to generic locations like the coast, a hill or a forest based
   on the surrounding terrain.
-* Anomalies only activate when players are nearby and go dormant when no one is in range. The activity grid system now checks map squares around players to toggle fields efficiently.
+* Anomalies only activate when players are nearby and go dormant when no one is in range. The activity grid system now checks map squares around players to toggle fields efficiently. You can adjust how many grid cells are simulated around each player with `VSA_activityZoneDepth`.
 
 ### Mutants
 * Spawns roaming mutant packs and ambient herds.
@@ -73,7 +73,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Generates APERS minefields on town outskirts and single IEDs on roads.
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way.
-* When debug mode is enabled the activity grid is drawn on the map with yellow dashed blocks for active squares and black dashed blocks for inactive ones.
+* When debug mode is enabled the activity grid is drawn on the map with yellow dashed blocks for active squares and red dashed blocks for inactive ones.
 * Abandoned and damaged vehicles may appear on or near roads.
 * Tripwires and booby traps can spawn inside buildings around towns.
 * Fallen players leave a red X marker that vanishes once the body is removed.
@@ -172,7 +172,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    * [Stalker Stuff](https://steamcommunity.com/sharedfiles/filedetails/?id=2781344095)
    * [Chemical Warfare Plus](https://steamcommunity.com/sharedfiles/filedetails/?id=3295358796)
    * [Necroplague](https://steamcommunity.com/workshop/filedetails/?id=2616555444)
-3. Review `cba_settings.sqf` for adjustable options such as the player nearby range used by many systems.
+3. Review `cba_settings.sqf` for adjustable options such as the player nearby range and activity zone depth used by many systems.
 4. Enable **VSA_autoInit** if you want the world to populate automatically on mission start. When disabled, use the debug actions to spawn systems manually.
 5. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    This option can now be toggled while a mission is running and the debug

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -24,6 +24,14 @@
 ] call CBA_fnc_addSetting;
 
 [
+    "VSA_activityZoneDepth",
+    "SLIDER",
+    ["Activity Zone Depth", "Grid cells around players kept active"],
+    "Viceroy's STALKER ALife - Core",
+    [1, 10, 4, 0]
+] call CBA_fnc_addSetting;
+
+[
     "VSA_autoInit",
     "CHECKBOX",
     ["Automatically Initialize", "Populate the world and start managers on mission start"],

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
@@ -24,7 +24,8 @@ private _cells = [];
     private _pos = getPos _x;
     private _gx = floor ((_pos select 0) / _size);
     private _gy = floor ((_pos select 1) / _size);
-    private _rad = ceil((_range + _diag) / _size);
+    private _depth = ["VSA_activityZoneDepth", 4] call VIC_fnc_getSetting;
+    private _rad = [_depth, ceil((_range + _diag) / _size)] call BIS_fnc_max;
     for "_ix" from (_gx - _rad) to (_gx + _rad) do {
         for "_iy" from (_gy - _rad) to (_gy + _rad) do {
             private _cx = _ix * _size + _half;
@@ -72,11 +73,11 @@ if (_debug) then {
             private _mx = (parseNumber (_parts select 0)) * _size + _half;
             private _my = (parseNumber (_parts select 1)) * _size + _half;
             private _name = format ["grid_%1", _key];
-            _marker = [_name, [_mx, _my, 0], "RECTANGLE", "", "ColorBlack", 0.1, "", [_size, _size], true] call VIC_fnc_createGlobalMarker;
+            _marker = [_name, [_mx, _my, 0], "RECTANGLE", "", "ColorRed", 0.1, "", [_size, _size], true] call VIC_fnc_createGlobalMarker;
             _marker setMarkerBrush "Border";
             STALKER_activityMarkers pushBack [_key, _marker];
         };
-        _marker setMarkerColor (if (_active) then {"ColorYellow"} else {"ColorBlack"});
+        _marker setMarkerColor (if (_active) then {"ColorYellow"} else {"ColorRed"});
         _marker setMarkerAlpha 0.1;
     } forEach STALKER_activityGrid;
 } else {


### PR DESCRIPTION
## Summary
- add new `VSA_activityZoneDepth` slider to settings
- allow activity grid range to respect the new setting
- draw red dashed inactive markers on the activity grid
- document the new option in README

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/cba_settings.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6854938e282c832f84afed292a15bf50