### PR TITLE
Implement per-map caches

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -9,23 +9,71 @@ if (!isServer) exitWith { false };
 
 // Load cached data when available to avoid expensive scans
 private _roads = ["STALKER_roads"] call VIC_fnc_loadCache;
-if (isNil {_roads}) then {
+if (isNil {_roads} || {_roads isEqualTo []}) then {
     _roads = [] call VIC_fnc_findRoads;
     ["STALKER_roads", _roads] call VIC_fnc_saveCache;
 };
 
 // Land zones are optional but load if present
-["STALKER_landZones"] call VIC_fnc_loadCache;
+private _zones = ["STALKER_landZones"] call VIC_fnc_loadCache;
+if (!isNil {_zones} && {_zones isEqualType [] && {count _zones == 0}}) then {
+    _zones = [] call VIC_fnc_findLandZones;
+    ["STALKER_landZones", _zones] call VIC_fnc_saveCache;
+};
 
-[] call VIC_fnc_findRockClusters;
-[] call VIC_fnc_findSniperSpots;
-[] call VIC_fnc_findSwamps;
-[] call VIC_fnc_findBeachesInMap;
-[] call VIC_fnc_findValleys;
-[] call VIC_fnc_findBridges;
-[] call VIC_fnc_findCrossroads;
-[] call VIC_fnc_findBuildingClusters;
-[] call VIC_fnc_findWrecks;
+private _rockClusters = ["STALKER_rockClusters"] call VIC_fnc_loadCache;
+if (isNil {_rockClusters} || {_rockClusters isEqualTo []}) then {
+    _rockClusters = [] call VIC_fnc_findRockClusters;
+    ["STALKER_rockClusters", _rockClusters] call VIC_fnc_saveCache;
+};
+
+private _sniperSpots = ["STALKER_sniperSpots"] call VIC_fnc_loadCache;
+if (isNil {_sniperSpots} || {_sniperSpots isEqualTo []}) then {
+    _sniperSpots = [] call VIC_fnc_findSniperSpots;
+    ["STALKER_sniperSpots", _sniperSpots] call VIC_fnc_saveCache;
+};
+
+private _swamps = ["STALKER_swamps"] call VIC_fnc_loadCache;
+if (isNil {_swamps} || {_swamps isEqualTo []}) then {
+    _swamps = [] call VIC_fnc_findSwamps;
+    ["STALKER_swamps", _swamps] call VIC_fnc_saveCache;
+};
+
+private _beaches = ["STALKER_beachSpots"] call VIC_fnc_loadCache;
+if (isNil {_beaches} || {_beaches isEqualTo []}) then {
+    _beaches = [] call VIC_fnc_findBeachesInMap;
+    ["STALKER_beachSpots", _beaches] call VIC_fnc_saveCache;
+};
+
+private _valleys = ["STALKER_valleys"] call VIC_fnc_loadCache;
+if (isNil {_valleys} || {_valleys isEqualTo []}) then {
+    _valleys = [] call VIC_fnc_findValleys;
+    ["STALKER_valleys", _valleys] call VIC_fnc_saveCache;
+};
+
+private _bridges = ["STALKER_bridges"] call VIC_fnc_loadCache;
+if (isNil {_bridges} || {_bridges isEqualTo []}) then {
+    _bridges = [] call VIC_fnc_findBridges;
+    ["STALKER_bridges", _bridges] call VIC_fnc_saveCache;
+};
+
+private _crossroads = ["STALKER_crossroads"] call VIC_fnc_loadCache;
+if (isNil {_crossroads} || {_crossroads isEqualTo []}) then {
+    _crossroads = [] call VIC_fnc_findCrossroads;
+    ["STALKER_crossroads", _crossroads] call VIC_fnc_saveCache;
+};
+
+private _bClusters = ["STALKER_buildingClusters"] call VIC_fnc_loadCache;
+if (isNil {_bClusters} || {_bClusters isEqualTo []}) then {
+    _bClusters = [] call VIC_fnc_findBuildingClusters;
+    ["STALKER_buildingClusters", _bClusters] call VIC_fnc_saveCache;
+};
+
+private _wrecks = ["STALKER_wrecks"] call VIC_fnc_loadCache;
+if (isNil {_wrecks} || {_wrecks isEqualTo []}) then {
+    _wrecks = [] call VIC_fnc_findWrecks;
+    ["STALKER_wrecks", _wrecks] call VIC_fnc_saveCache;
+};
 
 // Automatically display cached points when debug mode is active
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
@@ -10,14 +10,15 @@ params ["_name"];
 
 if (isNil {_name}) exitWith { nil };
 
-private _data = profileNamespace getVariable [_name, nil];
+private _key = format ["%1_%2", worldName, _name];
+private _data = profileNamespace getVariable [_key, nil];
 if (!isNil {_data}) then {
     missionNamespace setVariable [_name, _data];
     private _count = "";
     if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };
-    [format ["loadCache %1%2", _name, _count]] call VIC_fnc_debugLog;
+    [format ["loadCache %1%2", _key, _count]] call VIC_fnc_debugLog;
 } else {
-    [format ["loadCache %1: none", _name]] call VIC_fnc_debugLog;
+    [format ["loadCache %1: none", _key]] call VIC_fnc_debugLog;
 };
 
 _data

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf
@@ -12,15 +12,32 @@ private _roads = [] call VIC_fnc_findRoads;
 private _zones = [] call VIC_fnc_findLandZones;
 ["STALKER_landZones", _zones] call VIC_fnc_saveCache;
 
