### PR TITLE
Adjust faction side rules

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -15,24 +15,95 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
     _x params ["_camp", "_grp", "_pos", "_marker", "_side", "_faction",["_active",false]];
     private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
-        if (isNull _camp) then { _camp = "Campfire_burning_F" createVehicle _pos; };
+        if (isNull _camp) then {
+            // Spawn the campfire a few meters away from the building
+            private _firePos = _pos getPos [3 + random 3, random 360];
+            _camp = "Campfire_burning_F" createVehicle _firePos;
+        };
         if (isNull _grp || { count units _grp == 0 }) then {
-            private _class = switch (_side) do {
-                case blufor: { "B_Soldier_F" };
-                case opfor: { "O_Soldier_F" };
-                default { "I_Soldier_F" };
+            private _class = switch (_faction) do {
+                case "ClearSky": {
+                    selectRandom [
+                        "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
+                        "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
+                        "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+                    ]
+                };
+                case "Mercenaries": {
+                    selectRandom [
+                        "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
+                        "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
+                        "B_Merc_Trained_Merc_01"
+                    ]
+                };
+                case "Freedom": {
+                    selectRandom [
+                        "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
+                        "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
+                        "B_FD_Wardog_01"
+                    ]
+                };
+                case "Bandits": {
+                    selectRandom [
+                        "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
+                        "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
+                        "O_Bdz_Thug_01","O_Bdz_Waster_01"
+                    ]
+                };
+                case "Duty": {
+                    selectRandom [
+                        "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
+                        "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
+                        "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+                    ]
+                };
+                case "Monolith": {
+                    selectRandom [
+                        "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
+                        "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
+                        "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+                    ]
+                };
+                case "Military": {
+                    selectRandom [
+                        "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
+                        "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+                    ]
+                };
+                case "Spetznaz": {
+                    selectRandom [
+                        "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
+                        "I_UA_Spetznaz_Sergeant_01","I_UA_Spetznaz_Sniper_01"
+                    ]
+                };
+                case "Ecologists": {
+                    selectRandom [
+                        "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
+                        "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+                    ]
+                };
+                case "Loners": {
+                    selectRandom [
+                        "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
+                        "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
+                        "I_LNR_Tourist_01","I_LNR_Veteran_01"
+                    ]
+                };
+                default {
+                    "I_Soldier_F"
+                };
             };
             private _new = createGroup _side;
             for "_i" from 1 to _size do { _new createUnit [_class, _pos, [], 0, "FORM"]; };
             if (local _new) then {
                 if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
-                    [_new, _pos, 50] call lambs_wp_fnc_taskCamp;
+                    [_new, _pos, 150, [], true, true] call lambs_wp_fnc_taskCamp;
                 } else {
                     [_new, _pos] call BIS_fnc_taskDefend;
                 };
             } else {
                 if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
-                    [_new, _pos, 50] remoteExecCall ["lambs_wp_fnc_taskCamp", groupOwner _new];
+                    [_new, _pos, 150, [], true, true] remoteExecCall ["lambs_wp_fnc_taskCamp", groupOwner _new];
                 } else {
                     [_new, _pos] remoteExecCall ["BIS_fnc_taskDefend", groupOwner _new];
                 };

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
@@ -19,9 +19,63 @@ private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
     if (_newActive) then {
         if (isNull _grp || { count units _grp == 0 }) then {
-            _grp = createGroup independent;
+            private _factionInfo = [
+                ["ClearSky",   [blufor,opfor,independent,civilian], [
+                    "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
+                    "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
+                    "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+                ]],
+                ["Mercenaries", [blufor,opfor,independent], [
+                    "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
+                    "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
+                    "B_Merc_Trained_Merc_01"
+                ]],
+                ["Freedom",    [blufor,opfor,independent,civilian], [
+                    "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
+                    "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
+                    "B_FD_Wardog_01"
+                ]],
+                ["Bandits",    [blufor,opfor,independent,civilian], [
+                    "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
+                    "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
+                    "O_Bdz_Thug_01","O_Bdz_Waster_01"
+                ]],
+                ["Duty",       [blufor,opfor], [
+                    "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
+                    "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
+                    "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+                ]],
+                ["Monolith",   [opfor], [
+                    "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
+                    "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
+                    "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+                ]],
+                ["Military",   [blufor], [
+                    "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
+                    "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+                ]],
+                ["Spetznaz",   [blufor], [
+                    "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
+                    "I_UA_Spetznaz_Sergeant_01","I_UA_Spetznaz_Sniper_01"
+                ]],
+                ["Ecologists", [blufor,opfor,independent,civilian], [
+                    "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
+                    "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+                ]],
+                ["Loners",     [independent], [
+                    "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
+                    "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
+                    "I_LNR_Tourist_01","I_LNR_Veteran_01"
+                ]]
+            ];
+
+            private _entry = selectRandom _factionInfo;
+            private _side    = selectRandom (_entry select 1);
+            private _class   = selectRandom (_entry select 2);
+
+            _grp = createGroup _side;
             for "_i" from 1 to _groupSize do {
-                _grp createUnit ["I_Soldier_F", _pos, [], 0, "FORM"];
+                _grp createUnit [_class, _pos, [], 0, "FORM"];
             };
             [_grp, _pos] call BIS_fnc_taskPatrol;
         };

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -33,9 +33,65 @@ for "_i" from 1 to _groupCount do {
     if (isNil {_pos} || {_pos isEqualTo []}) then { continue };
     if (!([_pos, _dist] call VIC_fnc_hasPlayersNearby)) then { continue };
 
-    private _grp = createGroup independent;
+    // Random faction and side for this wanderer group
+    // Format: [name, [allowed sides], unit classes]
+    private _factionInfo = [
+        ["ClearSky",   [blufor,opfor,independent,civilian], [
+            "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
+            "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
+            "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+        ]],
+        ["Mercenaries", [blufor,opfor,independent], [
+            "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
+            "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
+            "B_Merc_Trained_Merc_01"
+        ]],
+        ["Freedom",    [blufor,opfor,independent,civilian], [
+            "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
+            "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
+            "B_FD_Wardog_01"
+        ]],
+        ["Bandits",    [blufor,opfor,independent,civilian], [
+            "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
+            "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
+            "O_Bdz_Thug_01","O_Bdz_Waster_01"
+        ]],
+        ["Duty",       [blufor,opfor], [
+            "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
+            "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
+            "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+        ]],
+        ["Monolith",   [opfor], [
+            "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
+            "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
+            "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+        ]],
+        ["Military",   [blufor], [
+            "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
+            "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+        ]],
+        ["Spetznaz",   [blufor], [
+            "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
+            "I_UA_Spetznaz_Sergeant_01","I_UA_Spetznaz_Sniper_01"
+        ]],
+        ["Ecologists", [blufor,opfor,independent,civilian], [
+            "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
+            "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+        ]],
+        ["Loners",     [independent], [
+            "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
+            "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
+            "I_LNR_Tourist_01","I_LNR_Veteran_01"
+        ]]
+    ];
+
+    private _entry = selectRandom _factionInfo;
+    private _side    = selectRandom (_entry select 1);
+    private _class   = selectRandom (_entry select 2);
+
+    private _grp = createGroup _side;
     for "_j" from 1 to _groupSize do {
-        _grp createUnit ["I_Soldier_F", _pos, [], 0, "FORM"];
+        _grp createUnit [_class, _pos, [], 0, "FORM"];
     };
     [_grp, _pos] call BIS_fnc_taskPatrol;
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -1,6 +1,7 @@
 /*
     Spawns a single stalker camp at the given position.
-    Camp side is chosen randomly using configured side weights.
+    A random faction is selected with a valid side according to the
+    configuration below.
     Params:
         0: POSITION - camp position
 */
@@ -13,26 +14,73 @@ if (!isServer) exitWith {};
 if (isNil "STALKER_camps") then { STALKER_camps = []; };
 
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
-private _wBlu = ["VSA_stalkerCampBLUChance", 34] call VIC_fnc_getSetting;
-private _wOpf = ["VSA_stalkerCampOPFChance", 33] call VIC_fnc_getSetting;
-private _wInd = ["VSA_stalkerCampINDChance", 33] call VIC_fnc_getSetting;
 
-private _side = selectRandomWeighted [blufor,_wBlu,opfor,_wOpf,independent,_wInd];
+// Available factions and their unit classes
+// Each entry: [FactionName, [allowed sides], [unit classes]]
+private _factionInfo = [
+    ["ClearSky",   [blufor,opfor,independent,civilian], [
+        "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
+        "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
+        "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+    ]],
+    ["Mercenaries", [blufor,opfor,independent], [
+        "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
+        "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
+        "B_Merc_Trained_Merc_01"
+    ]],
+    ["Freedom",    [blufor,opfor,independent,civilian], [
+        "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
+        "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
+        "B_FD_Wardog_01"
+    ]],
+    ["Bandits",    [blufor,opfor,independent,civilian], [
+        "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
+        "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
+        "O_Bdz_Thug_01","O_Bdz_Waster_01"
+    ]],
+    ["Duty",       [blufor,opfor], [
+        "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
+        "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
+        "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+    ]],
+    ["Monolith",   [opfor], [
+        "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
+        "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
+        "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+    ]],
+    ["Military",   [blufor], [
+        "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
+        "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+    ]],
+    ["Spetznaz",   [blufor], [
+        "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
+        "I_UA_Spetznaz_Sergeant_01","I_UA_Spetznaz_Sniper_01"
+    ]],
+    ["Ecologists", [blufor,opfor,independent,civilian], [
+        "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
+        "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+    ]],
+    ["Loners",     [independent], [
+        "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
+        "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
+        "I_LNR_Tourist_01","I_LNR_Veteran_01"
+    ]]
+];
 
-private _factions = ["Bandits","ClearSky","Ecologists","Military","Duty","Freedom","Loners","Mercs"];
-private _faction  = selectRandom _factions;
+private _entry = selectRandom _factionInfo;
+private _side    = selectRandom (_entry select 1);
+private _faction = _entry select 0;
+private _class   = selectRandom (_entry select 2);
 
 private _grp = createGroup _side;
-private _class = switch (_side) do {
-    case blufor: { "B_Soldier_F" };
-    case opfor: { "O_Soldier_F" };
-    default { "I_Soldier_F" };
-};
 for "_i" from 1 to _size do {
     _grp createUnit [_class, _pos, [], 0, "FORM"];
 };
 
-private _campfire = "Campfire_burning_F" createVehicle _pos;
+// Move the campfire slightly away from the building so it sits
+// outside rather than at the building centre
+private _firePos = _pos getPos [3 + random 3, random 360];
+private _campfire = "Campfire_burning_F" createVehicle _firePos;
 
 // Random loot crate near the camp
 private _cratePos = _pos getPos [2, random 360];
@@ -56,13 +104,13 @@ for "_i" from 0 to (_sitCount - 1) do {
 };
 if (local _grp) then {
     if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
-        [_grp, _pos, 50] call lambs_wp_fnc_taskCamp;
+        [_grp, _pos, 150, [], true, true] call lambs_wp_fnc_taskCamp;
     } else {
         [_grp, _pos] call BIS_fnc_taskDefend;
     };
 } else {
     if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
-        [_grp, _pos, 50] remoteExecCall ["lambs_wp_fnc_taskCamp", groupOwner _grp];
+        [_grp, _pos, 150, [], true, true] remoteExecCall ["lambs_wp_fnc_taskCamp", groupOwner _grp];
     } else {
         [_grp, _pos] remoteExecCall ["BIS_fnc_taskDefend", groupOwner _grp];
     };


### PR DESCRIPTION
## Summary
- allow each faction to spawn on permitted sides like bandits being any side or monolith always opfor
- update camp and wanderer spawns to pick random sides from these lists

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6861df802124832f9466b1b5dc343b37