### PR TITLE
Fix global marker debug spam

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf
@@ -32,7 +32,7 @@ if (isNil {_name} || { isNil {_pos} }) exitWith {
     ""
 };
 
-["createGlobalMarker"] call VIC_fnc_debugLog;
+
 
 if (!isServer) exitWith { _name };
 
@@ -40,6 +40,6 @@ private _target = if (_global) then { 0 } else { remoteExecutedOwner };
 
 [_name, _pos, _shape, _type, _color, _alpha, _text, _size] remoteExecCall ["VIC_fnc_createLocalMarker", _target, true];
 
-["createGlobalMarker done"] call VIC_fnc_debugLog;
+
 
 _name


### PR DESCRIPTION
## Summary
- cut routine debug logs from `fn_createGlobalMarker.sqf`

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_createGlobalMarker.sqf`

------
https://chatgpt.com/codex/tasks/task_e_686078703de4832f8af69a6c8332c69e