### PR TITLE
Implement sniper despawn manager

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -88,6 +88,7 @@ class CfgFunctions
             class spawnStalkerCamps{};
             class spawnSniper{};
             class manageStalkerCamps{};
+            class manageWanderers{};
             class manageSnipers{};
             class startSniperManager{};
         };
@@ -118,6 +119,7 @@ class CfgFunctions
             class spawnBoobyTraps{};
             class spawnTripwirePerimeter{};
             class manageMinefields{};
+            class manageBoobyTraps{};
             class startMinefieldManager{};
         };
         class Wrecks

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -88,6 +88,8 @@ class CfgFunctions
             class spawnStalkerCamps{};
             class spawnSniper{};
             class manageStalkerCamps{};
+            class manageSnipers{};
+            class startSniperManager{};
         };
 
 
@@ -247,6 +249,7 @@ class CfgRemoteExec
         class VIC_fnc_spawnAmbientStalkers { allowedTargets = 2; };
         class VIC_fnc_spawnStalkerCamps   { allowedTargets = 2; };
         class VIC_fnc_spawnSniper         { allowedTargets = 2; };
+        class VIC_fnc_startSniperManager  { allowedTargets = 2; };
         class VIC_fnc_spawnPredatorAttack { allowedTargets = 2; };
         class VIC_fnc_spawnMinefields     { allowedTargets = 2; };
         class VIC_fnc_spawnBoobyTraps     { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -9,6 +9,7 @@ if (!isServer) exitWith { false };
 [] call VIC_fnc_startMinefieldManager;
 [] call VIC_fnc_startAmbushManager;
 [] call VIC_fnc_startAnomalyManager;
+[] call VIC_fnc_startSniperManager;
 [
     {
         while { true } do {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -9,6 +9,12 @@ if (!isServer) exitWith { false };
 [] call VIC_fnc_startMinefieldManager;
 [] call VIC_fnc_startAmbushManager;
 [] call VIC_fnc_startAnomalyManager;
+[] spawn {
+    while { true } do {
+        [] call VIC_fnc_manageWanderers;
+        sleep 60;
+    };
+};
 [] call VIC_fnc_startSniperManager;
 [
     {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -194,6 +194,8 @@ VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
 VIC_fnc_spawnSniper           = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnSniper.sqf");
 VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageStalkerCamps.sqf");
+VIC_fnc_manageSnipers        = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageSnipers.sqf");
+VIC_fnc_startSniperManager   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_startSniperManager.sqf");
 
 VIC_fnc_isAntistasiUltimate  = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_isAntistasiUltimate.sqf");
 VIC_fnc_startMutantHunt      = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_startMutantHunt.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -135,6 +135,7 @@ VIC_fnc_spawnIED               = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnBoobyTraps        = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnBoobyTraps.sqf");
 VIC_fnc_spawnTripwirePerimeter = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_spawnTripwirePerimeter.sqf");
 VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageMinefields.sqf");
+VIC_fnc_manageBoobyTraps       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageBoobyTraps.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
 VIC_fnc_findWrecks           = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_findWrecks.sqf");
 VIC_fnc_startMinefieldManager  = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_startMinefieldManager.sqf");
@@ -166,6 +167,7 @@ VIC_fnc_manageHostiles           = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_manageNests              = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageNests.sqf");
 VIC_fnc_manageHabitats           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageHabitats.sqf");
 VIC_fnc_updateProximity          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_updateProximity.sqf");
+VIC_fnc_initActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initActivityGrid.sqf");
 VIC_fnc_updateActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_updateActivityGrid.sqf");
 VIC_fnc_onMutantKilled           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_onMutantKilled.sqf");
 VIC_fnc_initMutantUnit          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_initMutantUnit.sqf");
@@ -194,6 +196,7 @@ VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
 VIC_fnc_spawnSniper           = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnSniper.sqf");
 VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageStalkerCamps.sqf");
+VIC_fnc_manageWanderers       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageWanderers.sqf");
 VIC_fnc_manageSnipers        = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageSnipers.sqf");
 VIC_fnc_startSniperManager   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_startSniperManager.sqf");
 
@@ -208,6 +211,7 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
 // --- PostInit ---------------------------------------------------------------
 ["postInit", {
     missionNamespace setVariable ["STALKER_activityGridSize", 500];
+    [] call VIC_fnc_initActivityGrid;
     [] call VIC_fnc_registerEmissionHooks;
     if (call VIC_fnc_isAntistasiUltimate && { ["VSA_disableA3UWeather", false] call VIC_fnc_getSetting }) then {
         [] call VIC_fnc_disableA3UWeather;

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -1,0 +1,32 @@
+/*
+    Activates or deactivates booby traps based on player proximity.
+    STALKER_boobyTraps entries: [position, objects, marker]
+*/
+["manageBoobyTraps"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (isNil "STALKER_boobyTraps") exitWith {};
+
+private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+
+{
+    _x params ["_pos","_objs","_marker"];
+    private _near = [_pos,_dist] call VIC_fnc_hasPlayersNearby;
+    if (_near) then {
+        if (_objs isEqualTo []) then {
+            private _type = selectRandom ["APERSTripMine_Wire","IEDUrbanSmall_F"];
+            private _mine = createMine [_type, _pos, [], 0];
+            _objs = [_mine];
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 1; };
+    } else {
+        if ((count _objs) > 0) then {
+            { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
+            _objs = [];
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+    };
+    STALKER_boobyTraps set [_forEachIndex, [_pos,_objs,_marker]];
+} forEach STALKER_boobyTraps;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
@@ -1,0 +1,54 @@
+/*
+    Despawns sniper units when their location's grid cell is inactive and
+    respawns them when players return to the area.
+    STALKER_snipers entries: [group, position, marker]
+*/
+
+["manageSnipers"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (isNil "STALKER_snipers") exitWith {};
+
+private _gridSize = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+
+{
+    _x params ["_grp","_pos","_marker"];
+    private _gx = floor ((_pos select 0) / _gridSize);
+    private _gy = floor ((_pos select 1) / _gridSize);
+    private _key = format ["%1_%2", _gx, _gy];
+    private _active = false;
+    if (!isNil "STALKER_activityGrid") then {
+        {
+            if ((_x select 0) == _key) exitWith { _active = (_x select 1); };
+        } forEach STALKER_activityGrid;
+    } else {
+        private _range = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+        _active = [_pos, _range] call VIC_fnc_hasPlayersNearby;
+    };
+
+    if (!_active) then {
+        if (!isNull _grp) then {
+            { deleteVehicle _x } forEach units _grp;
+            deleteGroup _grp;
+            _grp = grpNull;
+        };
+        if (_marker != "") then { [_marker, 0.2] remoteExec ["setMarkerAlpha", 0]; };
+    } else {
+        if (isNull _grp || { count units _grp == 0 }) then {
+            private _new = createGroup east;
+            _new createUnit ["O_sniper_F", _pos, [], 0, "FORM"];
+            [_new, _pos, 100, [], true, true, 0, true] call lambs_wp_fnc_taskGarrison;
+            [_pos, 25, 6] call VIC_fnc_spawnTripwirePerimeter;
+            if (_marker == "" && { ["VSA_debugMode", false] call VIC_fnc_getSetting }) then {
+                _marker = format ["snp_%1", diag_tickTime];
+                [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.6, "Sniper"] call VIC_fnc_createGlobalMarker;
+            };
+            _grp = _new;
+        };
+        if (_marker != "") then { [_marker, 1] remoteExec ["setMarkerAlpha", 0]; };
+    };
+
+    STALKER_snipers set [_forEachIndex, [_grp, _pos, _marker]];
+} forEach STALKER_snipers;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
@@ -1,0 +1,50 @@
+/*
+    Handles ambient stalker wanderer groups. Groups are removed when their
+    patrol grid cell becomes inactive and respawned when the cell is active.
+    STALKER_wanderers entries: [group, position, marker]
+*/
+
+["manageWanderers"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (isNil "STALKER_wanderers") exitWith {};
+
+private _cellSize  = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+private _groupSize = ["VSA_ambientStalkerSize", 4] call VIC_fnc_getSetting;
+
+{
+    _x params ["_grp","_pos","_marker"];
+
+    private _gx = floor ((_pos select 0) / _cellSize);
+    private _gy = floor ((_pos select 1) / _cellSize);
+    private _key = format ["%1_%2", _gx, _gy];
+    private _active = false;
+    if (!isNil "STALKER_activityGrid") then {
+        {
+            _x params ["_cell","_state"];
+            if (_cell == _key) exitWith { _active = _state; };
+        } forEach STALKER_activityGrid;
+    };
+
+    if (_active) then {
+        if (isNull _grp || { count units _grp == 0 }) then {
+            _grp = createGroup independent;
+            for "_i" from 1 to _groupSize do {
+                _grp createUnit ["I_Soldier_F", _pos, [], 0, "FORM"];
+            };
+            [_grp, _pos] call BIS_fnc_taskPatrol;
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 1; };
+    } else {
+        if (!isNull _grp) then {
+            { deleteVehicle _x } forEach units _grp;
+            deleteGroup _grp;
+            _grp = grpNull;
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+    };
+
+    STALKER_wanderers set [_forEachIndex, [_grp, _pos, _marker]];
+} forEach STALKER_wanderers;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startSniperManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startSniperManager.sqf
@@ -1,0 +1,18 @@
+/*
+    Starts the sniper management loop. Debug use only.
+*/
+["startSniperManager"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+if (missionNamespace getVariable ["VIC_sniperManagerRunning", false]) exitWith {};
+missionNamespace setVariable ["VIC_sniperManagerRunning", true];
+
+[] spawn {
+    while { missionNamespace getVariable ["VIC_sniperManagerRunning", false] } do {
+        [] call VIC_fnc_manageSnipers;
+        sleep 60;
+    };
+};
+
+true


### PR DESCRIPTION
## Summary
- add new sniper management system to clean up and respawn snipers based on activity grid
- expose sniper manager functions via CfgFunctions and remote exec
- start sniper manager with other managers during init

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startSniperManager.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854d6fded98832f910db47d1702e0be