### PR TITLE
Enable player range markers in debug mode

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf
@@ -14,7 +14,7 @@ missionNamespace setVariable ["VSA_rangeMarkersActive", true];
 if (isNil "STALKER_playerRangeMarker") then { STALKER_playerRangeMarker = "" };
 
 [] spawn {
-    while { true } do {
+    while { missionNamespace getVariable ["VSA_debugMode", true] } do {
         private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
         if (STALKER_playerRangeMarker isEqualTo "") then {
             private _name = format ["playerRange_%1", diag_tickTime];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -264,9 +264,18 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
 ["CBA_SettingChanged", {
     params ["_setting", "_value"];
     if (_setting isEqualTo "VSA_debugMode") then {
-        if (hasInterface && {_value}) then {
-            [] call VIC_fnc_setupDebugActions;
-            [] call VIC_fnc_markPlayerRanges;
+        if (hasInterface) then {
+            if (_value) then {
+                [] call VIC_fnc_setupDebugActions;
+                [] call VIC_fnc_markPlayerRanges;
+            } else {
+                if (!isNil "STALKER_playerRangeMarker" &&
+                    {STALKER_playerRangeMarker != ""}) then {
+                    deleteMarkerLocal STALKER_playerRangeMarker;
+                };
+                STALKER_playerRangeMarker = "";
+                missionNamespace setVariable ["VSA_rangeMarkersActive", false];
+            };
         };
     };
 }] call CBA_fnc_addEventHandler;


### PR DESCRIPTION
## Summary
- show player range markers continuously when debug mode is enabled
- remove range markers when debug mode is turned off

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_markPlayerRanges.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68607a728e98832f96d07ba14d21cec7