### PR TITLE
Enable weighted anomaly spawns

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Fields are distributed randomly across the entire map but avoid towns by 500 meters.
 * Field radius is configurable via the `VSA_anomalyFieldRadius` CBA setting (default 200m, up to 2000m).
 * Each field spawns a random number of anomalies up to the `VSA_anomaliesPerField` CBA setting (default 40, min 5, max 200).
+* Spawn weights for individual anomaly types can be tuned from the **Anomaly Weights** settings category.
+* Density multipliers let you increase or reduce how many anomalies of each type spawn in their fields.
 * Fields can be **Stable** or **Unstable**. Stable fields remain in place
   and only reshuffle their anomalies during an emission. Unstable fields are
   deleted after an emission and respawn at new random positions. The ratio of

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -103,6 +103,38 @@
     [0, 100, 50, 0]
 ] call CBA_fnc_addSetting;
 
+// Individual anomaly spawn weights
+["VSA_anomalyWeight_Burner","SLIDER",["Burner Weight","Relative spawn chance for Burner fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Clicker","SLIDER",["Clicker Weight","Relative spawn chance for Clicker fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Electra","SLIDER",["Electra Weight","Relative spawn chance for Electra fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Fruitpunch","SLIDER",["Fruit Punch Weight","Relative spawn chance for Fruit Punch fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Gravi","SLIDER",["Gravi Weight","Relative spawn chance for Gravi fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Meatgrinder","SLIDER",["Meatgrinder Weight","Relative spawn chance for Meatgrinder fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Springboard","SLIDER",["Springboard Weight","Relative spawn chance for Springboard fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Whirligig","SLIDER",["Whirligig Weight","Relative spawn chance for Whirligig fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Comet","SLIDER",["Comet Weight","Relative spawn chance for Comet fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Launchpad","SLIDER",["Launchpad Weight","Relative spawn chance for Launchpad fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Leech","SLIDER",["Leech Weight","Relative spawn chance for Leech fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Trapdoor","SLIDER",["Trapdoor Weight","Relative spawn chance for Trapdoor fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Zapper","SLIDER",["Zapper Weight","Relative spawn chance for Zapper fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyWeight_Bridge","SLIDER",["Bridge Electra Weight","Relative spawn chance for Bridge Electra fields"],"Viceroy's STALKER ALife - Anomaly Weights",[0,100,100,0]] call CBA_fnc_addSetting;
+
+// Individual anomaly density multipliers
+["VSA_anomalyDensity_Burner","SLIDER",["Burner Density","Multiplier for Burner anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Clicker","SLIDER",["Clicker Density","Multiplier for Clicker anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Electra","SLIDER",["Electra Density","Multiplier for Electra anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Fruitpunch","SLIDER",["Fruit Punch Density","Multiplier for Fruit Punch anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Gravi","SLIDER",["Gravi Density","Multiplier for Gravi anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Meatgrinder","SLIDER",["Meatgrinder Density","Multiplier for Meatgrinder anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Springboard","SLIDER",["Springboard Density","Multiplier for Springboard anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Whirligig","SLIDER",["Whirligig Density","Multiplier for Whirligig anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Comet","SLIDER",["Comet Density","Multiplier for Comet anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Launchpad","SLIDER",["Launchpad Density","Multiplier for Launchpad anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Leech","SLIDER",["Leech Density","Multiplier for Leech anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Trapdoor","SLIDER",["Trapdoor Density","Multiplier for Trapdoor anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Zapper","SLIDER",["Zapper Density","Multiplier for Zapper anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+["VSA_anomalyDensity_Bridge","SLIDER",["Bridge Electra Density","Multiplier for Bridge Electra anomaly count"],"Viceroy's STALKER ALife - Anomaly Density",[0,300,100,0]] call CBA_fnc_addSetting;
+
 [
     "VSA_stableFieldChance",
     "SLIDER",

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Bridge",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_burner.sqf
@@ -30,6 +30,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Burner",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_clicker.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Clicker",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_comet.sqf
@@ -30,6 +30,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Comet",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_electra.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Electra",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_fruitpunch.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Fruitpunch",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_gravi.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Gravi",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_launchpad.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Launchpad",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_leech.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Leech",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_meatgrinder.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Meatgrinder",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_springboard.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Springboard",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_trapdoor.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Trapdoor",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_whirligig.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Whirligig",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_zapper.sqf
@@ -29,6 +29,8 @@ if (_count < 0) then {
     private _max = ["VSA_anomaliesPerField", 40] call VIC_fnc_getSetting;
     _max = _max max 5;
     _count = floor (random (_max - 5 + 1)) + 5;
+    private _dens = ["VSA_anomalyDensity_Zapper",100] call VIC_fnc_getSetting;
+    _count = round (_count * (_dens / 100));
 };
 
 // Create a marker for this anomaly field

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
@@ -32,21 +32,21 @@ private _createField = {
     true
 };
 
-private _types = [
-    VIC_fnc_createField_burner,
-    VIC_fnc_createField_clicker,
-    VIC_fnc_createField_electra,
-    VIC_fnc_createField_fruitpunch,
-    VIC_fnc_createField_gravi,
-    VIC_fnc_createField_meatgrinder,
-    VIC_fnc_createField_springboard,
-    VIC_fnc_createField_whirligig,
-    VIC_fnc_createField_comet,
-    VIC_fnc_createField_launchpad,
-    VIC_fnc_createField_leech,
-    VIC_fnc_createField_trapdoor,
-    VIC_fnc_createField_zapper,
-    VIC_fnc_createField_bridgeElectra
+private _weights = [
+    [VIC_fnc_createField_burner,      ["VSA_anomalyWeight_Burner",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_clicker,     ["VSA_anomalyWeight_Clicker",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_electra,     ["VSA_anomalyWeight_Electra",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_fruitpunch,  ["VSA_anomalyWeight_Fruitpunch",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_gravi,       ["VSA_anomalyWeight_Gravi",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_meatgrinder, ["VSA_anomalyWeight_Meatgrinder",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_springboard, ["VSA_anomalyWeight_Springboard",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_whirligig,   ["VSA_anomalyWeight_Whirligig",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_comet,       ["VSA_anomalyWeight_Comet",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_launchpad,   ["VSA_anomalyWeight_Launchpad",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_leech,       ["VSA_anomalyWeight_Leech",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_trapdoor,    ["VSA_anomalyWeight_Trapdoor",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_zapper,      ["VSA_anomalyWeight_Zapper",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_bridgeElectra,["VSA_anomalyWeight_Bridge",100] call VIC_fnc_getSetting]
 ];
 
 private _center = [worldSize/2, worldSize/2, 0];
@@ -60,7 +60,7 @@ _buildings = _buildings arrayIntersect _buildings; // remove duplicates
     _pos = [_pos, 0, 100, 5, 0, 0, 0] call BIS_fnc_findSafePos;
     if (random 1 > 0.5) then {
         if (!(_pos call VIC_fnc_isWaterPosition)) then {
-            private _fn = selectRandom _types;
+            private _fn = [_weights] call VIC_fnc_weightedPick;
             [_fn, _pos] call _createField;
         };
     };
@@ -72,7 +72,7 @@ for "_i" from 1 to 20 do {
     private _pos = getPosATL _b;
     _pos = [_pos, 0, 25, 5, 0, 0, 0] call BIS_fnc_findSafePos;
     if (!(_pos call VIC_fnc_isWaterPosition)) then {
-        private _fn = selectRandom _types;
+        private _fn = [_weights] call VIC_fnc_weightedPick;
         [_fn, _pos] call _createField;
     };
 };
@@ -82,7 +82,7 @@ private _forestSites = selectBestPlaces [_center, worldSize, "forest", 1, 50];
     private _pos = (_x select 0);
     _pos = [_pos, 0, 75, 5, 0, 0, 0] call BIS_fnc_findSafePos;
     if (!(_pos call VIC_fnc_isWaterPosition)) then {
-        private _fn = selectRandom _types;
+        private _fn = [_weights] call VIC_fnc_weightedPick;
         [_fn, _pos] call _createField;
     };
 } forEach (_forestSites select [0,10]);
@@ -92,7 +92,7 @@ private _swampSites = selectBestPlaces [_center, worldSize, "meadow", 1, 50];
     private _pos = (_x select 0);
     _pos = [_pos, 0, 75, 5, 0, 0, 0] call BIS_fnc_findSafePos;
     if (!(_pos call VIC_fnc_isWaterPosition)) then {
-        private _fn = selectRandom _types;
+        private _fn = [_weights] call VIC_fnc_weightedPick;
         [_fn, _pos] call _createField;
     };
 } forEach (_swampSites select [0,10]);

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -36,21 +36,21 @@ if (_nightOnly && {daytime > 5 && daytime < 20}) exitWith {
 
 if (isNil "STALKER_anomalyFields") then { STALKER_anomalyFields = [] };
 
-private _types = [
-    VIC_fnc_createField_burner,
-    VIC_fnc_createField_clicker,
-    VIC_fnc_createField_electra,
-    VIC_fnc_createField_fruitpunch,
-    VIC_fnc_createField_gravi,
-    VIC_fnc_createField_meatgrinder,
-    VIC_fnc_createField_springboard,
-    VIC_fnc_createField_whirligig,
-    VIC_fnc_createField_comet,
-    VIC_fnc_createField_launchpad,
-    VIC_fnc_createField_leech,
-    VIC_fnc_createField_trapdoor,
-    VIC_fnc_createField_zapper,
-    VIC_fnc_createField_bridgeElectra
+private _weights = [
+    [VIC_fnc_createField_burner,      ["VSA_anomalyWeight_Burner",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_clicker,     ["VSA_anomalyWeight_Clicker",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_electra,     ["VSA_anomalyWeight_Electra",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_fruitpunch,  ["VSA_anomalyWeight_Fruitpunch",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_gravi,       ["VSA_anomalyWeight_Gravi",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_meatgrinder, ["VSA_anomalyWeight_Meatgrinder",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_springboard, ["VSA_anomalyWeight_Springboard",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_whirligig,   ["VSA_anomalyWeight_Whirligig",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_comet,       ["VSA_anomalyWeight_Comet",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_launchpad,   ["VSA_anomalyWeight_Launchpad",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_leech,       ["VSA_anomalyWeight_Leech",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_trapdoor,    ["VSA_anomalyWeight_Trapdoor",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_zapper,      ["VSA_anomalyWeight_Zapper",100] call VIC_fnc_getSetting],
+    [VIC_fnc_createField_bridgeElectra,["VSA_anomalyWeight_Bridge",100] call VIC_fnc_getSetting]
 ];
 
 for "_i" from 1 to _fieldCount do {
@@ -63,7 +63,7 @@ for "_i" from 1 to _fieldCount do {
     private _pos = [[random worldSize, random worldSize, 0], worldSize, 10] call VIC_fnc_findLandPos;
     if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
 
-    private _fn = selectRandom _types;
+    private _fn = [_weights] call VIC_fnc_weightedPick;
     private _typeName = switch (_fn) do {
         case VIC_fnc_createField_burner: {"burner"};
         case VIC_fnc_createField_electra: {"electra"};


### PR DESCRIPTION
## Summary
- allow each anomaly type to have a configurable spawn weight
- apply weighted pick logic in anomaly field spawning scripts
- add density multipliers for each anomaly type
- document new weights and density settings in README

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/cba_settings.sqf`
- `for f in addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_*.sqf; do sqflint "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_6854c5b44a50832fa8f4fda9ef83f203