### PR TITLE
Implement stalker camp manager

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -365,6 +365,22 @@
     [0, 100, 33, 0]
 ] call CBA_fnc_addSetting;
 
+[
+    "VSA_minStalkerCamps",
+    "SLIDER",
+    ["Min Active Camps", "Minimum number of stalker camps"],
+    "Viceroy's STALKER ALife - Stalkers",
+    [0, 50, 1, 0]
+] call CBA_fnc_addSetting;
+
+[
+    "VSA_maxStalkerCamps",
+    "SLIDER",
+    ["Max Active Camps", "Maximum number of stalker camps"],
+    "Viceroy's STALKER ALife - Stalkers",
+    [0, 50, 5, 0]
+] call CBA_fnc_addSetting;
+
 // -----------------------------------------------------------------------------
 // Spooks
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -94,6 +94,7 @@ class CfgFunctions
             class spawnSniper{};
             class manageSnipers{};
             class startSniperManager{};
+            class startCampManager{};
             class manageStalkerCamps{};
             class manageWanderers{};
         };
@@ -266,6 +267,7 @@ class CfgRemoteExec
         class VIC_fnc_spawnStalkerCamps   { allowedTargets = 2; };
         class VIC_fnc_spawnSniper         { allowedTargets = 2; };
         class VIC_fnc_startSniperManager  { allowedTargets = 2; };
+        class VIC_fnc_startCampManager   { allowedTargets = 2; };
         class VIC_fnc_spawnPredatorAttack { allowedTargets = 2; };
         class VIC_fnc_spawnHabitatHunters { allowedTargets = 2; };
         class VIC_fnc_spawnMinefields     { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -10,6 +10,7 @@ if (!isServer) exitWith { false };
 [] call VIC_fnc_startIEDManager;
 [] call VIC_fnc_startAmbushManager;
 [] call VIC_fnc_startSniperManager;
+[] call VIC_fnc_startCampManager;
 [] call VIC_fnc_startAnomalyManager;
 [] spawn {
     while { true } do {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -208,6 +208,7 @@ VIC_fnc_spawnFlareTripwires    = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnSniper           = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnSniper.sqf");
 VIC_fnc_manageSnipers         = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageSnipers.sqf");
 VIC_fnc_startSniperManager    = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_startSniperManager.sqf");
+VIC_fnc_startCampManager     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_startCampManager.sqf");
 VIC_fnc_manageStalkerCamps     = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageStalkerCamps.sqf");
 VIC_fnc_manageWanderers       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageWanderers.sqf");
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
@@ -1,0 +1,51 @@
+/*
+    Starts the stalker camp management loop. Debug use only.
+    Periodically manages STALKER_camps, removing excess camps
+    and spawning new ones if below the configured minimum.
+*/
+["startCampManager"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith {};
+
+if (missionNamespace getVariable ["VIC_campManagerRunning", false]) exitWith {};
+missionNamespace setVariable ["VIC_campManagerRunning", true];
+
+[] spawn {
+    while { missionNamespace getVariable ["VIC_campManagerRunning", false] } do {
+        // Update existing camps based on player proximity
+        [] call VIC_fnc_manageStalkerCamps;
+
+        if (isNil "STALKER_camps") then { STALKER_camps = []; };
+        private _min = ["VSA_minStalkerCamps", 1] call VIC_fnc_getSetting;
+        private _max = ["VSA_maxStalkerCamps", 5] call VIC_fnc_getSetting;
+
+        private _count = count STALKER_camps;
+
+        if (_count > _max) then {
+            for "_i" from 1 to (_count - _max) do {
+                if ((count STALKER_camps) == 0) exitWith {};
+                private _idx = floor random (count STALKER_camps);
+                private _camp = STALKER_camps select _idx;
+                _camp params ["_fire","_grp","_pos","_marker"];
+                if (!isNull _grp) then { { deleteVehicle _x } forEach units _grp; deleteGroup _grp; };
+                if (!isNull _fire) then { deleteVehicle _fire; };
+                if (_marker != "") then { deleteMarker _marker; };
+                STALKER_camps deleteAt _idx;
+            };
+        };
+
+        if ((count STALKER_camps) < _min) then {
+            private _needed = _min - (count STALKER_camps);
+            for "_i" from 1 to _needed do {
+                private _building = [] call VIC_fnc_findCampBuilding;
+                if (isNull _building) exitWith {};
+                private _pos = getPosATL _building;
+                [_pos] call VIC_fnc_spawnStalkerCamp;
+            };
+        };
+
+        sleep 6;
+    };
+};
+
+true


### PR DESCRIPTION
## Summary
- add a camp manager loop for stalkers
- expose min/max camp settings
- register and start the new manager

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/cba_settings.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68607200defc832fa641abb91bac08e4