### PR TITLE
Add tight sniper tripwire circles

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf
@@ -4,10 +4,16 @@
         0: POSITION - center position
         1: NUMBER   - radius of the perimeter (default 25)
         2: NUMBER   - number of mines to spawn (default 6)
+        3: NUMBER   - desired spacing between mines (optional)
     Returns:
         ARRAY - spawned mine objects
 */
-params ["_center", ["_radius",25], ["_count",6]];
+params ["_center", ["_radius",25], ["_count",6], ["_spacing",-1]];
+
+if (_spacing > 0) then {
+    _count = floor ((2 * pi * _radius) / _spacing);
+    if (_count < 1) then { _count = 1 }; 
+};
 
 ["spawnTripwirePerimeter"] call VIC_fnc_debugLog;
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
@@ -30,7 +30,7 @@ private _cellSize = missionNamespace getVariable ["STALKER_activityGridSize", 50
             _grp = createGroup east;
             _grp createUnit ["O_sniper_F", _pos, [], 0, "FORM"];
             [_grp, _pos, 100, [], true, true, 0, true] call lambs_wp_fnc_taskGarrison;
-            [_pos, 25, 6] call VIC_fnc_spawnTripwirePerimeter;
+            [_pos, 6, 0, 4] call VIC_fnc_spawnTripwirePerimeter;
         };
         if (_marker != "") then { _marker setMarkerAlpha 1; };
     } else {

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
@@ -37,7 +37,7 @@ private _grp = createGroup east;
 _grp createUnit ["O_sniper_F", _spotAGL, [], 0, "FORM"];
 // Increase search radius and prioritize high vantage points
 [_grp, _spotAGL, 100, [], true, true, 0, true] call lambs_wp_fnc_taskGarrison;
-[_spotAGL, 25, 6] call VIC_fnc_spawnTripwirePerimeter;
+[_spotAGL, 6, 0, 4] call VIC_fnc_spawnTripwirePerimeter;
 
 private _marker = "";
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {


### PR DESCRIPTION
## Summary
- allow custom spacing for tripwire perimeters
- make snipers deploy a 6 m circle of tripwires 4 m apart

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnTripwirePerimeter.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6860001fed68832fa6356e7b94b06dba