### PR TITLE
Suppress debug logs

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf
@@ -3,7 +3,7 @@
     STALKER_ambushes entries: [position, vehicle, mines, groups, triggered, marker, active]
 */
 
-["manageAmbushes"] call VIC_fnc_debugLog;
+// ["manageAmbushes"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_ambushes") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
@@ -4,7 +4,7 @@
     STALKER_anomalyFields entries:
         [center, radius, fn, count, objects, marker, site, expires, stable, active]
 */
-["manageAnomalyFields"] call VIC_fnc_debugLog;
+// ["manageAnomalyFields"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_anomalyFields") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/chemical/fn_manageChemicalZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/chemical/fn_manageChemicalZones.sqf
@@ -4,7 +4,7 @@
     STALKER_chemicalZones as [position, radius, active, marker, expires].
 */
 
-["manageChemicalZones"] call VIC_fnc_debugLog;
+// ["manageChemicalZones"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_chemicalZones") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -2,7 +2,7 @@
     Activates or deactivates booby traps based on player proximity.
     STALKER_boobyTraps entries: [position, objects, marker, active]
 */
-["manageBoobyTraps"] call VIC_fnc_debugLog;
+// ["manageBoobyTraps"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_boobyTraps") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf
@@ -2,7 +2,7 @@
     Activates or deactivates IED sites and handles cleanup.
     STALKER_iedSites entries: [position, object, marker, active]
 */
-["manageIEDSites"] call VIC_fnc_debugLog;
+// ["manageIEDSites"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_iedSites") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf
@@ -2,7 +2,7 @@
     Activates or deactivates minefields based on player proximity.
     STALKER_minefields entries: [center, type, size, objects, marker, active]
 */
-["manageMinefields"] call VIC_fnc_debugLog;
+// ["manageMinefields"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_minefields") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -5,7 +5,7 @@
     STALKER_mutantHabitats entries: [areaMarker, labelMarker, group, position, type, max, count, near]
 */
 
-["manageHabitats"] call VIC_fnc_debugLog;
+// ["manageHabitats"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_mutantHabitats") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHerds.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHerds.sqf
@@ -4,7 +4,7 @@
     STALKER_activeHerds entries: [leader, group, max, count, near, marker]
 */
 
-["manageHerds"] call VIC_fnc_debugLog;
+// ["manageHerds"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_activeHerds") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHostiles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHostiles.sqf
@@ -2,7 +2,7 @@
     Handles despawn and respawn of hostile mutant groups.
 */
 
-["manageHostiles"] call VIC_fnc_debugLog;
+// ["manageHostiles"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_activeHostiles") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageNests.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageNests.sqf
@@ -2,7 +2,7 @@
     Manages mutant nests, despawning or respawning the defenders based on player proximity.
 */
 
-["manageNests"] call VIC_fnc_debugLog;
+// ["manageNests"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_mutantNests") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf
@@ -3,10 +3,10 @@
     STALKER_activePredators entries: [group, target, marker, near]
 */
 
-["managePredators"] call VIC_fnc_debugLog;
+// ["managePredators"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {
-    ["managePredators exit: not server"] call VIC_fnc_debugLog;
+    // ["managePredators exit: not server"] call VIC_fnc_debugLog;
 };
 if (isNil "STALKER_activePredators") then { STALKER_activePredators = []; };
 
@@ -37,4 +37,4 @@ private _range = ["VSA_predatorRange", 1500] call VIC_fnc_getSetting;
     STALKER_activePredators set [_forEachIndex, [_grp, _target, _marker, _near]];
 } forEach STALKER_activePredators;
 
-["managePredators completed"] call VIC_fnc_debugLog;
+// ["managePredators completed"] call VIC_fnc_debugLog;

--- a/addons/Viceroys-STALKER-ALife/functions/spooks/fn_manageSpookZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/spooks/fn_manageSpookZones.sqf
@@ -7,7 +7,7 @@
         spookCount    - number of units to spawn
 */
 
-["manageSpookZones"] call VIC_fnc_debugLog;
+// ["manageSpookZones"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "drg_activeSpookZones") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
@@ -4,7 +4,7 @@
     STALKER_snipers entries: [group, position, marker, active]
 */
 
-["manageSnipers"] call VIC_fnc_debugLog;
+// ["manageSnipers"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_snipers") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -3,7 +3,7 @@
     STALKER_camps entries: [campfire, group, position, marker, side, faction, active]
 */
 
-["manageStalkerCamps"] call VIC_fnc_debugLog;
+// ["manageStalkerCamps"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_camps") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
@@ -4,7 +4,7 @@
     STALKER_wanderers entries: [group, position, marker, active]
 */
 
-["manageWanderers"] call VIC_fnc_debugLog;
+// ["manageWanderers"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_wanderers") exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf
@@ -8,7 +8,7 @@
     STALKER_wreckMarkers using the same index.
 */
 
-["manageWrecks"] call VIC_fnc_debugLog;
+// ["manageWrecks"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith {};
 if (isNil "STALKER_wrecks") exitWith {};


### PR DESCRIPTION
## Summary
- comment out `VIC_fnc_debugLog` calls in recurring manager functions

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/mutants/fn_managePredators.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68607592fe24832fb5f12f4f35212924