### PR TITLE
Fix scheduled loops for proximity updates

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -35,13 +35,12 @@ if !( ["VSA_autoInit", false] call VIC_fnc_getSetting ) exitWith {
         sleep 6;
     };
 };
-[
-    {
-        while { true } do {
-            [] call VIC_fnc_updateProximity;
-            sleep 6;
-        };
-    }, [], 8
-] call CBA_fnc_waitAndExecute;
+[] spawn {
+    sleep 8;
+    while { true } do {
+        [] call VIC_fnc_updateProximity;
+        sleep 6;
+    };
+};
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -228,14 +228,13 @@ VIC_fnc_disableA3UWeather    = compile preprocessFileLineNumbers (_root + "\func
         [] call VIC_fnc_disableA3UWeather;
     };
     if (isServer && {isNil "VIC_activityThread"}) then {
-        VIC_activityThread = [
-            {
-                while {true} do {
-                    [] call VIC_fnc_updateProximity;
-                    sleep 6;
-                };
-            }, [], 8
-        ] call CBA_fnc_waitAndExecute;
+        VIC_activityThread = [] spawn {
+            sleep 8;
+            while {true} do {
+                [] call VIC_fnc_updateProximity;
+                sleep 6;
+            };
+        };
         // Additional managers have been disabled for quicker startup and can be
         // invoked via debug actions when needed.
     };


### PR DESCRIPTION
## Summary
- run `fn_updateProximity` in a spawned thread in `fn_initManagers`
- run `fn_updateProximity` in a spawned thread in `fn_masterInit`

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf`
- `sqflint addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`


------
https://chatgpt.com/codex/tasks/task_e_68616581b28c832fbc2ef9b22779c145