### PR TITLE
Implement wreck manager

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -127,6 +127,7 @@ class CfgFunctions
             file = "Viceroys-STALKER-ALife\functions\wrecks";
             class spawnAbandonedVehicles{};
             class findWrecks{};
+            class manageWrecks{};
         };
 
         class Ambushes

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -16,6 +16,12 @@ if (!isServer) exitWith { false };
         sleep 60;
     };
 };
+[] spawn {
+    while { true } do {
+        [] call VIC_fnc_manageWrecks;
+        sleep 60;
+    };
+};
 [
     {
         while { true } do {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -138,6 +138,7 @@ VIC_fnc_manageMinefields       = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_manageBoobyTraps       = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_manageBoobyTraps.sqf");
 VIC_fnc_spawnAbandonedVehicles = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_spawnAbandonedVehicles.sqf");
 VIC_fnc_findWrecks           = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_findWrecks.sqf");
+VIC_fnc_manageWrecks         = compile preprocessFileLineNumbers (_root + "\functions\wrecks\fn_manageWrecks.sqf");
 VIC_fnc_startMinefieldManager  = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_startMinefieldManager.sqf");
 VIC_fnc_spawnAmbushes          = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_spawnAmbushes.sqf");
 VIC_fnc_manageAmbushes         = compile preprocessFileLineNumbers (_root + "\functions\ambushes\fn_manageAmbushes.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf
@@ -1,0 +1,55 @@
+/*
+    Manages abandoned vehicles. Vehicles are deleted when their grid cell
+    becomes inactive and their markers cleaned up. If a vehicle has moved more
+    than 200m from its original site the entry is removed but the vehicle is
+    left intact so players can keep using it.
+    STALKER_wrecks entries: vehicle objects with a `VIC_wreckSite` variable
+    storing the spawn position. Debug markers are optional and tracked in
+    STALKER_wreckMarkers using the same index.
+*/
+
+["manageWrecks"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+if (isNil "STALKER_wrecks") exitWith {};
+
+private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+
+for [{_i = (count STALKER_wrecks) - 1}, {_i >= 0}, {_i = _i - 1}] do {
+    private _veh = STALKER_wrecks select _i;
+    if (isNull _veh) then {
+        if (!isNil "STALKER_wreckMarkers") then {
+            private _m = STALKER_wreckMarkers param [_i, ""];
+            if (_m != "") then { deleteMarker _m; };
+            STALKER_wreckMarkers deleteAt _i;
+        };
+        STALKER_wrecks deleteAt _i;
+        continue;
+    };
+
+    private _site = _veh getVariable ["VIC_wreckSite", getPosATL _veh];
+    _veh setVariable ["VIC_wreckSite", _site];
+
+    if (_veh distance2D _site > 200) then {
+        if (!isNil "STALKER_wreckMarkers") then {
+            private _m = STALKER_wreckMarkers param [_i, ""];
+            if (_m != "") then { deleteMarker _m; };
+            STALKER_wreckMarkers deleteAt _i;
+        };
+        STALKER_wrecks deleteAt _i;
+        continue;
+    };
+
+    private _near = [_site, _dist] call VIC_fnc_hasPlayersNearby;
+    if (!_near) then {
+        deleteVehicle _veh;
+        if (!isNil "STALKER_wreckMarkers") then {
+            private _m = STALKER_wreckMarkers param [_i, ""];
+            if (_m != "") then { deleteMarker _m; };
+            STALKER_wreckMarkers deleteAt _i;
+        };
+        STALKER_wrecks deleteAt _i;
+    };
+};
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -38,6 +38,7 @@ for "_i" from 1 to _count do {
             _veh setDamage (0.3 + random 0.7);
             _veh setFuel 0;
             _veh lock 2;
+            _veh setVariable ["VIC_wreckSite", ASLtoATL _pos];
             STALKER_wrecks pushBack _veh;
         };
     };


### PR DESCRIPTION
## Summary
- handle abandoned vehicle cleanup via new `manageWrecks` function
- track wreck spawn positions for cleanup
- register and start the wreck manager

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68559b1cfd84832f96c706740f399dc2