### PR TITLE
Fix Clear Sky camp marker color

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -73,7 +73,7 @@ if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     _marker = format ["camp_%1", diag_tickTime];
     private _color = switch (_faction) do {
         case "Bandits": {"ColorOrange"};
-        case "ClearSky": {"ColorCyan"};
+        case "ClearSky": {"ColorBlue"};
         case "Ecologists": {"ColorKhaki"};
         case "Military": {"ColorGreen"};
         case "Duty": {"ColorRed"};


### PR DESCRIPTION
## Summary
- fix `ClearSky` faction marker color to a valid value

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6861de25aa20832fa613d555adaadc75