### PR TITLE
Fix undefined variable when marking land zones

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markLandZones.sqf
@@ -20,6 +20,7 @@ STALKER_landZoneMarkers = [];
 if (isNil "STALKER_landZones") then {
     private _cached = ["STALKER_landZones"] call VIC_fnc_loadCache;
     if (isNil {_cached}) exitWith { false };
+    STALKER_landZones = _cached;
 };
 private _zones = STALKER_landZones;
 


### PR DESCRIPTION
## Summary
- define global variable `STALKER_landZones` after loading from cache

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6861b3a99ea4832f8488c34e4c28dcbb