### PR TITLE
Update STALKER camp faction info

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -1,6 +1,6 @@
 /*
     Activates or deactivates stalker camps based on player proximity.
-    STALKER_camps entries: [campfire, group, position, marker, side]
+    STALKER_camps entries: [campfire, group, position, marker, side, faction]
 */
 
 ["manageStalkerCamps"] call VIC_fnc_debugLog;
@@ -12,7 +12,7 @@ private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
 
 {
-    _x params ["_camp", "_grp", "_pos", "_marker", "_side"];
+    _x params ["_camp", "_grp", "_pos", "_marker", "_side", "_faction"];
     private _near = [_pos, _dist] call VIC_fnc_hasPlayersNearby;
     if (_near) then {
         if (isNull _camp) then { _camp = "Campfire_burning_F" createVehicle _pos; };
@@ -50,7 +50,7 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
     if (_marker != "") then {
         [_marker, (if (_near) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
     };
-    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _marker, _side]];
+    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _marker, _side, _faction]];
 } forEach STALKER_camps;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -19,6 +19,9 @@ private _wInd = ["VSA_stalkerCampINDChance", 33] call VIC_fnc_getSetting;
 
 private _side = selectRandomWeighted [blufor,_wBlu,opfor,_wOpf,independent,_wInd];
 
+private _factions = ["Bandits","ClearSky","Ecologists","Military","Duty","Freedom","Loners","Mercs"];
+private _faction  = selectRandom _factions;
+
 private _grp = createGroup _side;
 private _class = switch (_side) do {
     case blufor: { "B_Soldier_F" };
@@ -47,8 +50,18 @@ if (local _grp) then {
 private _marker = "";
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     _marker = format ["camp_%1", diag_tickTime];
-    private _color = switch (_side) do { case blufor: {"ColorBlue"}; case opfor: {"ColorRed"}; default {"ColorGreen"}; };
-    [_marker, _pos, "ICON", "mil_box", _color, 0.2] call VIC_fnc_createGlobalMarker;
+    private _color = switch (_faction) do {
+        case "Bandits": {"ColorOrange"};
+        case "ClearSky": {"ColorCyan"};
+        case "Ecologists": {"ColorKhaki"};
+        case "Military": {"ColorGreen"};
+        case "Duty": {"ColorRed"};
+        case "Freedom": {"ColorBlue"};
+        case "Loners": {"ColorWhite"};
+        case "Mercs": {"ColorPink"};
+        default {"ColorWhite"};
+    };
+    [_marker, _pos, "ICON", "mil_box", _color, 0.2, _faction] call VIC_fnc_createGlobalMarker;
 };
 
-STALKER_camps pushBack [_campfire, _grp, _pos, _marker, _side];
+STALKER_camps pushBack [_campfire, _grp, _pos, _marker, _side, _faction];


### PR DESCRIPTION
## Summary
- expand camp arrays to store a faction name
- pick a random faction when spawning camps
- color camp debug markers per faction and label them
- handle the faction entry while managing camps

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf`

------
https://chatgpt.com/codex/tasks/task_e_685497081268832f9acc4c3d21423d39