### PR TITLE
Fix early exit initialization in fn_loadCache

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
@@ -8,7 +8,8 @@
 */
 params ["_name"];
 
-if (isNil {_name}) exitWith { nil };
+private _data = nil;
+if (isNil {_name}) exitWith { _data };
 
 private _key = format ["%1_%2", worldName, _name];
 private _data = profileNamespace getVariable [_key, nil];


### PR DESCRIPTION
## Summary
- initialize `_data` early in `fn_loadCache`
- return `_data` when `_name` is nil

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68616a818ba4832fb29429daa853973f