### PR TITLE
Fix caching error in fn_loadCache

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf
@@ -12,7 +12,7 @@ private _data = nil;
 if (isNil {_name}) exitWith { _data };
 
 private _key = format ["%1_%2", worldName, _name];
-private _data = profileNamespace getVariable [_key, nil];
+_data = profileNamespace getVariable [_key, nil];
 if (!isNil {_data}) then {
     missionNamespace setVariable [_name, _data];
     private _count = "";


### PR DESCRIPTION
## Summary
- fix variable redeclaration in `fn_loadCache.sqf`

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/core/fn_loadCache.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6861d3e9ad44832fad0aeab053b89c2a