### PR TITLE
Prevent anomaly fields from spawning off-map

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf
@@ -27,5 +27,16 @@ params [
     ["_maxAttempts",     200,   [0]   ]
 ];
 
+// suppress unused variable warnings
+private _dummy = [_minWaterDist, _maxSlope, _blacklist, _clearanceRad, _maxAttempts];
+_dummy;
+
 private _p = [[[ _centrePos, _radius ]], ["water"]] call BIS_fnc_randomPos;
-if ((_p isEqualTo [0,0]) || { _p isEqualTo [0,0,0] }) then { [] } else { _p }
+if ((_p isEqualTo [0,0]) || { _p isEqualTo [0,0,0] }) exitWith { [] };
+
+// ensure the position lies within map bounds
+private _px = _p select 0;
+private _py = _p select 1;
+if (_px < 0 || { _py < 0 } || { _px > worldSize } || { _py > worldSize }) exitWith { [] };
+
+_p

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf
@@ -21,6 +21,9 @@ params [
     ["_maxRadius", -1]
 ];
 
+private _dummy = [_maxTries, _maxRadius];
+_dummy;
+
 private _base = if (_centerPos isEqualType objNull) then { getPos _centerPos } else { _centerPos };
 
 private _townRadius = ["VSA_townRadius", 500] call VIC_fnc_getSetting;
@@ -34,4 +37,10 @@ private _condition = if (_excludeTowns) then {
 };
 
 private _pos = [[[_base, _radius]], ["water"], _condition] call BIS_fnc_randomPos;
-if ((_pos isEqualTo [0,0]) || { _pos isEqualTo [0,0,0] }) then { nil } else { _pos }
+if ((_pos isEqualTo [0,0]) || { _pos isEqualTo [0,0,0] }) exitWith { nil };
+
+private _px = _pos select 0;
+private _py = _pos select 1;
+if (_px < 0 || { _py < 0 } || { _px > worldSize } || { _py > worldSize }) exitWith { nil };
+
+_pos


### PR DESCRIPTION
## Summary
- guard against off-map positions in land-finding helpers

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPos.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findLandPosition.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854c9dd7634832f836a1bd96e3acf0b