### PR TITLE
Improve camp building selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 
 ### Stalker Camps
 * Roaming stalker groups wander the wilderness providing ambient life.
-* Random camps appear in buildings or open terrain.
+* Random camps appear in buildings with interior positions or open terrain.
 * Camps may belong to BLUFOR, OPFOR or Independent factions based on configurable chances.
 * Group counts and sizes are fully adjustable through CBA settings.
 

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -342,6 +342,14 @@
 ] call CBA_fnc_addSetting;
 
 [
+    "VSA_minCampPositions",
+    "SLIDER",
+    ["Min Building Positions", "Minimum number of positions inside camp buildings"],
+    "Viceroy's STALKER ALife - Stalkers",
+    [0, 20, 1, 0]
+] call CBA_fnc_addSetting;
+
+[
     "VSA_stalkerCampBLUChance",
     "SLIDER",
     ["BLUFOR Camp Chance", "Relative chance for BLUFOR camps"],

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
@@ -3,10 +3,19 @@
     Params:
         0: NUMBER - minimum distance from player (default 700)
         1: NUMBER - maximum distance from player (default 1500)
+        2: NUMBER - minimum building positions (default setting or 1)
     Returns:
         OBJECT - building or objNull if none found
 */
-params [["_min",700],["_max",1500]];
+params [
+    ["_min",700],
+    ["_max",1500],
+    ["_minPos",-1]
+];
+
+if (_minPos < 0) then {
+    _minPos = ["VSA_minCampPositions", 1] call VIC_fnc_getSetting;
+};
 
 ["findCampBuilding"] call VIC_fnc_debugLog;
 
@@ -19,7 +28,12 @@ private _candidates = [];
     private _blds = nearestObjects [_pPos, ["House"], _max];
     {
         private _dist = _x distance2D _pPos;
-        if (_dist > _min && { _dist <= _max }) then {
+        private _posCount = count (_x buildingPos -1);
+        if (
+            _dist > _min &&
+            { _dist <= _max } &&
+            { _posCount >= _minPos }
+        ) then {
             _candidates pushBack _x;
         };
     } forEach _blds;


### PR DESCRIPTION
## Summary
- filter camp buildings by available building positions
- add CBA setting `VSA_minCampPositions`
- document building position requirement for camps

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6861b6e370f8832f8f0f52d52cda7f8b