### PR TITLE
Enable auto-init gate in manager startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    * [Chemical Warfare Plus](https://steamcommunity.com/sharedfiles/filedetails/?id=3295358796)
    * [Necroplague](https://steamcommunity.com/workshop/filedetails/?id=2616555444)
 3. Review `cba_settings.sqf` for adjustable options such as the player nearby range and activity zone depth used by many systems.
-4. Enable **VSA_autoInit** if you want the world to populate automatically on mission start. When disabled, use the debug actions to spawn systems manually.
+4. Enable **VSA_autoInit** if you want the world to populate automatically on mission start. When enabled, all managers (minefields, IEDs, ambushes, snipers, anomaly fields and camps) start on their own. When disabled, use the debug actions to spawn systems manually.
 5. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    The activity grid overlay now refreshes automatically while this mode is active.
    This option can now be toggled while a mission is running and the debug

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -2,9 +2,19 @@
     Starts background manager systems for STALKER ALife.
 */
 
+
+// Starts background manager systems when auto init is enabled.
+// The old activity grid logic has been removed so managers rely on
+// simple proximity checks inside their own loops.
 ["initManagers"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith { false };
+
+// Only start managers automatically when configured to do so
+if !( ["VSA_autoInit", false] call VIC_fnc_getSetting ) exitWith {
+    ["initManagers: auto init disabled"] call VIC_fnc_debugLog;
+    false
+};
 
 [] call VIC_fnc_startMinefieldManager;
 [] call VIC_fnc_startIEDManager;


### PR DESCRIPTION
## Summary
- add setting check in `fn_initManagers.sqf`
- document that enabling **VSA_autoInit** starts all managers automatically

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf README.md`

------
https://chatgpt.com/codex/tasks/task_e_68607bbdfc6c832fa1a6eb9adf21463d