### PR TITLE
Implement wanderer management

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -88,6 +88,7 @@ class CfgFunctions
             class spawnStalkerCamps{};
             class spawnSniper{};
             class manageStalkerCamps{};
+            class manageWanderers{};
         };
 
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -9,6 +9,12 @@ if (!isServer) exitWith { false };
 [] call VIC_fnc_startMinefieldManager;
 [] call VIC_fnc_startAmbushManager;
 [] call VIC_fnc_startAnomalyManager;
+[] spawn {
+    while { true } do {
+        [] call VIC_fnc_manageWanderers;
+        sleep 60;
+    };
+};
 [
     {
         while { true } do {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -194,6 +194,7 @@ VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
 VIC_fnc_spawnSniper           = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnSniper.sqf");
 VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageStalkerCamps.sqf");
+VIC_fnc_manageWanderers       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageWanderers.sqf");
 
 VIC_fnc_isAntistasiUltimate  = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_isAntistasiUltimate.sqf");
 VIC_fnc_startMutantHunt      = compile preprocessFileLineNumbers (_root + "\functions\antistasi\fn_startMutantHunt.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
@@ -1,0 +1,50 @@
+/*
+    Handles ambient stalker wanderer groups. Groups are removed when their
+    patrol grid cell becomes inactive and respawned when the cell is active.
+    STALKER_wanderers entries: [group, position, marker]
+*/
+
+["manageWanderers"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (isNil "STALKER_wanderers") exitWith {};
+
+private _cellSize  = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+private _groupSize = ["VSA_ambientStalkerSize", 4] call VIC_fnc_getSetting;
+
+{
+    _x params ["_grp","_pos","_marker"];
+
+    private _gx = floor ((_pos select 0) / _cellSize);
+    private _gy = floor ((_pos select 1) / _cellSize);
+    private _key = format ["%1_%2", _gx, _gy];
+    private _active = false;
+    if (!isNil "STALKER_activityGrid") then {
+        {
+            _x params ["_cell","_state"];
+            if (_cell == _key) exitWith { _active = _state; };
+        } forEach STALKER_activityGrid;
+    };
+
+    if (_active) then {
+        if (isNull _grp || { count units _grp == 0 }) then {
+            _grp = createGroup independent;
+            for "_i" from 1 to _groupSize do {
+                _grp createUnit ["I_Soldier_F", _pos, [], 0, "FORM"];
+            };
+            [_grp, _pos] call BIS_fnc_taskPatrol;
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 1; };
+    } else {
+        if (!isNull _grp) then {
+            { deleteVehicle _x } forEach units _grp;
+            deleteGroup _grp;
+            _grp = grpNull;
+        };
+        if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+    };
+
+    STALKER_wanderers set [_forEachIndex, [_grp, _pos, _marker]];
+} forEach STALKER_wanderers;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -14,6 +14,7 @@ if (!isServer) exitWith {};
 if (["VSA_enableAmbientStalkers", true] call VIC_fnc_getSetting isEqualTo false) exitWith {};
 
 if (isNil "STALKER_stalkerGroups") then { STALKER_stalkerGroups = []; };
+if (isNil "STALKER_wanderers") then { STALKER_wanderers = []; };
 
 private _groupCount = ["VSA_ambientStalkerGroups", 2] call VIC_fnc_getSetting;
 private _groupSize  = ["VSA_ambientStalkerSize", 4] call VIC_fnc_getSetting;
@@ -45,4 +46,5 @@ for "_i" from 1 to _groupCount do {
     };
 
     STALKER_stalkerGroups pushBack [_grp, _marker];
+    STALKER_wanderers pushBack [_grp, _pos, _marker];
 };

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -24,6 +24,7 @@ STALKER_mutantNests = [];
 STALKER_anomalyFields = [];
 STALKER_minefields = [];
 STALKER_panicGroups = [];
+STALKER_wanderers = [];
 
 // Prepare spook zone locations via debug action when needed
 // [] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\spooks\fn_setupSpookZones.sqf";


### PR DESCRIPTION
## Summary
- track ambient stalker groups in a new `STALKER_wanderers` list
- add a manager loop that respawns or removes groups based on grid activity
- initialize the wanderer array on the server
- compile and start the new manager automatically

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/config.cpp addons/Viceroys-STALKER-ALife/initServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6854d6f9894c832fa4968046ff97e66c