### PR TITLE
Fix auto init not launching server setup

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -306,3 +306,11 @@ class Extended_PreInit_EventHandlers
         init = "call compile preprocessFileLineNumbers 'Viceroys-STALKER-ALife\functions\core\fn_masterInit.sqf'";
     };
 };
+
+class Extended_PostInit_EventHandlers
+{
+    class VIC_StalkerALife_PostInit
+    {
+        init = "call compile preprocessFileLineNumbers 'Viceroys-STALKER-ALife\initServer.sqf'";
+    };
+};

--- a/addons/Viceroys-STALKER-ALife/initServer.sqf
+++ b/addons/Viceroys-STALKER-ALife/initServer.sqf
@@ -7,6 +7,11 @@ if (!isServer) exitWith {};
 // Ensure core functions are compiled when running script-only
 [] call compile preprocessFileLineNumbers "\Viceroys-STALKER-ALife\functions\core\fn_masterInit.sqf";
 
+if !( ["VSA_autoInit", false] call VIC_fnc_getSetting ) exitWith {
+    ["initServer: auto init disabled"] call VIC_fnc_debugLog;
+    false
+};
+
 // Spook zone configuration
 STALKER_MinSpookFields = 2;      // minimum zones spawned per emission
 STALKER_MaxSpookFields = 5;      // maximum zones spawned per emission


### PR DESCRIPTION
## Summary
- run `initServer.sqf` after mission start via Extended_PostInit handler
- skip server setup when `VSA_autoInit` setting is disabled

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/initServer.sqf`

------
https://chatgpt.com/codex/tasks/task_e_686086240f58832fb5cbbd9f0c94e9de