### PR TITLE
Optimize player proximity checks

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
@@ -27,7 +27,7 @@ for "_i" from ((count STALKER_anomalyFields) - 1) to 0 step -1 do {
     };
 
     private _pos = if (_site isEqualTo []) then {_center} else {_site};
-    private _dist = ["VSA_playerNearbyRange", 1500] call VIC_fnc_getSetting;
+    private _dist = 400;
     private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
 
     if (_newActive) then {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf
@@ -13,16 +13,14 @@ params ["_pos", "_radius"];
 // Use the activity grid when available for quick lookups
 if (!isNil "STALKER_activityGrid") then {
     private _size = missionNamespace getVariable ["STALKER_activityGridSize", 500];
+    private _max  = floor (worldSize / _size);
     private _gx = floor ((_pos select 0) / _size);
     private _gy = floor ((_pos select 1) / _size);
-    private _key = format ["%1_%2", _gx, _gy];
-    private _found = false;
-    private _near = false;
-    {
-        _x params ["_cell","_state"];
-        if (_cell == _key) exitWith { _found = true; _near = _state; };
-    } forEach STALKER_activityGrid;
-    if (_found) exitWith { _near };
+    if (_gx >= 0 && {_gx <= _max} && {_gy >= 0} && {_gy <= _max}) then {
+        private _idx = _gx * (_max + 1) + _gy;
+        private _entry = STALKER_activityGrid select _idx;
+        if (!isNil "_entry") exitWith { _entry select 1 };
+    };
 };
 
 // Fallback radial search


### PR DESCRIPTION
## Summary
- reduce anomaly activation radius to 400m
- streamline `hasPlayersNearby` using direct index lookup

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_hasPlayersNearby.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68577761f5f8832fad2ecb810ecf327d