### PR TITLE
Fix local marker sizing

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -47,7 +47,7 @@ for "_i" from 1 to _fieldCount do {
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["mf_%1", diag_tickTime];
         [_marker, _pos, "RECTANGLE", "", "ColorYellow", 0.2, "APERS Field"] call VIC_fnc_createGlobalMarker;
-        [_marker, [_size/2,_size/2]] remoteExec ["setMarkerSize", 0];
+        _marker setMarkerSize [_size/2, _size/2];
     };
     STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker];
 };


### PR DESCRIPTION
## Summary
- update minefield marker sizing logic to run locally

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854b2cc6754832f8b85a78f1425deba