### PR TITLE
Initialize map caches and spawn road sites

### DIFF
--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -50,3 +50,15 @@ STALKER_wanderers = [];
 //     private _pos = [random worldSize, random worldSize, 0];
 //     [_pos, 1000] call VIC_fnc_spawnAmbushes;
 // };
+
+// Automatically initialize map caches and spawn core sites
+[] call VIC_fnc_initMap;
+
+private _center = [worldSize / 2, worldSize / 2, 0];
+[_center, worldSize] call VIC_fnc_spawnMinefields;
+[_center, worldSize] call VIC_fnc_spawnIEDSites;
+
+private _wreckCount = ["VSA_wreckCount", 10] call VIC_fnc_getSetting;
+[_wreckCount] call VIC_fnc_spawnAbandonedVehicles;
+
+[] call VIC_fnc_initManagers;


### PR DESCRIPTION
## Summary
- initialize map caches on mission start
- spawn minefields, IED sites, and wrecks across the map
- start manager loops to control spawned objects

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/initServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_686000988f5c832fbc747210c0ec4f58