### PR TITLE
Implement proximity-based site activation

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf
@@ -1,6 +1,6 @@
 /*
     Handles ambush activation and cleanup.
-    STALKER_ambushes entries: [position, vehicle, mines, groups, triggered, marker]
+    STALKER_ambushes entries: [position, vehicle, mines, groups, triggered, marker, active]
 */
 
 ["manageAmbushes"] call VIC_fnc_debugLog;
@@ -13,10 +13,10 @@ private _minUnits = ["VSA_ambushMinUnits", 3] call VIC_fnc_getSetting;
 private _maxUnits = ["VSA_ambushMaxUnits", 6] call VIC_fnc_getSetting;
 
 {
-    _x params ["_pos","_veh","_mines","_groups","_triggered","_marker"];
-    private _near = [_pos,_range] call VIC_fnc_hasPlayersNearby;
+    _x params ["_pos","_veh","_mines","_groups","_triggered","_marker",["_active",false]];
+    private _newActive = [_pos,_range,_active] call VIC_fnc_evalSiteProximity;
 
-    if (_near) then {
+    if (_newActive) then {
         if (isNull _veh) then {
             _veh = "C_Van_01_transport_F" createVehicle _pos;
             _veh allowDamage false;
@@ -87,8 +87,8 @@ private _maxUnits = ["VSA_ambushMaxUnits", 6] call VIC_fnc_getSetting;
         _triggered = false;
     };
 
-    if (_marker != "") then { _marker setMarkerAlpha (if (_near) then {1} else {0.2}); };
-    STALKER_ambushes set [_forEachIndex, [_pos,_veh,_mines,_groups,_triggered,_marker]];
+    if (_marker != "") then { _marker setMarkerAlpha (if (_newActive) then {1} else {0.2}); };
+    STALKER_ambushes set [_forEachIndex, [_pos,_veh,_mines,_groups,_triggered,_marker,_newActive]];
 } forEach STALKER_ambushes;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -51,7 +51,7 @@ for "_i" from 1 to _count do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorBlack", 0.2, "Ambush"] call VIC_fnc_createGlobalMarker;
     };
 
-    STALKER_ambushes pushBack [_pos, objNull, [], [], false, _marker];
+    STALKER_ambushes pushBack [_pos, objNull, [], [], false, _marker, false];
 };
 
 true;

--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_startAmbushManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_startAmbushManager.sqf
@@ -11,7 +11,7 @@ missionNamespace setVariable ["VIC_ambushManagerRunning", true];
 [] spawn {
     while { missionNamespace getVariable ["VIC_ambushManagerRunning", false] } do {
         [] call VIC_fnc_manageAmbushes;
-        sleep 60;
+        sleep 6;
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_activateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_activateSite.sqf
@@ -11,7 +11,7 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 if (_index < 0 || {_index >= count STALKER_anomalyFields}) exitWith {};
 
 private _entry = STALKER_anomalyFields select _index;
-_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
+_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
 
 if (_objs isEqualTo [] || {{isNull _x} count _objs == count _objs}) then {
     private _spawned = [_center,_radius,_count,_site] call _fn;
@@ -30,6 +30,7 @@ if (_marker != "") then {
     _marker setMarkerAlpha 1;
 };
 
-STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
+_active = true;
+STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_active]];
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_deactivateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_deactivateSite.sqf
@@ -11,7 +11,7 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 if (_index < 0 || {_index >= count STALKER_anomalyFields}) exitWith {};
 
 private _entry = STALKER_anomalyFields select _index;
-_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
+_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
 
 if ((count _objs) > 0) then {
     { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
@@ -22,6 +22,7 @@ if (_marker != "") then {
     _marker setMarkerAlpha 0.2;
 };
 
-STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
+_active = false;
+STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_active]];
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
@@ -49,7 +49,7 @@ private _createField = {
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
 
-    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_pos,_exp,true];
+    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_pos,_exp,true,false];
     private _idx = (count STALKER_anomalyFields) - 1;
     private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
     private _gx = floor ((_pos select 0) / _gs);

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -103,7 +103,7 @@ for "_i" from 1 to _fieldCount do {
 
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
-    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_site,_exp,_stable];
+    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
     [format ["spawnAllAnomalyFields: spawned %1 %2", count _spawned, _typeName]] call VIC_fnc_debugLog;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_startAnomalyManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_startAnomalyManager.sqf
