### PR TITLE
Fix anomaly field activation

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -167,6 +167,7 @@ class CfgFunctions
             class spawnAllAnomalyFields{};
             class cleanupAnomalyMarkers{};
             class manageAnomalyFields{};
+            class startAnomalyManager{};
             class onEmissionBuildUp{};
             class onEmissionStart{};
             class onEmissionEnd{};
@@ -253,6 +254,7 @@ class CfgRemoteExec
         class VIC_fnc_startMinefieldManager { allowedTargets = 2; };
         class VIC_fnc_spawnAmbushes       { allowedTargets = 2; };
         class VIC_fnc_startAmbushManager  { allowedTargets = 2; };
+        class VIC_fnc_startAnomalyManager { allowedTargets = 2; };
         class VIC_fnc_setupMutantHabitats { allowedTargets = 2; };
         class VIC_fnc_manageHabitats      { allowedTargets = 2; };
         class VIC_fnc_triggerAIPanic      { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_startAnomalyManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_startAnomalyManager.sqf
@@ -1,0 +1,18 @@
+/*
+    Starts the anomaly field management loop. Debug use only.
+*/
+["startAnomalyManager"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+if (missionNamespace getVariable ["VIC_anomalyManagerRunning", false]) exitWith {};
+missionNamespace setVariable ["VIC_anomalyManagerRunning", true];
+
+[] spawn {
+    while { missionNamespace getVariable ["VIC_anomalyManagerRunning", false] } do {
+        [] call VIC_fnc_manageAnomalyFields;
+        sleep 60;
+    };
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -8,6 +8,7 @@ if (!isServer) exitWith { false };
 
 [] call VIC_fnc_startMinefieldManager;
 [] call VIC_fnc_startAmbushManager;
+[] call VIC_fnc_startAnomalyManager;
 [
     {
         while { true } do {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -91,6 +91,7 @@ VIC_fnc_spawnAllAnomalyFields    = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_cycleAnomalyFields       = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_cycleAnomalyFields.sqf");
 VIC_fnc_cleanupAnomalyMarkers    = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_cleanupAnomalyMarkers.sqf");
 VIC_fnc_manageAnomalyFields     = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_manageAnomalyFields.sqf");
+VIC_fnc_startAnomalyManager     = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_startAnomalyManager.sqf");
 VIC_fnc_generateFieldName       = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_generateFieldName.sqf");
 VIC_fnc_findSite_electra         = compile preprocessFileLineNumbers (_root + "\functions\anomalies\find_sites\fn_findSite_electra.sqf");
 VIC_fnc_findSite_springboard     = compile preprocessFileLineNumbers (_root + "\functions\anomalies\find_sites\fn_findSite_springboard.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf
@@ -178,6 +178,13 @@ player addAction ["<t color='#0000ff'>Start Ambush Logic</t>", {
         [] remoteExec ["VIC_fnc_startAmbushManager", 2];
     };
 }];
+player addAction ["<t color='#0000ff'>Start Anomaly Logic</t>", {
+    if (isServer) then {
+        [] call VIC_fnc_startAnomalyManager;
+    } else {
+        [] remoteExec ["VIC_fnc_startAnomalyManager", 2];
+    };
+}];
 player addAction ["<t color='#0000ff'>Generate Mutant Habitats</t>", {
     if (isServer) then {
         [] call VIC_fnc_setupMutantHabitats;


### PR DESCRIPTION
## Summary
- add a manager loop for anomaly fields
- hook anomaly manager into init and debug actions
- expose startAnomalyManager in config

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/config.cpp addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_setupDebugActions.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_startAnomalyManager.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854d0349224832fb85ac789e283b160