### PR TITLE
Improve debug grid and anomaly markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Generates APERS minefields on town outskirts and single IEDs on roads.
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way.
-* When debug mode is enabled the activity grid overlay automatically refreshes on the map, drawing yellow dashed blocks for active squares and red dashed blocks for inactive ones.
+* When debug mode is enabled the activity grid overlay automatically refreshes on the map, filling each grid block with 20% opacity: yellow for active squares and red for inactive ones.
 * Abandoned and damaged vehicles may appear on or near roads.
 * Tripwires and booby traps can spawn inside buildings around towns.
 * Fallen players leave a red X marker that vanishes once the body is removed.

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -37,6 +37,7 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_bridge_%1", diag_tickTime];
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, format ["Bridge Electra %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -39,6 +39,7 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_burner_%1", diag_tickTime];
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorOrange", 1, format ["Burner %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -38,6 +38,7 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_clicker_%1", diag_tickTime];
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorPink", 1, format ["Clicker %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -39,6 +39,7 @@ if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_comet_%1", diag_tickTime];
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorOrange", 1, "Comet Path"] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _create = missionNamespace getVariable ["diwako_anomalies_main_fnc_createComet", {}];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_electra_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlue", 1, format ["Electra %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_fruitpunch_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, format ["Fruitpunch %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 // Surround fruitpunch anomalies with a chemical zone

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_gravi_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBrown", 1, format ["Gravi %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_launchpad_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorYellow", 1, format ["Launchpad %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_leech_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorBlack", 1, format ["Leech %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_meatgrinder_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorRed", 1, format ["Meatgrinder %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_springboard_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorKhaki", 1, format ["Springboard %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_trapdoor_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorGreen", 1, format ["Trapdoor %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_whirligig_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorWhite", 1, format ["Whirligig %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -37,6 +37,7 @@ private _markerName = format ["anom_zapper_%1", diag_tickTime];
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
 private _marker = [_markerName, _site, "ELLIPSE", "", "ColorEAST", 1, format ["Zapper %1m", _size]] call VIC_fnc_createGlobalMarker;
 _marker setMarkerSize [_size,_size];
+_marker setMarkerBrush "Border";
 STALKER_anomalyMarkers pushBack _marker;
 
 private _spawned = [];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf
@@ -28,6 +28,7 @@ if (isServer && !isNil "STALKER_anomalyFields") then {
             _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
             _site = getMarkerPos _marker;
             _objs = _spawned;
+            if (_marker != "") then { _marker setMarkerBrush "Border"; _marker setMarkerAlpha 1; };
             if (_stable && {_marker != ""}) then {
                 private _type = switch (_fn) do {
                     case VIC_fnc_createField_burner: {"burner"};

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
@@ -39,13 +39,19 @@ for [{_i = (count STALKER_anomalyFields) - 1}, {_i >= 0}, {_i = _i - 1}] do {
                 _objs = _spawned;
             };
         };
-        if (_marker != "") then { _marker setMarkerAlpha 1; };
+        if (_marker != "") then {
+            _marker setMarkerBrush "Border";
+            _marker setMarkerAlpha 1;
+        };
     } else {
         if ((count _objs) > 0) then {
             { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
             _objs = [];
         };
-        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+        if (_marker != "") then {
+            _marker setMarkerBrush "Border";
+            _marker setMarkerAlpha 1;
+        };
     };
     STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
 };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
@@ -24,7 +24,28 @@ private _createField = {
     if (_spawned isEqualTo []) exitWith { false };
 
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
-    if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+    if (_marker != "") then {
+        _marker setMarkerBrush "Border";
+        _marker setMarkerAlpha 1;
+        private _type = switch (_fn) do {
+            case VIC_fnc_createField_burner: {"burner"};
+            case VIC_fnc_createField_electra: {"electra"};
+            case VIC_fnc_createField_fruitpunch: {"fruitpunch"};
+            case VIC_fnc_createField_springboard: {"springboard"};
+            case VIC_fnc_createField_gravi: {"gravi"};
+            case VIC_fnc_createField_meatgrinder: {"meatgrinder"};
+            case VIC_fnc_createField_whirligig: {"whirligig"};
+            case VIC_fnc_createField_comet: {"comet"};
+            case VIC_fnc_createField_clicker: {"clicker"};
+            case VIC_fnc_createField_launchpad: {"launchpad"};
+            case VIC_fnc_createField_leech: {"leech"};
+            case VIC_fnc_createField_trapdoor: {"trapdoor"};
+            case VIC_fnc_createField_zapper: {"zapper"};
+            case VIC_fnc_createField_bridgeElectra: {"bridge"};
+            default {""};
+        };
+        _marker setMarkerText ([_type, _pos] call VIC_fnc_generateFieldName);
+    };
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -94,7 +94,8 @@ for "_i" from 1 to _fieldCount do {
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
     if (_marker != "") then {
-        _marker setMarkerAlpha 0.2;
+        _marker setMarkerBrush "Border";
+        _marker setMarkerAlpha 1;
         if (_stable) then {
             _marker setMarkerText ([_typeName, _site] call VIC_fnc_generateFieldName);
         };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
@@ -73,12 +73,12 @@ if (_debug) then {
             private _mx = (parseNumber (_parts select 0)) * _size + _half;
             private _my = (parseNumber (_parts select 1)) * _size + _half;
             private _name = format ["grid_%1", _key];
-            _marker = [_name, [_mx, _my, 0], "RECTANGLE", "", "ColorRed", 0.1, "", [_size, _size], true] call VIC_fnc_createGlobalMarker;
-            _marker setMarkerBrush "Border";
+            _marker = [_name, [_mx, _my, 0], "RECTANGLE", "", "ColorRed", 1, "", [_size, _size], true] call VIC_fnc_createGlobalMarker;
+            _marker setMarkerBrush "SolidFull";
             STALKER_activityMarkers pushBack [_key, _marker];
         };
         _marker setMarkerColor (if (_active) then {"ColorYellow"} else {"ColorRed"});
-        _marker setMarkerAlpha 0.1;
+        _marker setMarkerAlpha 0.2;
     } forEach STALKER_activityGrid;
 } else {
     {


### PR DESCRIPTION
## Summary
- show activity grid blocks with full fills and 20% opacity
- draw all anomaly field markers with dashed brush
- always display names for permanent fields
- use full opacity for anomaly markers
- document grid overlay change in README

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf` (and other modified files)


------
https://chatgpt.com/codex/tasks/task_e_6854c63f3ee0832f8a6a504b80f6768a