### PR TITLE
Add debug summaries for minefield spawning

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
@@ -23,6 +23,8 @@ if (_towns isEqualTo []) exitWith { false };
 
 if (isNil "STALKER_boobyTraps") then { STALKER_boobyTraps = [] };
 
+private _spawned = 0;
+
 for "_i" from 1 to _count do {
     if (_towns isEqualTo []) exitWith {};
     private _town = selectRandom _towns;
@@ -42,6 +44,9 @@ for "_i" from 1 to _count do {
     };
 
     STALKER_boobyTraps pushBack [_pos, [], _marker, false];
+    _spawned = _spawned + 1;
 };
+
+[format ["spawnBoobyTraps: placed %1 traps", _spawned]] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf
@@ -17,6 +17,8 @@ if (["VSA_enableMinefields", true] call VIC_fnc_getSetting isEqualTo false) exit
 
 if (isNil "STALKER_iedSites") then { STALKER_iedSites = [] };
 
+private _spawned = 0;
+
 if (_count < 0) then { _count = ["VSA_IEDSiteCount",10] call VIC_fnc_getSetting; };
 
 private _towns = nearestLocations [_center, ["NameVillage","NameCity","NameCityCapital","NameLocal"], _radius];
@@ -41,6 +43,9 @@ for "_i" from 1 to _count do {
     };
 
     STALKER_iedSites pushBack [_pos, objNull, _marker, false];
+    _spawned = _spawned + 1;
 };
+
+[format ["spawnIEDSites: placed %1 sites", _spawned]] call VIC_fnc_debugLog;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -24,6 +24,9 @@ if (_fieldCount < 0) then { _fieldCount = ["VSA_minefieldCount",2] call VIC_fnc_
 if (_iedCount < 0) then { _iedCount = ["VSA_IEDCount",2] call VIC_fnc_getSetting; };
 private _size = ["VSA_minefieldSize",30] call VIC_fnc_getSetting;
 
+private _fieldsSpawned = 0;
+private _iedsSpawned = 0;
+
 private _towns = nearestLocations [_center, ["NameVillage","NameCity","NameCityCapital","NameLocal"], _radius];
 
 private _useFallback = _towns isEqualTo [];
@@ -50,6 +53,7 @@ for "_i" from 1 to _fieldCount do {
         _marker setMarkerSize [_size/2, _size/2];
     };
     STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker,false];
+    _fieldsSpawned = _fieldsSpawned + 1;
 };
 
 for "_i" from 1 to _iedCount do {
@@ -69,9 +73,12 @@ for "_i" from 1 to _iedCount do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.2, "IED"] call VIC_fnc_createGlobalMarker;
     };
     STALKER_minefields pushBack [_pos,"IED",0,[],_marker,false];
+    _iedsSpawned = _iedsSpawned + 1;
 };
 
 if !(missionNamespace getVariable ["VIC_minefieldManagerRunning", false]) then {
     [] call VIC_fnc_startMinefieldManager;
 };
+
+[format ["spawnMinefields: placed %1 fields and %2 IEDs", _fieldsSpawned, _iedsSpawned]] call VIC_fnc_debugLog;
 


### PR DESCRIPTION
## Summary
- emit counts after spawning minefields, IED sites and booby traps

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6860793f5fa8832f84db533acf07a7b0