### PR TITLE
Add activity grid initialization

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initActivityGrid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initActivityGrid.sqf
@@ -1,0 +1,24 @@
+/*
+    Pre-populates the activity grid with cells covering the map.
+
+    Returns: BOOL
+*/
+
+["initActivityGrid"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {false};
+
+STALKER_activityGrid = [];
+if (isNil "STALKER_activityMarkers") then { STALKER_activityMarkers = [] };
+
+private _size = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+private _max = floor (worldSize / _size);
+
+for "_gx" from 0 to _max do {
+    for "_gy" from 0 to _max do {
+        private _key = format ["%1_%2", _gx, _gy];
+        STALKER_activityGrid pushBack [_key, false];
+    };
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -166,6 +166,7 @@ VIC_fnc_manageHostiles           = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_manageNests              = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageNests.sqf");
 VIC_fnc_manageHabitats           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageHabitats.sqf");
 VIC_fnc_updateProximity          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_updateProximity.sqf");
+VIC_fnc_initActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initActivityGrid.sqf");
 VIC_fnc_updateActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_updateActivityGrid.sqf");
 VIC_fnc_onMutantKilled           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_onMutantKilled.sqf");
 VIC_fnc_initMutantUnit          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_initMutantUnit.sqf");
@@ -206,6 +207,7 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
     missionNamespace setVariable ["STALKER_activityGridSize", 500];
+    [] call VIC_fnc_initActivityGrid;
     [] call VIC_fnc_registerEmissionHooks;
     if (call VIC_fnc_isAntistasiUltimate && { ["VSA_disableA3UWeather", false] call VIC_fnc_getSetting }) then {
         [] call VIC_fnc_disableA3UWeather;


### PR DESCRIPTION
## Summary
- add `fn_initActivityGrid.sqf` to setup STALKER_activityGrid
- compile and call the new function in `fn_masterInit.sqf`

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_initActivityGrid.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6854d71c7cb8832fac8b744db0b7639f