-[] call VIC_fnc_findRockClusters;
-[] call VIC_fnc_findSniperSpots;
-[] call VIC_fnc_findSwamps;
-[] call VIC_fnc_findBeachesInMap;
-[] call VIC_fnc_findValleys;
-[] call VIC_fnc_findBridges;
-[] call VIC_fnc_findCrossroads;
-[] call VIC_fnc_findBuildingClusters;
-[] call VIC_fnc_findWrecks;
+private _rockClusters = [] call VIC_fnc_findRockClusters;
+["STALKER_rockClusters", _rockClusters] call VIC_fnc_saveCache;
+
+private _sniperSpots = [] call VIC_fnc_findSniperSpots;
+["STALKER_sniperSpots", _sniperSpots] call VIC_fnc_saveCache;
+
+private _swamps = [] call VIC_fnc_findSwamps;
+["STALKER_swamps", _swamps] call VIC_fnc_saveCache;
+
+private _beaches = [] call VIC_fnc_findBeachesInMap;
+["STALKER_beachSpots", _beaches] call VIC_fnc_saveCache;
+
+private _valleys = [] call VIC_fnc_findValleys;
+["STALKER_valleys", _valleys] call VIC_fnc_saveCache;
+
+private _bridges = [] call VIC_fnc_findBridges;
+["STALKER_bridges", _bridges] call VIC_fnc_saveCache;
+
+private _crossroads = [] call VIC_fnc_findCrossroads;
+["STALKER_crossroads", _crossroads] call VIC_fnc_saveCache;
+
+private _bClusters = [] call VIC_fnc_findBuildingClusters;
+["STALKER_buildingClusters", _bClusters] call VIC_fnc_saveCache;
+
+private _wrecks = [] call VIC_fnc_findWrecks;
+["STALKER_wrecks", _wrecks] call VIC_fnc_saveCache;
 
 "Map points regenerated" remoteExec ["hint", 0];
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf
@@ -13,11 +13,12 @@ if (isNil {_name}) exitWith { false };
 if (isNil {_data}) then { _data = missionNamespace getVariable [_name, nil] };
 if (isNil {_data}) exitWith { false };
 
-profileNamespace setVariable [_name, _data];
+private _key = format ["%1_%2", worldName, _name];
+profileNamespace setVariable [_key, _data];
 saveProfileNamespace;
 
 private _count = "";
 if (_data isEqualType []) then { _count = format [" (%1 items)", count _data]; };
-[format ["saveCache %1%2", _name, _count]] call VIC_fnc_debugLog;
+[format ["saveCache %1%2", _key, _count]] call VIC_fnc_debugLog;
 
 true


### PR DESCRIPTION
## Summary
- persist cache variables using map-specific keys
- regen map caches when they load as empty
- save all map caches for rock clusters, sniper spots, swamps, beaches, valleys, bridges, crossroads, building clusters, and wrecks

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_saveCache.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68608b912440832f8c2cb6cf891d3920