### PR TITLE
Cache valleys for reuse

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -99,5 +99,8 @@ for "_gx" from 0 to worldSize step _step do {
 if (isNil "STALKER_valleys") then { STALKER_valleys = [] };
 { STALKER_valleys pushBackUnique _x } forEach _valleys;
 
+// Persist the cached valleys for later sessions
+["STALKER_valleys", STALKER_valleys] call VIC_fnc_saveCache;
+
 _valleys
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf
@@ -18,6 +18,12 @@ if (isNil "STALKER_valleyMarkers") then { STALKER_valleyMarkers = [] };
 } forEach STALKER_valleyMarkers;
 STALKER_valleyMarkers = [];
 
+if (isNil "STALKER_valleys") then {
+    private _cached = ["STALKER_valleys"] call VIC_fnc_loadCache;
+    if (isNil {_cached}) exitWith { false };
+    STALKER_valleys = _cached;
+};
+
 if (isNil "STALKER_valleys") exitWith { false };
 private _valleys = STALKER_valleys;
 [format ["markValleys: %1 valleys", count _valleys]] call VIC_fnc_debugLog;


### PR DESCRIPTION
## Summary
- persist valley search results via `saveCache`
- load saved valley data when marking valley positions

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markValleys.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854a177e8b4832fa29d2b06f0ac4657