### PR TITLE
Randomize anomaly counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Relies on **Diwako’s Anomalies** for the core anomaly logic.
 * Fields are distributed randomly across the entire map but avoid towns by 500 meters.
 * Field radius is configurable via the `VSA_anomalyFieldRadius` CBA setting (default 200m, up to 2000m).
+* Each field spawns a random number of anomalies up to the `VSA_anomaliesPerField` CBA setting (default 40, min 5, max 200).
 * Fields can be **Stable** or **Unstable**. Stable fields remain in place
   and only reshuffle their anomalies during an emission. Unstable fields are
   deleted after an emission and respawn at new random positions. The ratio of

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -12,6 +12,7 @@
     true
 ] call CBA_fnc_addSetting;
 
+
 // -----------------------------------------------------------------------------
 // Core
 // -----------------------------------------------------------------------------
@@ -116,6 +117,14 @@
     ["Anomaly Field Radius", "Radius of each anomaly field"],
     "Viceroy's STALKER ALife - Anomalies",
     [0, 2000, 200, 0]
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_anomaliesPerField",
+    "SLIDER",
+    ["Max Anomalies per Field", "Upper limit for anomalies spawned"],
+    "Viceroy's STALKER ALife - Anomalies",
+    [5, 200, 40, 0]
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER - anomaly count (optional, default 5)
+        2: NUMBER - anomaly count (optional, -1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_bridgeElectra"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,6 +23,12 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_bridgeElectra: land position failed"] call VIC_fnc_debugLog;
     []
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomaly objects
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 
 ["createField_burner"] call VIC_fnc_debugLog;
 
@@ -24,6 +24,12 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_burner: land position failed"] call VIC_fnc_debugLog;
     []
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_clicker"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,6 +23,12 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_clicker: land position failed"] call VIC_fnc_debugLog;
     []
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 1)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomaly triggers
 */
-params ["_center","_radius", ["_count",1], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 
 ["fn_createField_comet"] call VIC_fnc_debugLog;
 
@@ -24,6 +24,12 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_comet: land position failed"] call VIC_fnc_debugLog;
     []
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_electra"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_electra: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_fruitpunch"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_fruitpunch: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_gravi"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_gravi: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_launchpad"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_launchpad: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_leech"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (count _site == 0) exitWith {
     ["createField_leech: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_meatgrinder"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_meatgrinder: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_springboard"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_springboard: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_trapdoor"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_trapdoor: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_whirligig"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_whirligig: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -3,11 +3,11 @@
     Params:
         0: POSITION or OBJECT - search center
         1: NUMBER - search radius
-        2: NUMBER (optional) - anomaly count (default 5)
+        2: NUMBER (optional) - anomaly count (-1 = random)
         3: ARRAY (optional) - site position to use (must be valid when provided)
     Returns: ARRAY - spawned anomalies
 */
-params ["_center","_radius", ["_count",5], ["_site", []]];
+params ["_center","_radius", ["_count",-1], ["_site", []]];
 ["fn_createField_zapper"] call VIC_fnc_debugLog;
 
 if (isNil {_site} || {count _site == 0}) then {
@@ -23,7 +23,13 @@ _site = [_site] call VIC_fnc_findLandPos;
 if (isNil {_site} || {count _site == 0}) exitWith {
     ["createField_zapper: land position failed"] call VIC_fnc_debugLog;
     []
-}; 
+};
+
+if (_count < 0) then {
+    private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
+    _max = _max max 5;
+    _count = floor (random (_max - 5 + 1)) + 5;
+};
 
 // Create a marker for this anomaly field
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };


### PR DESCRIPTION
## Summary
- randomize anomaly counts when creating anomaly fields
- default to 40 but configurable via new `VSA_anomaliesPerField` CBA setting
- document new setting in README

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/cba_settings.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854c13277dc832f9106891a97bd8824