### PR TITLE
Fix boobytrap tripwire ammo class

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -14,7 +14,8 @@ private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
     private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (!_active) then {
-            private _type = selectRandom ["APERSTripMine_Wire","IEDUrbanSmall_F"];
+            // Use ammo classes for tripwire mines when spawning
+            private _type = selectRandom ["APERSTripMine_Wire_Ammo", "IEDUrbanSmall_F"];
             private _mine = createMine [_type, _pos, [], 0];
             _objs = [_mine];
         };

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
@@ -32,7 +32,8 @@ for "_i" from 0 to ((count _positions) - 1) do {
     private _pos = _positions select _i;
     private _nextPos = _positions select ((_i + 1) mod (count _positions));
 
-    private _mine = createMine ["APERSTripMine_Wire", _pos, [], 0];
+    // Tripwire mines require the ammo class when spawned
+    private _mine = createMine ["APERSTripMine_Wire_Ammo", _pos, [], 0];
     _mine setDir ([_pos, _nextPos] call BIS_fnc_dirTo);
     _objs pushBack _mine;
 


### PR DESCRIPTION
## Summary
- use `APERSTripMine_Wire_Ammo` with `createMine`

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68576f312d3c832fb8542055ea509a07