### PR TITLE
Initialize booby traps on server start

### DIFF
--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -58,6 +58,9 @@ private _center = [worldSize / 2, worldSize / 2, 0];
 [_center, worldSize] call VIC_fnc_spawnMinefields;
 [_center, worldSize] call VIC_fnc_spawnIEDSites;
 
+[_center, worldSize] call VIC_fnc_spawnBoobyTraps;
+[format ["initServer: %1 traps placed", count STALKER_boobyTraps]] call VIC_fnc_debugLog;
+
 private _wreckCount = ["VSA_wreckCount", 10] call VIC_fnc_getSetting;
 [_wreckCount] call VIC_fnc_spawnAbandonedVehicles;
 


### PR DESCRIPTION
## Summary
- call `VIC_fnc_spawnBoobyTraps` from `initServer.sqf`
- log number of traps spawned

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/initServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6860749fb908832fb5185c767fd4f483