### PR TITLE
Implement cached mutant habitats

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Swamp detection scans neighbouring grid cells for shallow water so habitats reliably appear in marshy areas.
   Locations are offset slightly each mission so nests appear in different spots every time.
 * Habitats will never overlap one another so each territory is distinct.
+* Habitat locations are cached in the profile so subsequent missions load faster.
 * CBA settings allow mission makers to customize these behaviors.
 
 ### Stalker Camps

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -80,6 +80,7 @@ class CfgFunctions
             class manageNests{};
             class manageHabitats{};
             class setupMutantHabitats{};
+            class spawnCachedHabitats{};
             class onEmissionStart{};
             class onEmissionEnd{};
         };
@@ -282,6 +283,7 @@ class CfgRemoteExec
         class VIC_fnc_startAmbushManager  { allowedTargets = 2; };
         class VIC_fnc_startAnomalyManager { allowedTargets = 2; };
         class VIC_fnc_setupMutantHabitats { allowedTargets = 2; };
+        class VIC_fnc_spawnCachedHabitats { allowedTargets = 2; };
         class VIC_fnc_manageHabitats      { allowedTargets = 2; };
         class VIC_fnc_triggerAIPanic      { allowedTargets = 2; };
         class VIC_fnc_resetAIBehavior     { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -75,6 +75,16 @@ if (isNil {_wrecks} || {_wrecks isEqualTo []}) then {
     ["STALKER_wrecks", _wrecks] call VIC_fnc_saveCache;
 };
 
+// Load or generate mutant habitats
+private _habData = ["STALKER_mutantHabitatData"] call VIC_fnc_loadCache;
+if (isNil {_habData} || {_habData isEqualTo []}) then {
+    [] call VIC_fnc_setupMutantHabitats;
+    _habData = missionNamespace getVariable ["STALKER_mutantHabitatData", []];
+    ["STALKER_mutantHabitatData", _habData] call VIC_fnc_saveCache;
+} else {
+    [_habData] call VIC_fnc_spawnCachedHabitats;
+};
+
 // Automatically display cached points when debug mode is active
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     [] remoteExec ["VIC_fnc_markRockClusters", 0];

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -164,6 +164,7 @@ VIC_fnc_spawnAcidSmasherNest    = compile preprocessFileLineNumbers (_root + "\f
 VIC_fnc_spawnBehemothNest       = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnBehemothNest.sqf");
 VIC_fnc_spawnPredatorAttack     = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnPredatorAttack.sqf");
 VIC_fnc_spawnHabitatHunters    = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnHabitatHunters.sqf");
+VIC_fnc_spawnCachedHabitats   = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_spawnCachedHabitats.sqf");
 VIC_fnc_managePredators         = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_managePredators.sqf");
 VIC_fnc_manageHerds              = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageHerds.sqf");
 VIC_fnc_manageHostiles           = compile preprocessFileLineNumbers (_root + "\functions\mutants\fn_manageHostiles.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -8,6 +8,7 @@
 if (!isServer) exitWith {};
 
 if (isNil "STALKER_mutantHabitats") then { STALKER_mutantHabitats = []; };
+STALKER_mutantHabitatData = [];
 
 private _createMarker = {
     params ["_type", "_pos"];
@@ -58,6 +59,7 @@ private _createMarker = {
 
     _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
     STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
+    STALKER_mutantHabitatData pushBack [_type, _pos, _max];
 };
 
 private _weightedPick = {
@@ -184,5 +186,8 @@ private _existing = STALKER_mutantHabitats apply { _x#4 };
         };
     };
 } forEach _allTypes;
+
+// Persist generated habitats for future sessions
+["STALKER_mutantHabitatData", STALKER_mutantHabitatData] call VIC_fnc_saveCache;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
@@ -1,0 +1,42 @@
+/*
+    Spawns mutant habitat markers from cached data.
+    Params:
+        0: ARRAY - [[type, position, max], ...]
+    Returns: BOOL
+*/
+params [["_data", []]];
+
+["spawnCachedHabitats"] call VIC_fnc_debugLog;
+
+if (!isServer) exitWith { false };
+
+if (isNil "STALKER_mutantHabitats") then { STALKER_mutantHabitats = []; };
+
+private _createMarker = {
+    params ["_type", "_pos", "_max"];
+    private _overlap = false;
+    {
+        if (_pos distance2D (_x#3) < 300) exitWith { _overlap = true };
+    } forEach STALKER_mutantHabitats;
+    if (!_overlap && {!isNil "STALKER_anomalyFields"}) then {
+        {
+            if (_pos distance2D (_x#6) < 300) exitWith { _overlap = true };
+        } forEach STALKER_anomalyFields;
+    };
+    if (_overlap) exitWith { false };
+    private _base = format ["hab_%1_%2", toLower _type, diag_tickTime + random 1000];
+    private _area = _base + "_area";
+    [_area, _pos, "ELLIPSE", "", "ColorGreen", 1, format ["%1 Habitat Area", _type]] call VIC_fnc_createGlobalMarker;
+    [_area, [150,150]] remoteExec ["setMarkerSize", 0];
+    private _label = _base + "_label";
+    [_label, _pos, "ICON", "mil_dot", "ColorGreen", 1] call VIC_fnc_createGlobalMarker;
+    _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
+    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
+};
+
+{
+    _x params ["_type","_pos","_max"];
+    [_type, _pos, _max] call _createMarker;
+} forEach _data;
+
+true


### PR DESCRIPTION
## Summary
- cache mutant habitat locations when they are generated
- spawn cached habitats on map init if available
- add function to spawn habitats from cached data
- document habitat caching in README

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68616ecb9500832f8b48d2c71d5c5b26