### PR TITLE
Add configurable anomaly field radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Supports common anomaly types like burners, electras, fruit punches and springboards.
 * Relies on **Diwako’s Anomalies** for the core anomaly logic.
 * Fields are distributed randomly across the entire map but avoid towns by 500 meters.
+* Field radius is configurable via the `VSA_anomalyFieldRadius` CBA setting (default 200m, up to 2000m).
 * Fields can be **Stable** or **Unstable**. Stable fields remain in place
   and only reshuffle their anomalies during an emission. Unstable fields are
   deleted after an emission and respawn at new random positions. The ratio of

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -111,6 +111,14 @@
 ] call CBA_fnc_addSetting;
 
 [
+    "VSA_anomalyFieldRadius",
+    "SLIDER",
+    ["Anomaly Field Radius", "Radius of each anomaly field"],
+    "Viceroy's STALKER ALife - Anomalies",
+    [0, 2000, 200, 0]
+] call CBA_fnc_addSetting;
+
+[
     "VSA_anomalyNightOnly",
     "CHECKBOX",
     ["Night Time Only", "Anomalies only spawn at night"],

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -25,15 +25,17 @@ if (isNil {_site} || {count _site == 0}) exitWith {
     []
 };
 
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_bridge_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, "Bridge Electra 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, format ["Bridge Electra %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createElectra", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -19,23 +19,25 @@ if (isNil {_site} || {count _site == 0}) then {
     };
 } else {
     [format ["createField_burner: using site %1", _site]] call VIC_fnc_debugLog;
-};
+}; 
 _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_burner: land position failed"] call VIC_fnc_debugLog;
     []
 };
 
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_burner_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorOrange", 1, "Burner 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorOrange", 1, format ["Burner %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createBurner", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -25,16 +25,18 @@ if (isNil {_site} || {count _site == 0}) exitWith {
     []
 };
 
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_clicker_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorPink", 1, "Clicker 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorPink", 1, format ["Clicker %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createClicker", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -26,11 +26,13 @@ if (isNil {_site} || {count _site == 0}) exitWith {
     []
 };
 
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_comet_%1", diag_tickTime];
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorOrange", 1, "Comet Path"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createComet", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_electra: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_electra_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, "Electra 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, format ["Electra %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createElectra", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -23,13 +23,14 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_fruitpunch: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_fruitpunch_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, "Fruitpunch 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, format ["Fruitpunch %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 // Surround fruitpunch anomalies with a chemical zone
@@ -40,7 +41,7 @@ if (["VSA_enableChemicalZones", true] call VIC_fnc_getSetting) then {
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createFruitPunch", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_gravi: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_gravi_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBrown", 1, "Gravi 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBrown", 1, format ["Gravi %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createGravi", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_launchpad: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_launchpad_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorYellow", 1, "Launchpad 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorYellow", 1, format ["Launchpad %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _anom = createVehicle ["DSA_Launchpad", ASLToATL _surf, [], 0, "NONE"];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (count _site == 0) exitWith {
     ["createField_leech: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_leech_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlack", 1, "Leech 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlack", 1, format ["Leech %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _anom = createVehicle ["DSA_Leech", ASLToATL _surf, [], 0, "NONE"];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_meatgrinder: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_meatgrinder_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorRed", 1, "Meatgrinder 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorRed", 1, format ["Meatgrinder %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createMeatgrinder", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_springboard: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_springboard_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorKhaki", 1, "Springboard 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorKhaki", 1, format ["Springboard %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createSpringboard", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_trapdoor: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_trapdoor_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, "Trapdoor 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, format ["Trapdoor %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _anom = createVehicle ["DSA_Trapdoor", ASLToATL _surf, [], 0, "NONE"];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_whirligig: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_whirligig_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorWhite", 1, "Whirligig 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorWhite", 1, format ["Whirligig %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createWhirligig", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -23,18 +23,19 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_zapper: land position failed"] call VIC_fnc_debugLog;
     []
-};
+}; 
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_zapper_%1", diag_tickTime];
-private _marker = [_markerName, _site, "ELLIPSE", "", "ColorEAST", 1, "Zapper 30m"] call VIC_fnc_createGlobalMarker;
-_marker setMarkerSize [30,30];
+private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _marker = [_markerName, _site, "ELLIPSE", "", "ColorEAST", 1, format ["Zapper %1m", _size]] call VIC_fnc_createGlobalMarker;
+_marker setMarkerSize [_size,_size];
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];
 for "_i" from 1 to _count do {
-    private _off = [_site, random 30, random 360] call BIS_fnc_relPos;
+    private _off = [_site, random _size, random 360] call BIS_fnc_relPos;
     private _surf = [_off] call VIC_fnc_getLandSurfacePosition;
     if (_surf isEqualTo []) then { continue };
     private _anom = createVehicle ["DSA_Zapper", ASLToATL _surf, [], 0, "NONE"];


### PR DESCRIPTION
## Summary
- add CBA setting `VSA_anomalyFieldRadius`
- scale anomaly field markers and spawn offsets based on setting
- document new setting in README

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/cba_settings.sqf $(ls addons/Viceroys-STALKER-ALife/functions/anomalies/fields/*.sqf)`

------
https://chatgpt.com/codex/tasks/task_e_6854b67b6d28832fb6df2b8b6d952e7b