### PR TITLE
Spawn camps across map without distance params

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 
 ### Stalker Camps
 * Roaming stalker groups wander the wilderness providing ambient life.
-* Random camps appear in buildings with interior positions or open terrain.
+* Camps are distributed across building clusters all over the map and only activate when players come close.
 * Camps may belong to BLUFOR, OPFOR or Independent factions based on configurable chances.
 * Group counts and sizes are fully adjustable through CBA settings.
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
@@ -1,17 +1,14 @@
 /*
-    Finds a building suitable for a stalker camp near any player.
+    Finds a building suitable for a stalker camp.
+    Camps are distributed across the map but only activate when
+    players come within range. Camp selection ignores player
+    distance and draws from cached building clusters.
     Params:
-        0: NUMBER - minimum distance from player (default 700)
-        1: NUMBER - maximum distance from player (default 1500)
-        2: NUMBER - minimum building positions (default setting or 1)
+        0: NUMBER - minimum building positions (default setting or 1)
     Returns:
         OBJECT - building or objNull if none found
 */
-params [
-    ["_min",700],
-    ["_max",1500],
-    ["_minPos",-1]
-];
+params [["_minPos",-1]];
 
 if (_minPos < 0) then {
     _minPos = ["VSA_minCampPositions", 1] call VIC_fnc_getSetting;
@@ -19,25 +16,17 @@ if (_minPos < 0) then {
 
 ["findCampBuilding"] call VIC_fnc_debugLog;
 
-private _players = allPlayers select { alive _x && {!isNull _x} };
-if (_players isEqualTo []) exitWith { objNull };
+private _clusters = missionNamespace getVariable ["STALKER_buildingClusters", []];
+if (_clusters isEqualTo []) exitWith { objNull };
 
 private _candidates = [];
 {
-    private _pPos = getPosATL _x;
-    private _blds = nearestObjects [_pPos, ["House"], _max];
     {
-        private _dist = _x distance2D _pPos;
-        private _posCount = count (_x buildingPos -1);
-        if (
-            _dist > _min &&
-            { _dist <= _max } &&
-            { _posCount >= _minPos }
-        ) then {
+        if (count (_x buildingPos -1) >= _minPos) then {
             _candidates pushBack _x;
         };
-    } forEach _blds;
-} forEach _players;
+    } forEach _x;
+} forEach _clusters;
 
 if (_candidates isEqualTo []) exitWith { objNull };
 selectRandom _candidates


### PR DESCRIPTION
## Summary
- rely solely on building clusters for camp placement
- remove unused parameters in camp search function

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6861d4b056ec832fa5ca6c4e4c09fc09