### PR TITLE
Fix grid initialization

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initActivityGrid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initActivityGrid.sqf
@@ -21,4 +21,7 @@ for "_gx" from 0 to _max do {
     };
 };
 
+// Draw initial grid markers in debug mode
+[] call VIC_fnc_updateActivityGrid;
+
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -217,19 +217,20 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
     if (call VIC_fnc_isAntistasiUltimate && { ["VSA_disableA3UWeather", false] call VIC_fnc_getSetting }) then {
         [] call VIC_fnc_disableA3UWeather;
     };
-    if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {
-    [
-        {
-            while {true} do {
-                [] call VIC_fnc_updateProximity;
-                [] call VIC_fnc_updateActivityGrid;
-                private _delay = if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {5} else { ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting };
-                sleep _delay;
-            };
-        }, [], 8
-    ] call CBA_fnc_waitAndExecute;
-    // Additional managers have been disabled for quicker startup and can be
-    // invoked via debug actions when needed.
+    if (isServer && {isNil "VIC_activityGridThread"}) then {
+        VIC_activityGridThread = [
+            {
+                while {true} do {
+                    [] call VIC_fnc_updateProximity;
+                    [] call VIC_fnc_updateActivityGrid;
+                    private _delay = ["VSA_proximityCheckInterval", 5] call VIC_fnc_getSetting;
+                    if (["VSA_autoInit", false] call VIC_fnc_getSetting) then { _delay = 5 };
+                    sleep _delay;
+                };
+            }, [], 8
+        ] call CBA_fnc_waitAndExecute;
+        // Additional managers have been disabled for quicker startup and can be
+        // invoked via debug actions when needed.
     };
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         [] call VIC_fnc_setupDebugActions;


### PR DESCRIPTION
## Summary
- draw initial activity grid markers when debug is enabled
- start a background thread to continuously update proximity and activity grid

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_initActivityGrid.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6856c41e4354832f891afd1c0f50be72