### PR TITLE
Implement booby trap management

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -116,6 +116,7 @@ class CfgFunctions
             class spawnBoobyTraps{};
             class spawnTripwirePerimeter{};
             class manageMinefields{};
+            class manageBoobyTraps{};
             class startMinefieldManager{};
         };
         class Wrecks

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -135,6 +135,7 @@ VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnBoobyTraps        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnBoobyTraps.sqf");
 VIC_fnc_spawnTripwirePerimeter = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnTripwirePerimeter.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
+VIC_fnc_manageBoobyTraps       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageBoobyTraps.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
 VIC_fnc_findWrecks           = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_findWrecks.sqf");
 VIC_fnc_startMinefieldManager  = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_startMinefieldManager.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -1,0 +1,32 @@
+/*
+    Activates or deactivates booby traps based on player proximity.
+    STALKER_boobyTraps entries: [position, objects, marker]
+*/
+["manageBoobyTraps"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (isNil "STALKER_boobyTraps") exitWith {};
+
+private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+
+{
+    _x params ["_pos","_objs","_marker"];
+    private _near = [_pos,_dist] call VIC_fnc_hasPlayersNearby;
+    if (_near) then {
+        if (_objs isEqualTo []) then {
+            private _type = selectRandom ["APERSTripMine_Wire","IEDUrbanSmall_F"];
+            private _mine = createMine [_type, _pos, [], 0];
+            _objs = [_mine];
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 1; };
+    } else {
+        if ((count _objs) > 0) then {
+            { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
+            _objs = [];
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+    };
+    STALKER_boobyTraps set [_forEachIndex, [_pos,_objs,_marker]];
+} forEach STALKER_boobyTraps;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
@@ -5,22 +5,23 @@
         1: NUMBER   - search radius (default 500)
         2: NUMBER   - trap count (optional)
     Returns:
-        ARRAY - spawned trap objects
+        BOOL
 */
 params ["_center", ["_radius",500], ["_count",-1]];
 
 ["spawnBoobyTraps"] call VIC_fnc_debugLog;
 
-if (!isServer) exitWith { [] };
+if (!isServer) exitWith { false };
 
-if (["VSA_enableBoobyTraps", true] call VIC_fnc_getSetting isEqualTo false) exitWith { [] };
+if (["VSA_enableBoobyTraps", true] call VIC_fnc_getSetting isEqualTo false) exitWith { false };
 
 if (_count < 0) then { _count = ["VSA_boobyTrapCount",5] call VIC_fnc_getSetting; };
 
 private _towns = nearestLocations [_center, ["NameVillage","NameCity","NameCityCapital","NameLocal"], _radius];
-if (_towns isEqualTo []) exitWith { [] };
 
-private _spawned = [];
+if (_towns isEqualTo []) exitWith { false };
+
+if (isNil "STALKER_boobyTraps") then { STALKER_boobyTraps = [] };
 
 for "_i" from 1 to _count do {
     if (_towns isEqualTo []) exitWith {};
@@ -34,14 +35,13 @@ for "_i" from 1 to _count do {
     if (_positions isEqualTo []) then { continue; };
 
     private _pos = selectRandom _positions;
-    private _type = selectRandom ["APERSTripMine_Wire","IEDUrbanSmall_F"];
-    private _mine = createMine [_type, _pos, [], 0];
-    _spawned pushBack _mine;
-
+    private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-        private _marker = format ["trap_%1", diag_tickTime + _i];
+        _marker = format ["trap_%1", diag_tickTime + _i];
         [_marker, _pos, "ICON", "mil_triangle", "ColorOrange", 0.2, "Trap"] call VIC_fnc_createGlobalMarker;
     };
+
+    STALKER_boobyTraps pushBack [_pos, [], _marker];
 };
 
-_spawned
+true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf
@@ -11,6 +11,7 @@ missionNamespace setVariable ["VIC_minefieldManagerRunning", true];
 [] spawn {
     while { missionNamespace getVariable ["VIC_minefieldManagerRunning", false] } do {
         [] call VIC_fnc_manageMinefields;
+        [] call VIC_fnc_manageBoobyTraps;
         sleep 60;
     };
 };

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -23,6 +23,7 @@ STALKER_activePredators = [];
 STALKER_mutantNests = [];
 STALKER_anomalyFields = [];
 STALKER_minefields = [];
+STALKER_boobyTraps = [];
 STALKER_panicGroups = [];
 
 // Prepare spook zone locations via debug action when needed


### PR DESCRIPTION
## Summary
- track booby traps in a new `STALKER_boobyTraps` array
- spawn trap locations instead of immediate mines
- periodically activate or remove traps when players are near
- update manager loop to handle booby traps

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/initServer.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6854d700a1a8832fbb83e29e38409e93