@@ -11,7 +11,7 @@ missionNamespace setVariable ["VIC_anomalyManagerRunning", true];
 [] spawn {
     while { missionNamespace getVariable ["VIC_anomalyManagerRunning", false] } do {
         [] call VIC_fnc_manageAnomalyFields;
-        sleep 60;
+        sleep 6;
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_manageChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_manageChemicalZones.sqf
@@ -21,18 +21,18 @@ for [{_i = (count STALKER_chemicalZones) - 1}, {_i >= 0}, {_i = _i - 1}] do {
         continue;
     };
 
-    private _near = [_pos,_range] call VIC_fnc_hasPlayersNearby;
-    if (_near) then {
+    private _newActive = [_pos,_range,_active] call VIC_fnc_evalSiteProximity;
+    if (_newActive) then {
         if (!_active) then {
             private _dur = if (_expires < 0) then {-1} else {_expires - diag_tickTime};
             [_pos,_radius,_dur] call VIC_fnc_spawnChemicalZone;
-            _active = true;
         };
         if (_marker != "") then { _marker setMarkerAlpha 1; };
     } else {
         if (_active) then { _active = false; };
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
+    _active = _newActive;
 
     STALKER_chemicalZones set [_i, [_pos,_radius,_active,_marker,_expires]];
 };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf
@@ -1,0 +1,30 @@
+/*
+    Determines whether a site should be active based on player proximity.
+    Applies a 200m hysteresis so active sites only deactivate when all players
+    are beyond the activation range plus 200 meters.
+
+    Params:
+        0: POSITION - position of the site
+        1: NUMBER   - activation range in meters
+        2: BOOL     - current active state
+
+    Returns: BOOL - updated active state
+*/
+
+params ["_pos", "_range", "_active"];
+
+private _near = [_pos, _range] call VIC_fnc_hasPlayersNearby;
+
+if (_active) then {
+    if (!_near) then {
+        if (![_pos, _range + 200] call VIC_fnc_hasPlayersNearby) then {
+            _active = false;
+        } else {
+            _active = true;
+        };
+    };
+} else {
+    if (_near) then { _active = true; };
+};
+
+_active

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -14,13 +14,13 @@ if (!isServer) exitWith { false };
     while { true } do {
         [] call VIC_fnc_manageWanderers;
         [] call VIC_fnc_manageSpookZones;
-        sleep 60;
+        sleep 6;
     };
 };
 [] spawn {
     while { true } do {
         [] call VIC_fnc_manageWrecks;
-        sleep 60;
+        sleep 6;
     };
 };
 [
@@ -28,7 +28,7 @@ if (!isServer) exitWith { false };
         while { true } do {
             [] call VIC_fnc_updateProximity;
             [] call VIC_fnc_updateActivityGrid;
-            private _delay = if (["VSA_autoInit", false] call VIC_fnc_getSetting) then {5} else { ["VSA_proximityCheckInterval", 0] call VIC_fnc_getSetting };
+            private _delay = 6;
             sleep _delay;
         };
     }, [], 8

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -199,6 +199,7 @@ VIC_fnc_findLandPos = compile preprocessFileLineNumbers (_root + "\functions\cor
 VIC_fnc_getLandSurfacePosition  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_getLandSurfacePosition.sqf");
 VIC_fnc_findRoadPosition        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRoadPosition.sqf");
 VIC_fnc_findRandomRoadPosition  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRandomRoadPosition.sqf");
+VIC_fnc_evalSiteProximity      = compile preprocessFileLineNumbers (_root + "\functions\core\fn_evalSiteProximity.sqf");
 VIC_fnc_spawnAmbientStalkers   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnAmbientStalkers.sqf");
 VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamp.sqf");
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
@@ -230,8 +231,7 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
                 while {true} do {
                     [] call VIC_fnc_updateProximity;
                     [] call VIC_fnc_updateActivityGrid;
-                    private _delay = ["VSA_proximityCheckInterval", 5] call VIC_fnc_getSetting;
-                    if (["VSA_autoInit", false] call VIC_fnc_getSetting) then { _delay = 5 };
+                    private _delay = 6;
                     sleep _delay;
                 };
             }, [], 8

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_activateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_activateSite.sqf
@@ -11,7 +11,7 @@ if (isNil "STALKER_minefields") exitWith {};
 if (_index < 0 || {_index >= count STALKER_minefields}) exitWith {};
 
 private _entry = STALKER_minefields select _index;
-_entry params ["_center","_type","_size","_objs","_marker"];
+_entry params ["_center","_type","_size","_objs","_marker",["_active",false]];
 
 if (_objs isEqualTo []) then {
     _objs = switch (_type) do {
@@ -20,8 +20,8 @@ if (_objs isEqualTo []) then {
         default { [] };
     };
 };
+_active = true;
 if (_marker != "") then { _marker setMarkerAlpha 1; };
-
-STALKER_minefields set [_index, [_center,_type,_size,_objs,_marker]];
+STALKER_minefields set [_index, [_center,_type,_size,_objs,_marker,_active]];
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_deactivateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_deactivateSite.sqf
@@ -11,7 +11,7 @@ if (isNil "STALKER_minefields") exitWith {};
 if (_index < 0 || {_index >= count STALKER_minefields}) exitWith {};
 
 private _entry = STALKER_minefields select _index;
-_entry params ["_center","_type","_size","_objs","_marker"];
+_entry params ["_center","_type","_size","_objs","_marker",["_active",false]];
 
 if ((count _objs) > 0) then {
     { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
@@ -19,6 +19,7 @@ if ((count _objs) > 0) then {
 };
 if (_marker != "") then { _marker setMarkerAlpha 0.2; };
 
-STALKER_minefields set [_index, [_center,_type,_size,_objs,_marker]];
+_active = false;
+STALKER_minefields set [_index, [_center,_type,_size,_objs,_marker,_active]];
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -1,6 +1,6 @@
 /*
     Activates or deactivates booby traps based on player proximity.
-    STALKER_boobyTraps entries: [position, objects, marker]
+    STALKER_boobyTraps entries: [position, objects, marker, active]
 */
 ["manageBoobyTraps"] call VIC_fnc_debugLog;
 
@@ -10,23 +10,23 @@ if (isNil "STALKER_boobyTraps") exitWith {};
 private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
 
 {
-    _x params ["_pos","_objs","_marker"];
-    private _near = [_pos,_dist] call VIC_fnc_hasPlayersNearby;
-    if (_near) then {
-        if (_objs isEqualTo []) then {
+    _x params ["_pos","_objs","_marker",["_active",false]];
+    private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
+    if (_newActive) then {
+        if (!_active) then {
             private _type = selectRandom ["APERSTripMine_Wire","IEDUrbanSmall_F"];
             private _mine = createMine [_type, _pos, [], 0];
             _objs = [_mine];
         };
         if (_marker != "") then { _marker setMarkerAlpha 1; };
     } else {
-        if ((count _objs) > 0) then {
+        if (_active && {(count _objs) > 0}) then {
             { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
             _objs = [];
         };
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
-    STALKER_boobyTraps set [_forEachIndex, [_pos,_objs,_marker]];
+    STALKER_boobyTraps set [_forEachIndex, [_pos,_objs,_marker,_newActive]];
 } forEach STALKER_boobyTraps;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
@@ -41,7 +41,7 @@ for "_i" from 1 to _count do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorOrange", 0.2, "Trap"] call VIC_fnc_createGlobalMarker;
     };
 
-    STALKER_boobyTraps pushBack [_pos, [], _marker];
+    STALKER_boobyTraps pushBack [_pos, [], _marker, false];
 };
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -49,7 +49,7 @@ for "_i" from 1 to _fieldCount do {
         [_marker, _pos, "RECTANGLE", "", "ColorYellow", 0.2, "APERS Field"] call VIC_fnc_createGlobalMarker;
         _marker setMarkerSize [_size/2, _size/2];
     };
-    STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker];
+    STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker,false];
     private _idx = (count STALKER_minefields) - 1;
     private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
     private _gx = floor ((_pos select 0) / _gs);
@@ -74,7 +74,7 @@ for "_i" from 1 to _iedCount do {
         _marker = format ["ied_%1", diag_tickTime];
         [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.2, "IED"] call VIC_fnc_createGlobalMarker;
     };
-    STALKER_minefields pushBack [_pos,"IED",0,[],_marker];
+    STALKER_minefields pushBack [_pos,"IED",0,[],_marker,false];
     private _idx = (count STALKER_minefields) - 1;
     private _gs = missionNamespace getVariable ["STALKER_activityGridSize", 500];
     private _gx = floor ((_pos select 0) / _gs);

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_startMinefieldManager.sqf
@@ -12,7 +12,7 @@ missionNamespace setVariable ["VIC_minefieldManagerRunning", true];
     while { missionNamespace getVariable ["VIC_minefieldManagerRunning", false] } do {
         [] call VIC_fnc_manageMinefields;
         [] call VIC_fnc_manageBoobyTraps;
-        sleep 60;
+        sleep 6;
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -1,6 +1,6 @@
 /*
     Activates or deactivates stalker camps based on player proximity.
-    STALKER_camps entries: [campfire, group, position, marker, side, faction]
+    STALKER_camps entries: [campfire, group, position, marker, side, faction, active]
 */
 
 ["manageStalkerCamps"] call VIC_fnc_debugLog;
@@ -12,9 +12,9 @@ private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
 
 {
-    _x params ["_camp", "_grp", "_pos", "_marker", "_side", "_faction"];
-    private _near = [_pos, _dist] call VIC_fnc_hasPlayersNearby;
-    if (_near) then {
+    _x params ["_camp", "_grp", "_pos", "_marker", "_side", "_faction",["_active",false]];
+    private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
+    if (_newActive) then {
         if (isNull _camp) then { _camp = "Campfire_burning_F" createVehicle _pos; };
         if (isNull _grp || { count units _grp == 0 }) then {
             private _class = switch (_side) do {
@@ -48,9 +48,9 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
         if (!isNull _camp) then { deleteVehicle _camp; _camp = objNull; };
     };
     if (_marker != "") then {
-        [_marker, (if (_near) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
+        [_marker, (if (_newActive) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
     };
-    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _marker, _side, _faction]];
+    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _marker, _side, _faction, _newActive]];
 } forEach STALKER_camps;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -64,4 +64,4 @@ if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     [_marker, _pos, "ICON", "mil_box", _color, 0.2, _faction] call VIC_fnc_createGlobalMarker;
 };
 
-STALKER_camps pushBack [_campfire, _grp, _pos, _marker, _side, _faction];
+STALKER_camps pushBack [_campfire, _grp, _pos, _marker, _side, _faction, false];

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startSniperManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startSniperManager.sqf
@@ -11,7 +11,7 @@ missionNamespace setVariable ["VIC_sniperManagerRunning", true];
 [] spawn {
     while { missionNamespace getVariable ["VIC_sniperManagerRunning", false] } do {
         [] call VIC_fnc_manageSnipers;
-        sleep 60;
+        sleep 6;
     };
 };
 


### PR DESCRIPTION
## Summary
- add evalSiteProximity helper for hysteresis checks
- apply new proximity logic to minefields, booby traps, chemical zones and anomaly fields
- track activation state in site arrays
- reduce manager loop intervals to 6 seconds

## Testing
- `./scripts/sqflint-hook.sh $(git ls-files '*.sqf')`

------
https://chatgpt.com/codex/tasks/task_e_685751c2c86c832f9654989f8c323603