### PR TITLE
Implement grid-based site registry

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -32,6 +32,9 @@ class CfgFunctions
             class selectWeightedBuilding{};
             class findBridges{};
             class radioMessage{};
+            class sitePlaced{};
+            class activateSite{};
+            class deactivateSite{};
         };
 
         class AI
@@ -100,6 +103,8 @@ class CfgFunctions
             class cleanupChemicalZones{};
             class spawnChemicalZone{};
             class spawnRandomChemicalZones{};
+            class activateSite{};
+            class deactivateSite{};
             class onEmissionStart{};
             class onEmissionEnd{};
         };
@@ -119,6 +124,8 @@ class CfgFunctions
             class spawnIED{};
             class spawnBoobyTraps{};
             class spawnTripwirePerimeter{};
+            class activateSite{};
+            class deactivateSite{};
             class manageMinefields{};
             class manageBoobyTraps{};
             class startMinefieldManager{};
@@ -174,6 +181,8 @@ class CfgFunctions
             class cleanupAnomalyMarkers{};
             class manageAnomalyFields{};
             class startAnomalyManager{};
+            class activateSite{};
+            class deactivateSite{};
             class onEmissionBuildUp{};
             class onEmissionStart{};
             class onEmissionEnd{};

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_activateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_activateSite.sqf
@@ -1,0 +1,35 @@
+/*
+    Activates the anomaly field at the given registry index.
+*/
+
+["anomalies_activateSite"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+params ["_index"];
+
+if (isNil "STALKER_anomalyFields") exitWith {};
+if (_index < 0 || {_index >= count STALKER_anomalyFields}) exitWith {};
+
+private _entry = STALKER_anomalyFields select _index;
+_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
+
+if (_objs isEqualTo [] || {{isNull _x} count _objs == count _objs}) then {
+    private _spawned = [_center,_radius,_count,_site] call _fn;
+    if !(_spawned isEqualTo []) then {
+        _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
+        _site = getMarkerPos _marker;
+        _objs = _spawned;
+    } else {
+        _objs = [];
+    };
+} else {
+    _objs = _objs select { !isNull _x };
+};
+if (_marker != "") then {
+    _marker setMarkerBrush "Border";
+    _marker setMarkerAlpha 1;
+};
+
+STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_deactivateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_deactivateSite.sqf
@@ -1,0 +1,27 @@
+/*
+    Deactivates the anomaly field at the given registry index.
+*/
+
+["anomalies_deactivateSite"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+params ["_index"];
+
+if (isNil "STALKER_anomalyFields") exitWith {};
+if (_index < 0 || {_index >= count STALKER_anomalyFields}) exitWith {};
+
+private _entry = STALKER_anomalyFields select _index;
+_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
+
+if ((count _objs) > 0) then {
+    { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
+    _objs = [];
+};
+if (_marker != "") then {
+    _marker setMarkerBrush "Border";
+    _marker setMarkerAlpha 0.2;
+};
+
+STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
@@ -50,6 +50,12 @@ private _createField = {
     private _exp = diag_tickTime + (_dur * 60);
 
     STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_pos,_exp,true];
+    private _idx = (count STALKER_anomalyFields) - 1;
+    private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+    private _gx = floor ((_pos select 0) / _gs);
+    private _gy = floor ((_pos select 1) / _gs);
+    private _key = format ["%1_%2", _gx, _gy];
+    [_key, "anomaly", _idx] call VIC_fnc_sitePlaced;
     true
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_activateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_activateSite.sqf
@@ -1,0 +1,25 @@
+/*
+    Activates the chemical zone at the given registry index.
+*/
+
+["chemical_activateSite"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+params ["_index"];
+
+if (isNil "STALKER_chemicalZones") exitWith {};
+if (_index < 0 || {_index >= count STALKER_chemicalZones}) exitWith {};
+
+private _entry = STALKER_chemicalZones select _index;
+_entry params ["_pos","_radius","_active","_marker","_expires"];
+
+if (!_active) then {
+    private _dur = if (_expires < 0) then {-1} else {_expires - diag_tickTime};
+    [_pos,_radius,_dur] call VIC_fnc_spawnChemicalZone;
+    _active = true;
+};
+if (_marker != "") then { _marker setMarkerAlpha 1; };
+
+STALKER_chemicalZones set [_index, [_pos,_radius,_active,_marker,_expires]];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_deactivateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_deactivateSite.sqf
@@ -1,0 +1,21 @@
+/*
+    Deactivates the chemical zone at the given registry index.
+*/
+
+["chemical_deactivateSite"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+params ["_index"];
+
+if (isNil "STALKER_chemicalZones") exitWith {};
+if (_index < 0 || {_index >= count STALKER_chemicalZones}) exitWith {};
+
+private _entry = STALKER_chemicalZones select _index;
+_entry params ["_pos","_radius","_active","_marker","_expires"];
+
+if (_active) then { _active = false; };
+if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+
+STALKER_chemicalZones set [_index, [_pos,_radius,_active,_marker,_expires]];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_spawnChemicalZone.sqf
@@ -82,4 +82,11 @@ STALKER_chemicalZones pushBack [
     _expires
 ];
 
+private _idx = (count STALKER_chemicalZones) - 1;
+private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+private _gx = floor ((_position select 0) / _gs);
+private _gy = floor ((_position select 1) / _gs);
+private _key = format ["%1_%2", _gx, _gy];
+[_key, "chemical", _idx] call VIC_fnc_sitePlaced;
+
 true;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -170,6 +170,13 @@ VIC_fnc_manageHabitats           = compile preprocessFileLineNumbers (_root + "\
 VIC_fnc_updateProximity          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_updateProximity.sqf");
 VIC_fnc_initActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_initActivityGrid.sqf");
 VIC_fnc_updateActivityGrid       = compile preprocessFileLineNumbers (_root + "\functions\core\fn_updateActivityGrid.sqf");
+call compile preprocessFileLineNumbers (_root + "\functions\core\fn_siteRegistry.sqf");
+minefields_fnc_activateSite   = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_activateSite.sqf");
+minefields_fnc_deactivateSite = compile preprocessFileLineNumbers (_root + "\functions\minefields\fn_deactivateSite.sqf");
+chemical_fnc_activateSite     = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_activateSite.sqf");
+chemical_fnc_deactivateSite   = compile preprocessFileLineNumbers (_root + "\functions\chemical\fn_deactivateSite.sqf");
+anomalies_fnc_activateSite    = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_activateSite.sqf");
+anomalies_fnc_deactivateSite  = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_deactivateSite.sqf");
 VIC_fnc_onMutantKilled           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_onMutantKilled.sqf");
 VIC_fnc_initMutantUnit          = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_initMutantUnit.sqf");
 panic_fnc_onEmissionBuildUp  = compile preprocessFileLineNumbers (_root + "\functions\panic\fn_onEmissionBuildUp.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_siteRegistry.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_siteRegistry.sqf
@@ -1,0 +1,40 @@
+/*
+    Maintains a registry of ALife sites keyed by activity grid cell.
+    Provides helpers for registering a site and routing activation
+    or deactivation events to subsystem handlers.
+*/
+
+if (isNil "STALKER_siteRegistry") then { STALKER_siteRegistry = []; };
+
+VIC_fnc_sitePlaced = {
+    params ["_key", "_type", "_index"];
+    if (isNil "STALKER_siteRegistry") then { STALKER_siteRegistry = []; };
+    private _idx = STALKER_siteRegistry findIf { (_x select 0) isEqualTo _key };
+    if (_idx < 0) then {
+        STALKER_siteRegistry pushBack [_key, [[_type, _index]]];
+    } else {
+        private _sites = STALKER_siteRegistry select _idx select 1;
+        _sites pushBack [_type, _index];
+        STALKER_siteRegistry set [_idx, [_key, _sites]];
+    };
+};
+
+VIC_fnc_activateSite = {
+    params ["_type", "_index"];
+    switch (_type) do {
+        case "anomaly":  { [_index] call anomalies_fnc_activateSite; };
+        case "minefield": { [_index] call minefields_fnc_activateSite; };
+        case "chemical": { [_index] call chemical_fnc_activateSite; };
+        default {};
+    };
+};
+
+VIC_fnc_deactivateSite = {
+    params ["_type", "_index"];
+    switch (_type) do {
+        case "anomaly":  { [_index] call anomalies_fnc_deactivateSite; };
+        case "minefield": { [_index] call minefields_fnc_deactivateSite; };
+        case "chemical": { [_index] call chemical_fnc_deactivateSite; };
+        default {};
+    };
+};

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_updateActivityGrid.sqf
@@ -41,8 +41,19 @@ private _cells = [];
 // Update grid states
 for "_i" from 0 to ((count STALKER_activityGrid) - 1) do {
     private _entry = STALKER_activityGrid select _i;
-    private _key = _entry select 0;
+    _entry params ["_key","_prevActive"];
     private _isActive = (_cells find _key) > -1;
+    if (_isActive != _prevActive) then {
+        private _regIdx = STALKER_siteRegistry findIf { (_x select 0) isEqualTo _key };
+        if (_regIdx >= 0) then {
+            private _sites = STALKER_siteRegistry select _regIdx select 1;
+            {
+                _x params ["_type","_sIndex"];
+                if (_isActive) then { [_type,_sIndex] call VIC_fnc_activateSite; }
+                else { [_type,_sIndex] call VIC_fnc_deactivateSite; };
+            } forEach _sites;
+        };
+    };
     STALKER_activityGrid set [_i, [_key, _isActive]];
 };
 
@@ -53,7 +64,16 @@ for "_i" from 0 to ((count STALKER_activityGrid) - 1) do {
     for "_i" from 0 to ((count STALKER_activityGrid) - 1) do {
         if ((STALKER_activityGrid select _i) select 0 == _key) exitWith { _exists = true; };
     };
-    if (!_exists) then { STALKER_activityGrid pushBack [_key, true]; };
+    if (!_exists) then {
+        STALKER_activityGrid pushBack [_key, true];
+        private _regIdx = STALKER_siteRegistry findIf { (_x select 0) isEqualTo _key };
+        if (_regIdx >= 0) then {
+            {
+                _x params ["_type","_sIndex"];
+                [_type,_sIndex] call VIC_fnc_activateSite;
+            } forEach (STALKER_siteRegistry select _regIdx select 1);
+        };
+    };
 } forEach _cells;
 
 private _debug = ["VSA_debugMode", false] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_activateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_activateSite.sqf
@@ -1,0 +1,27 @@
+/*
+    Activates the minefield at the given registry index.
+*/
+
+["minefields_activateSite"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+params ["_index"];
+
+if (isNil "STALKER_minefields") exitWith {};
+if (_index < 0 || {_index >= count STALKER_minefields}) exitWith {};
+
+private _entry = STALKER_minefields select _index;
+_entry params ["_center","_type","_size","_objs","_marker"];
+
+if (_objs isEqualTo []) then {
+    _objs = switch (_type) do {
+        case "APERS": { [_center,_size] call VIC_fnc_spawnAPERSField };
+        case "IED":   { [_center] call VIC_fnc_spawnIED };
+        default { [] };
+    };
+};
+if (_marker != "") then { _marker setMarkerAlpha 1; };
+
+STALKER_minefields set [_index, [_center,_type,_size,_objs,_marker]];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_deactivateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_deactivateSite.sqf
@@ -1,0 +1,24 @@
+/*
+    Deactivates the minefield at the given registry index.
+*/
+
+["minefields_deactivateSite"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+params ["_index"];
+
+if (isNil "STALKER_minefields") exitWith {};
+if (_index < 0 || {_index >= count STALKER_minefields}) exitWith {};
+
+private _entry = STALKER_minefields select _index;
+_entry params ["_center","_type","_size","_objs","_marker"];
+
+if ((count _objs) > 0) then {
+    { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
+    _objs = [];
+};
+if (_marker != "") then { _marker setMarkerAlpha 0.2; };
+
+STALKER_minefields set [_index, [_center,_type,_size,_objs,_marker]];
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -50,6 +50,12 @@ for "_i" from 1 to _fieldCount do {
         _marker setMarkerSize [_size/2, _size/2];
     };
     STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker];
+    private _idx = (count STALKER_minefields) - 1;
+    private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+    private _gx = floor ((_pos select 0) / _gs);
+    private _gy = floor ((_pos select 1) / _gs);
+    private _key = format ["%1_%2", _gx, _gy];
+    [_key, "minefield", _idx] call VIC_fnc_sitePlaced;
 };
 
 for "_i" from 1 to _iedCount do {
@@ -69,6 +75,12 @@ for "_i" from 1 to _iedCount do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.2, "IED"] call VIC_fnc_createGlobalMarker;
     };
     STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
+    private _idx = (count STALKER_minefields) - 1;
+    private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+    private _gx = floor ((_pos select 0) / _gs);
+    private _gy = floor ((_pos select 1) / _gs);
+    private _key = format ["%1_%2", _gx, _gy];
+    [_key, "minefield", _idx] call VIC_fnc_sitePlaced;
 };
 
 if !(missionNamespace getVariable ["VIC_minefieldManagerRunning", false]) then {


### PR DESCRIPTION
## Summary
- add global site registry helpers and subsystem hooks
- register new anomaly, chemical, and minefield sites in activity grid
- trigger site activation when grid cells change state
- expose registry functions in `config.cpp`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6856ca6d10f0832fb451055872ceb085