### PR TITLE
Add debug messages for caching results

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf
@@ -58,4 +58,6 @@ for "_x" from 0 to _size step _step do {
 if (isNil "STALKER_bridges") then { STALKER_bridges = [] };
 { STALKER_bridges pushBackUnique _x } forEach _found;
 
+[format ["findBridges: %1 cached", count STALKER_bridges]] call VIC_fnc_debugLog;
+
 _found

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
@@ -51,4 +51,6 @@ for "_px" from 0 to worldSize step _step do {
 if (isNil "STALKER_buildingClusters") then { STALKER_buildingClusters = [] };
 { STALKER_buildingClusters pushBackUnique _x } forEach _clusters;
 
+[format ["findBuildingClusters: %1 cached", count STALKER_buildingClusters]] call VIC_fnc_debugLog;
+
 _clusters

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf
@@ -40,5 +40,7 @@ private _crossroads = [];
 if (isNil "STALKER_crossroads") then { STALKER_crossroads = [] };
 { STALKER_crossroads pushBackUnique _x } forEach _crossroads;
 
+[format ["findCrossroads: %1 cached", count STALKER_crossroads]] call VIC_fnc_debugLog;
+
 _crossroads
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf
@@ -29,5 +29,7 @@ for "_xCoord" from 0 to worldSize step _step do {
 if (isNil "STALKER_roads") then { STALKER_roads = [] };
 { STALKER_roads pushBackUnique _x } forEach _roads;
 
+[format ["findRoads: %1 cached", count STALKER_roads]] call VIC_fnc_debugLog;
+
 _roads
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf
@@ -99,6 +99,8 @@ for "_gx" from 0 to worldSize step _step do {
 if (isNil "STALKER_valleys") then { STALKER_valleys = [] };
 { STALKER_valleys pushBackUnique _x } forEach _valleys;
 
+[format ["findValleys: %1 cached", count STALKER_valleys]] call VIC_fnc_debugLog;
+
 // Persist the cached valleys for later sessions
 ["STALKER_valleys", STALKER_valleys] call VIC_fnc_saveCache;
 


### PR DESCRIPTION
## Summary
- log the cache counts in map scanning functions

## Testing
- `~/.local/bin/pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findBridges.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findCrossroads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findRoads.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_findValleys.sqf addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf`

------
https://chatgpt.com/codex/tasks/task_e_686069cfefe8832fb7c9dc59e1d8e587