### PR TITLE
Add new faction soldier types

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -26,48 +26,101 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
                     selectRandom [
                         "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
                         "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
-                        "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+                        "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01",
+                        "SIL_STALKER_ClearSky_Medic_F","SIL_STALKER_ClearSky_Rifleman_1_F",
+                        "SIL_STALKER_ClearSky_Rifleman_2_F","SIL_STALKER_ClearSky_Rifleman_Light_F",
+                        "SIL_STALKER_ClearSky_Sharpshooter_F","SIL_STALKER_ClearSky_SEVA_Medic_F",
+                        "SIL_STALKER_ClearSky_SEVA_Rifleman_1_F","SIL_STALKER_ClearSky_SEVA_Rifleman_2_F",
+                        "SIL_STALKER_ClearSky_SEVA_Rifleman_Light_F","SIL_STALKER_ClearSky_SEVA_Sharpshooter_F",
+                        "SIL_STALKER_ClearSky_NoPPE_Medic_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_1_F",
+                        "SIL_STALKER_ClearSky_NoPPE_Rifleman_2_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_Light_F",
+                        "SIL_STALKER_ClearSky_NoPPE_Sharpshooter_F"
                     ]
                 };
                 case "Mercenaries": {
                     selectRandom [
                         "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
                         "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
-                        "B_Merc_Trained_Merc_01"
+                        "B_Merc_Trained_Merc_01",
+                        "SIL_STALKER_Merc_Autorifleman_F","SIL_STALKER_Merc_Medic_F",
+                        "SIL_STALKER_Merc_Rifleman_1_F","SIL_STALKER_Merc_Rifleman_2_F",
+                        "SIL_STALKER_Merc_Rifleman_Light_F","SIL_STALKER_Merc_Sharpshooter_F",
+                        "SIL_STALKER_Merc_Night_Medic_F","SIL_STALKER_Merc_Night_Rifleman_1_F",
+                        "SIL_STALKER_Merc_Night_Rifleman_2_F","SIL_STALKER_Merc_Night_Rifleman_Light_F",
+                        "SIL_STALKER_Merc_Night_Sharpshooter_F","SIL_STALKER_Merc_NoPPE_Autorifleman_F",
+                        "SIL_STALKER_Merc_NoPPE_Medic_F","SIL_STALKER_Merc_NoPPE_Rifleman_1_F",
+                        "SIL_STALKER_Merc_NoPPE_Rifleman_2_F","SIL_STALKER_Merc_NoPPE_Rifleman_Light_F",
+                        "SIL_STALKER_Merc_NoPPE_Sharpshooter_F"
                     ]
                 };
                 case "Freedom": {
                     selectRandom [
                         "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
                         "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
-                        "B_FD_Wardog_01"
+                        "B_FD_Wardog_01",
+                        "SIL_STALKER_Freedom_Engineer_F","SIL_STALKER_Freedom_Medic_F",
+                        "SIL_STALKER_Freedom_Rifleman_1_F","SIL_STALKER_Freedom_Rifleman_2_F",
+                        "SIL_STALKER_Freedom_Rifleman_Light_F","SIL_STALKER_Freedom_Sharpshooter_F",
+                        "SIL_STALKER_Freedom_Exo_Rifleman_1_F","SIL_STALKER_Freedom_Exo_Rifleman_2_F",
+                        "SIL_STALKER_Freedom_NoPPE_Engineer_F","SIL_STALKER_Freedom_NoPPE_Medic_F",
+                        "SIL_STALKER_Freedom_NoPPE_Rifleman_1_F","SIL_STALKER_Freedom_NoPPE_Rifleman_2_F",
+                        "SIL_STALKER_Freedom_NoPPE_Rifleman_Light_F","SIL_STALKER_Freedom_NoPPE_Sharpshooter_F",
+                        "SIL_STALKER_Freedom_SEVA_Medic_F","SIL_STALKER_Freedom_SEVA_Rifleman_1_F",
+                        "SIL_STALKER_Freedom_SEVA_Rifleman_2_F","SIL_STALKER_Freedom_SEVA_Rifleman_Light_F"
                     ]
                 };
                 case "Bandits": {
                     selectRandom [
                         "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
                         "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
-                        "O_Bdz_Thug_01","O_Bdz_Waster_01"
+                        "O_Bdz_Thug_01","O_Bdz_Waster_01",
+                        "SIL_STALKER_Bandit_Autorifleman_F","SIL_STALKER_Bandit_Rifleman_1_F",
+                        "SIL_STALKER_Bandit_Rifleman_2_F","SIL_STALKER_Bandit_Rifleman_Light_F",
+                        "SIL_STALKER_Bandit_Sharpshooter_F"
                     ]
                 };
                 case "Duty": {
                     selectRandom [
                         "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
                         "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
-                        "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+                        "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01",
+                        "SIL_STALKER_Duty_Autorifleman_F","SIL_STALKER_Duty_Engineer_F",
+                        "SIL_STALKER_Duty_Medic_F","SIL_STALKER_Duty_Rifleman_1_F",
+                        "SIL_STALKER_Duty_Rifleman_2_F","SIL_STALKER_Duty_Rifleman_Light_F",
+                        "SIL_STALKER_Duty_Sharpshooter_F","SIL_STALKER_Duty_Exo_Rifleman_1_F",
+                        "SIL_STALKER_Duty_Exo_Rifleman_2_F","SIL_STALKER_Duty_SEVA_Medic_F",
+                        "SIL_STALKER_Duty_SEVA_Rifleman_1_F","SIL_STALKER_Duty_SEVA_Rifleman_2_F",
+                        "SIL_STALKER_Duty_SEVA_Rifleman_Light_F"
                     ]
                 };
                 case "Monolith": {
                     selectRandom [
                         "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
                         "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
-                        "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+                        "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01",
+                        "SIL_STALKER_Monolith_Autorifleman_F","SIL_STALKER_Monolith_Engineer_F",
+                        "SIL_STALKER_Monolith_Medic_F","SIL_STALKER_Monolith_Rifleman_1_F",
+                        "SIL_STALKER_Monolith_Rifleman_2_F","SIL_STALKER_Monolith_Rifleman_Light_F",
+                        "SIL_STALKER_Monolith_Sharpshooter_F","SIL_STALKER_Monolith_Exo_Rifleman_1_F",
+                        "SIL_STALKER_Monolith_Exo_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Engineer_F",
+                        "SIL_STALKER_Monolith_SEVA_Medic_F","SIL_STALKER_Monolith_SEVA_Rifleman_1_F",
+                        "SIL_STALKER_Monolith_SEVA_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Rifleman_Light_F"
                     ]
                 };
                 case "Military": {
                     selectRandom [
                         "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
-                        "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+                        "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01",
+                        "SIL_STALKER_Military_Autorifleman_F","SIL_STALKER_Military_Engineer_F",
+                        "SIL_STALKER_Military_Medic_F","SIL_STALKER_Military_Rifleman_1_F",
+                        "SIL_STALKER_Military_Rifleman_2_F","SIL_STALKER_Military_Rifleman_Light_F",
+                        "SIL_STALKER_Military_Sharpshooter_F","SIL_STALKER_Military_NoPPE_Engineer_F",
+                        "SIL_STALKER_Military_NoPPE_Medic_F","SIL_STALKER_Military_NoPPE_Rifleman_1_F",
+                        "SIL_STALKER_Military_NoPPE_Rifleman_2_F","SIL_STALKER_Military_NoPPE_Rifleman_Light_F",
+                        "SIL_STALKER_Military_NoPPE_Sharpshooter_F","SIL_STALKER_Military_SEVA_Engineer_F",
+                        "SIL_STALKER_Military_SEVA_Medic_F","SIL_STALKER_Military_SEVA_Rifleman_1_F",
+                        "SIL_STALKER_Military_SEVA_Rifleman_2_F","SIL_STALKER_Military_SEVA_Rifleman_Light_F",
+                        "SIL_STALKER_Military_SEVA_Sharpshooter_F"
                     ]
                 };
                 case "Spetznaz": {
@@ -79,14 +132,38 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
                 case "Ecologists": {
                     selectRandom [
                         "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
-                        "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+                        "I_Eco_Lab_Scientist_01","I_Eco_Protector_01",
+                        "SIL_STALKER_Ecologist_Scientist_1_F","SIL_STALKER_Ecologist_Scientist_2_F"
                     ]
                 };
                 case "Loners": {
                     selectRandom [
                         "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
                         "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
-                        "I_LNR_Tourist_01","I_LNR_Veteran_01"
+                        "I_LNR_Tourist_01","I_LNR_Veteran_01",
+                        "SIL_STALKER_Loner_Autorifleman_F","SIL_STALKER_Loner_Engineer_F",
+                        "SIL_STALKER_Loner_Medic_F","SIL_STALKER_Loner_Rifleman_1_F",
+                        "SIL_STALKER_Loner_Rifleman_2_F","SIL_STALKER_Loner_Rifleman_Light_F",
+                        "SIL_STALKER_Loner_Sharpshooter_F","SIL_STALKER_Loner_NoPPE_Autorifleman_F",
+                        "SIL_STALKER_Loner_NoPPE_Medic_F","SIL_STALKER_Loner_NoPPE_Rifleman_1_F",
+                        "SIL_STALKER_Loner_NoPPE_Rifleman_2_F","SIL_STALKER_Loner_NoPPE_Rifleman_Light_F",
+                        "SIL_STALKER_Loner_NoPPE_Sharpshooter_F","SIL_STALKER_Loner_SEVA_Suit_Medic_F",
+                        "SIL_STALKER_Loner_SEVA_Suit_Rifleman_1_F","SIL_STALKER_Loner_SEVA_Suit_Rifleman_2_F",
+                        "SIL_STALKER_Loner_SEVA_Suit_Rifleman_Light_F"
+                    ]
+                };
+                case "Ward": {
+                    selectRandom [
+                        "SIL_STALKER_Ward_Engineer_F","SIL_STALKER_Ward_Medic_F",
+                        "SIL_STALKER_Ward_Rifleman_1_F","SIL_STALKER_Ward_Rifleman_2_F",
+                        "SIL_STALKER_Ward_Rifleman_Light_F"
+                    ]
+                };
+                case "IPSF": {
+                    selectRandom [
+                        "SIL_STALKER_IPSF_Medic_F","SIL_STALKER_IPSF_Rifleman_1_F",
+                        "SIL_STALKER_IPSF_Rifleman_2_F","SIL_STALKER_IPSF_Rifleman_Light_F",
+                        "SIL_STALKER_IPSF_Sharpshooter_F"
                     ]
                 };
                 default {

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
@@ -23,36 +23,89 @@ private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
                 ["ClearSky",   [blufor,opfor,independent,civilian], [
                     "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
                     "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
-                    "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+                    "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01",
+                    "SIL_STALKER_ClearSky_Medic_F","SIL_STALKER_ClearSky_Rifleman_1_F",
+                    "SIL_STALKER_ClearSky_Rifleman_2_F","SIL_STALKER_ClearSky_Rifleman_Light_F",
+                    "SIL_STALKER_ClearSky_Sharpshooter_F","SIL_STALKER_ClearSky_SEVA_Medic_F",
+                    "SIL_STALKER_ClearSky_SEVA_Rifleman_1_F","SIL_STALKER_ClearSky_SEVA_Rifleman_2_F",
+                    "SIL_STALKER_ClearSky_SEVA_Rifleman_Light_F","SIL_STALKER_ClearSky_SEVA_Sharpshooter_F",
+                    "SIL_STALKER_ClearSky_NoPPE_Medic_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_1_F",
+                    "SIL_STALKER_ClearSky_NoPPE_Rifleman_2_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_Light_F",
+                    "SIL_STALKER_ClearSky_NoPPE_Sharpshooter_F"
                 ]],
                 ["Mercenaries", [blufor,opfor,independent], [
                     "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
                     "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
-                    "B_Merc_Trained_Merc_01"
+                    "B_Merc_Trained_Merc_01",
+                    "SIL_STALKER_Merc_Autorifleman_F","SIL_STALKER_Merc_Medic_F",
+                    "SIL_STALKER_Merc_Rifleman_1_F","SIL_STALKER_Merc_Rifleman_2_F",
+                    "SIL_STALKER_Merc_Rifleman_Light_F","SIL_STALKER_Merc_Sharpshooter_F",
+                    "SIL_STALKER_Merc_Night_Medic_F","SIL_STALKER_Merc_Night_Rifleman_1_F",
+                    "SIL_STALKER_Merc_Night_Rifleman_2_F","SIL_STALKER_Merc_Night_Rifleman_Light_F",
+                    "SIL_STALKER_Merc_Night_Sharpshooter_F","SIL_STALKER_Merc_NoPPE_Autorifleman_F",
+                    "SIL_STALKER_Merc_NoPPE_Medic_F","SIL_STALKER_Merc_NoPPE_Rifleman_1_F",
+                    "SIL_STALKER_Merc_NoPPE_Rifleman_2_F","SIL_STALKER_Merc_NoPPE_Rifleman_Light_F",
+                    "SIL_STALKER_Merc_NoPPE_Sharpshooter_F"
                 ]],
                 ["Freedom",    [blufor,opfor,independent,civilian], [
                     "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
                     "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
-                    "B_FD_Wardog_01"
+                    "B_FD_Wardog_01",
+                    "SIL_STALKER_Freedom_Engineer_F","SIL_STALKER_Freedom_Medic_F",
+                    "SIL_STALKER_Freedom_Rifleman_1_F","SIL_STALKER_Freedom_Rifleman_2_F",
+                    "SIL_STALKER_Freedom_Rifleman_Light_F","SIL_STALKER_Freedom_Sharpshooter_F",
+                    "SIL_STALKER_Freedom_Exo_Rifleman_1_F","SIL_STALKER_Freedom_Exo_Rifleman_2_F",
+                    "SIL_STALKER_Freedom_NoPPE_Engineer_F","SIL_STALKER_Freedom_NoPPE_Medic_F",
+                    "SIL_STALKER_Freedom_NoPPE_Rifleman_1_F","SIL_STALKER_Freedom_NoPPE_Rifleman_2_F",
+                    "SIL_STALKER_Freedom_NoPPE_Rifleman_Light_F","SIL_STALKER_Freedom_NoPPE_Sharpshooter_F",
+                    "SIL_STALKER_Freedom_SEVA_Medic_F","SIL_STALKER_Freedom_SEVA_Rifleman_1_F",
+                    "SIL_STALKER_Freedom_SEVA_Rifleman_2_F","SIL_STALKER_Freedom_SEVA_Rifleman_Light_F"
                 ]],
                 ["Bandits",    [blufor,opfor,independent,civilian], [
                     "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
                     "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
-                    "O_Bdz_Thug_01","O_Bdz_Waster_01"
+                    "O_Bdz_Thug_01","O_Bdz_Waster_01",
+                    "SIL_STALKER_Bandit_Autorifleman_F","SIL_STALKER_Bandit_Rifleman_1_F",
+                    "SIL_STALKER_Bandit_Rifleman_2_F","SIL_STALKER_Bandit_Rifleman_Light_F",
+                    "SIL_STALKER_Bandit_Sharpshooter_F"
                 ]],
                 ["Duty",       [blufor,opfor], [
                     "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
                     "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
-                    "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+                    "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01",
+                    "SIL_STALKER_Duty_Autorifleman_F","SIL_STALKER_Duty_Engineer_F",
+                    "SIL_STALKER_Duty_Medic_F","SIL_STALKER_Duty_Rifleman_1_F",
+                    "SIL_STALKER_Duty_Rifleman_2_F","SIL_STALKER_Duty_Rifleman_Light_F",
+                    "SIL_STALKER_Duty_Sharpshooter_F","SIL_STALKER_Duty_Exo_Rifleman_1_F",
+                    "SIL_STALKER_Duty_Exo_Rifleman_2_F","SIL_STALKER_Duty_SEVA_Medic_F",
+                    "SIL_STALKER_Duty_SEVA_Rifleman_1_F","SIL_STALKER_Duty_SEVA_Rifleman_2_F",
+                    "SIL_STALKER_Duty_SEVA_Rifleman_Light_F"
                 ]],
                 ["Monolith",   [opfor], [
                     "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
                     "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
-                    "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+                    "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01",
+                    "SIL_STALKER_Monolith_Autorifleman_F","SIL_STALKER_Monolith_Engineer_F",
+                    "SIL_STALKER_Monolith_Medic_F","SIL_STALKER_Monolith_Rifleman_1_F",
+                    "SIL_STALKER_Monolith_Rifleman_2_F","SIL_STALKER_Monolith_Rifleman_Light_F",
+                    "SIL_STALKER_Monolith_Sharpshooter_F","SIL_STALKER_Monolith_Exo_Rifleman_1_F",
+                    "SIL_STALKER_Monolith_Exo_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Engineer_F",
+                    "SIL_STALKER_Monolith_SEVA_Medic_F","SIL_STALKER_Monolith_SEVA_Rifleman_1_F",
+                    "SIL_STALKER_Monolith_SEVA_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Rifleman_Light_F"
                 ]],
                 ["Military",   [blufor], [
                     "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
-                    "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+                    "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01",
+                    "SIL_STALKER_Military_Autorifleman_F","SIL_STALKER_Military_Engineer_F",
+                    "SIL_STALKER_Military_Medic_F","SIL_STALKER_Military_Rifleman_1_F",
+                    "SIL_STALKER_Military_Rifleman_2_F","SIL_STALKER_Military_Rifleman_Light_F",
+                    "SIL_STALKER_Military_Sharpshooter_F","SIL_STALKER_Military_NoPPE_Engineer_F",
+                    "SIL_STALKER_Military_NoPPE_Medic_F","SIL_STALKER_Military_NoPPE_Rifleman_1_F",
+                    "SIL_STALKER_Military_NoPPE_Rifleman_2_F","SIL_STALKER_Military_NoPPE_Rifleman_Light_F",
+                    "SIL_STALKER_Military_NoPPE_Sharpshooter_F","SIL_STALKER_Military_SEVA_Engineer_F",
+                    "SIL_STALKER_Military_SEVA_Medic_F","SIL_STALKER_Military_SEVA_Rifleman_1_F",
+                    "SIL_STALKER_Military_SEVA_Rifleman_2_F","SIL_STALKER_Military_SEVA_Rifleman_Light_F",
+                    "SIL_STALKER_Military_SEVA_Sharpshooter_F"
                 ]],
                 ["Spetznaz",   [blufor], [
                     "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
@@ -60,12 +113,32 @@ private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
                 ]],
                 ["Ecologists", [blufor,opfor,independent,civilian], [
                     "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
-                    "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+                    "I_Eco_Lab_Scientist_01","I_Eco_Protector_01",
+                    "SIL_STALKER_Ecologist_Scientist_1_F","SIL_STALKER_Ecologist_Scientist_2_F"
                 ]],
                 ["Loners",     [independent], [
                     "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
                     "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
-                    "I_LNR_Tourist_01","I_LNR_Veteran_01"
+                    "I_LNR_Tourist_01","I_LNR_Veteran_01",
+                    "SIL_STALKER_Loner_Autorifleman_F","SIL_STALKER_Loner_Engineer_F",
+                    "SIL_STALKER_Loner_Medic_F","SIL_STALKER_Loner_Rifleman_1_F",
+                    "SIL_STALKER_Loner_Rifleman_2_F","SIL_STALKER_Loner_Rifleman_Light_F",
+                    "SIL_STALKER_Loner_Sharpshooter_F","SIL_STALKER_Loner_NoPPE_Autorifleman_F",
+                    "SIL_STALKER_Loner_NoPPE_Medic_F","SIL_STALKER_Loner_NoPPE_Rifleman_1_F",
+                    "SIL_STALKER_Loner_NoPPE_Rifleman_2_F","SIL_STALKER_Loner_NoPPE_Rifleman_Light_F",
+                    "SIL_STALKER_Loner_NoPPE_Sharpshooter_F","SIL_STALKER_Loner_SEVA_Suit_Medic_F",
+                    "SIL_STALKER_Loner_SEVA_Suit_Rifleman_1_F","SIL_STALKER_Loner_SEVA_Suit_Rifleman_2_F",
+                    "SIL_STALKER_Loner_SEVA_Suit_Rifleman_Light_F"
+                ]],
+                ["Ward", [blufor], [
+                    "SIL_STALKER_Ward_Engineer_F","SIL_STALKER_Ward_Medic_F",
+                    "SIL_STALKER_Ward_Rifleman_1_F","SIL_STALKER_Ward_Rifleman_2_F",
+                    "SIL_STALKER_Ward_Rifleman_Light_F"
+                ]],
+                ["IPSF", [blufor], [
+                    "SIL_STALKER_IPSF_Medic_F","SIL_STALKER_IPSF_Rifleman_1_F",
+                    "SIL_STALKER_IPSF_Rifleman_2_F","SIL_STALKER_IPSF_Rifleman_Light_F",
+                    "SIL_STALKER_IPSF_Sharpshooter_F"
                 ]]
             ];
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -39,36 +39,89 @@ for "_i" from 1 to _groupCount do {
         ["ClearSky",   [blufor,opfor,independent,civilian], [
             "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
             "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
-            "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+            "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01",
+            "SIL_STALKER_ClearSky_Medic_F","SIL_STALKER_ClearSky_Rifleman_1_F",
+            "SIL_STALKER_ClearSky_Rifleman_2_F","SIL_STALKER_ClearSky_Rifleman_Light_F",
+            "SIL_STALKER_ClearSky_Sharpshooter_F","SIL_STALKER_ClearSky_SEVA_Medic_F",
+            "SIL_STALKER_ClearSky_SEVA_Rifleman_1_F","SIL_STALKER_ClearSky_SEVA_Rifleman_2_F",
+            "SIL_STALKER_ClearSky_SEVA_Rifleman_Light_F","SIL_STALKER_ClearSky_SEVA_Sharpshooter_F",
+            "SIL_STALKER_ClearSky_NoPPE_Medic_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_1_F",
+            "SIL_STALKER_ClearSky_NoPPE_Rifleman_2_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_Light_F",
+            "SIL_STALKER_ClearSky_NoPPE_Sharpshooter_F"
         ]],
         ["Mercenaries", [blufor,opfor,independent], [
             "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
             "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
-            "B_Merc_Trained_Merc_01"
+            "B_Merc_Trained_Merc_01",
+            "SIL_STALKER_Merc_Autorifleman_F","SIL_STALKER_Merc_Medic_F",
+            "SIL_STALKER_Merc_Rifleman_1_F","SIL_STALKER_Merc_Rifleman_2_F",
+            "SIL_STALKER_Merc_Rifleman_Light_F","SIL_STALKER_Merc_Sharpshooter_F",
+            "SIL_STALKER_Merc_Night_Medic_F","SIL_STALKER_Merc_Night_Rifleman_1_F",
+            "SIL_STALKER_Merc_Night_Rifleman_2_F","SIL_STALKER_Merc_Night_Rifleman_Light_F",
+            "SIL_STALKER_Merc_Night_Sharpshooter_F","SIL_STALKER_Merc_NoPPE_Autorifleman_F",
+            "SIL_STALKER_Merc_NoPPE_Medic_F","SIL_STALKER_Merc_NoPPE_Rifleman_1_F",
+            "SIL_STALKER_Merc_NoPPE_Rifleman_2_F","SIL_STALKER_Merc_NoPPE_Rifleman_Light_F",
+            "SIL_STALKER_Merc_NoPPE_Sharpshooter_F"
         ]],
         ["Freedom",    [blufor,opfor,independent,civilian], [
             "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
             "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
-            "B_FD_Wardog_01"
+            "B_FD_Wardog_01",
+            "SIL_STALKER_Freedom_Engineer_F","SIL_STALKER_Freedom_Medic_F",
+            "SIL_STALKER_Freedom_Rifleman_1_F","SIL_STALKER_Freedom_Rifleman_2_F",
+            "SIL_STALKER_Freedom_Rifleman_Light_F","SIL_STALKER_Freedom_Sharpshooter_F",
+            "SIL_STALKER_Freedom_Exo_Rifleman_1_F","SIL_STALKER_Freedom_Exo_Rifleman_2_F",
+            "SIL_STALKER_Freedom_NoPPE_Engineer_F","SIL_STALKER_Freedom_NoPPE_Medic_F",
+            "SIL_STALKER_Freedom_NoPPE_Rifleman_1_F","SIL_STALKER_Freedom_NoPPE_Rifleman_2_F",
+            "SIL_STALKER_Freedom_NoPPE_Rifleman_Light_F","SIL_STALKER_Freedom_NoPPE_Sharpshooter_F",
+            "SIL_STALKER_Freedom_SEVA_Medic_F","SIL_STALKER_Freedom_SEVA_Rifleman_1_F",
+            "SIL_STALKER_Freedom_SEVA_Rifleman_2_F","SIL_STALKER_Freedom_SEVA_Rifleman_Light_F"
         ]],
         ["Bandits",    [blufor,opfor,independent,civilian], [
             "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
             "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
-            "O_Bdz_Thug_01","O_Bdz_Waster_01"
+            "O_Bdz_Thug_01","O_Bdz_Waster_01",
+            "SIL_STALKER_Bandit_Autorifleman_F","SIL_STALKER_Bandit_Rifleman_1_F",
+            "SIL_STALKER_Bandit_Rifleman_2_F","SIL_STALKER_Bandit_Rifleman_Light_F",
+            "SIL_STALKER_Bandit_Sharpshooter_F"
         ]],
         ["Duty",       [blufor,opfor], [
             "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
             "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
-            "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+            "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01",
+            "SIL_STALKER_Duty_Autorifleman_F","SIL_STALKER_Duty_Engineer_F",
+            "SIL_STALKER_Duty_Medic_F","SIL_STALKER_Duty_Rifleman_1_F",
+            "SIL_STALKER_Duty_Rifleman_2_F","SIL_STALKER_Duty_Rifleman_Light_F",
+            "SIL_STALKER_Duty_Sharpshooter_F","SIL_STALKER_Duty_Exo_Rifleman_1_F",
+            "SIL_STALKER_Duty_Exo_Rifleman_2_F","SIL_STALKER_Duty_SEVA_Medic_F",
+            "SIL_STALKER_Duty_SEVA_Rifleman_1_F","SIL_STALKER_Duty_SEVA_Rifleman_2_F",
+            "SIL_STALKER_Duty_SEVA_Rifleman_Light_F"
         ]],
         ["Monolith",   [opfor], [
             "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
             "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
-            "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+            "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01",
+            "SIL_STALKER_Monolith_Autorifleman_F","SIL_STALKER_Monolith_Engineer_F",
+            "SIL_STALKER_Monolith_Medic_F","SIL_STALKER_Monolith_Rifleman_1_F",
+            "SIL_STALKER_Monolith_Rifleman_2_F","SIL_STALKER_Monolith_Rifleman_Light_F",
+            "SIL_STALKER_Monolith_Sharpshooter_F","SIL_STALKER_Monolith_Exo_Rifleman_1_F",
+            "SIL_STALKER_Monolith_Exo_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Engineer_F",
+            "SIL_STALKER_Monolith_SEVA_Medic_F","SIL_STALKER_Monolith_SEVA_Rifleman_1_F",
+            "SIL_STALKER_Monolith_SEVA_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Rifleman_Light_F"
         ]],
         ["Military",   [blufor], [
             "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
-            "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+            "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01",
+            "SIL_STALKER_Military_Autorifleman_F","SIL_STALKER_Military_Engineer_F",
+            "SIL_STALKER_Military_Medic_F","SIL_STALKER_Military_Rifleman_1_F",
+            "SIL_STALKER_Military_Rifleman_2_F","SIL_STALKER_Military_Rifleman_Light_F",
+            "SIL_STALKER_Military_Sharpshooter_F","SIL_STALKER_Military_NoPPE_Engineer_F",
+            "SIL_STALKER_Military_NoPPE_Medic_F","SIL_STALKER_Military_NoPPE_Rifleman_1_F",
+            "SIL_STALKER_Military_NoPPE_Rifleman_2_F","SIL_STALKER_Military_NoPPE_Rifleman_Light_F",
+            "SIL_STALKER_Military_NoPPE_Sharpshooter_F","SIL_STALKER_Military_SEVA_Engineer_F",
+            "SIL_STALKER_Military_SEVA_Medic_F","SIL_STALKER_Military_SEVA_Rifleman_1_F",
+            "SIL_STALKER_Military_SEVA_Rifleman_2_F","SIL_STALKER_Military_SEVA_Rifleman_Light_F",
+            "SIL_STALKER_Military_SEVA_Sharpshooter_F"
         ]],
         ["Spetznaz",   [blufor], [
             "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
@@ -76,12 +129,32 @@ for "_i" from 1 to _groupCount do {
         ]],
         ["Ecologists", [blufor,opfor,independent,civilian], [
             "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
-            "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+            "I_Eco_Lab_Scientist_01","I_Eco_Protector_01",
+            "SIL_STALKER_Ecologist_Scientist_1_F","SIL_STALKER_Ecologist_Scientist_2_F"
         ]],
         ["Loners",     [independent], [
             "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
             "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
-            "I_LNR_Tourist_01","I_LNR_Veteran_01"
+            "I_LNR_Tourist_01","I_LNR_Veteran_01",
+            "SIL_STALKER_Loner_Autorifleman_F","SIL_STALKER_Loner_Engineer_F",
+            "SIL_STALKER_Loner_Medic_F","SIL_STALKER_Loner_Rifleman_1_F",
+            "SIL_STALKER_Loner_Rifleman_2_F","SIL_STALKER_Loner_Rifleman_Light_F",
+            "SIL_STALKER_Loner_Sharpshooter_F","SIL_STALKER_Loner_NoPPE_Autorifleman_F",
+            "SIL_STALKER_Loner_NoPPE_Medic_F","SIL_STALKER_Loner_NoPPE_Rifleman_1_F",
+            "SIL_STALKER_Loner_NoPPE_Rifleman_2_F","SIL_STALKER_Loner_NoPPE_Rifleman_Light_F",
+            "SIL_STALKER_Loner_NoPPE_Sharpshooter_F","SIL_STALKER_Loner_SEVA_Suit_Medic_F",
+            "SIL_STALKER_Loner_SEVA_Suit_Rifleman_1_F","SIL_STALKER_Loner_SEVA_Suit_Rifleman_2_F",
+            "SIL_STALKER_Loner_SEVA_Suit_Rifleman_Light_F"
+        ]],
+        ["Ward", [blufor], [
+            "SIL_STALKER_Ward_Engineer_F","SIL_STALKER_Ward_Medic_F",
+            "SIL_STALKER_Ward_Rifleman_1_F","SIL_STALKER_Ward_Rifleman_2_F",
+            "SIL_STALKER_Ward_Rifleman_Light_F"
+        ]],
+        ["IPSF", [blufor], [
+            "SIL_STALKER_IPSF_Medic_F","SIL_STALKER_IPSF_Rifleman_1_F",
+            "SIL_STALKER_IPSF_Rifleman_2_F","SIL_STALKER_IPSF_Rifleman_Light_F",
+            "SIL_STALKER_IPSF_Sharpshooter_F"
         ]]
     ];
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -21,36 +21,89 @@ private _factionInfo = [
     ["ClearSky",   [blufor,opfor,independent,civilian], [
         "B_CS_Artifact_Seeker_01","B_CS_Exo_01","B_CS_Experienced_01",
         "B_CS_Guardian_01","B_CS_Journeyman_01","B_CS_Nomad_01",
-        "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01"
+        "B_CS_Pathfinder_01","B_CS_Rookie_01","B_CS_Tracker_01",
+        "SIL_STALKER_ClearSky_Medic_F","SIL_STALKER_ClearSky_Rifleman_1_F",
+        "SIL_STALKER_ClearSky_Rifleman_2_F","SIL_STALKER_ClearSky_Rifleman_Light_F",
+        "SIL_STALKER_ClearSky_Sharpshooter_F","SIL_STALKER_ClearSky_SEVA_Medic_F",
+        "SIL_STALKER_ClearSky_SEVA_Rifleman_1_F","SIL_STALKER_ClearSky_SEVA_Rifleman_2_F",
+        "SIL_STALKER_ClearSky_SEVA_Rifleman_Light_F","SIL_STALKER_ClearSky_SEVA_Sharpshooter_F",
+        "SIL_STALKER_ClearSky_NoPPE_Medic_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_1_F",
+        "SIL_STALKER_ClearSky_NoPPE_Rifleman_2_F","SIL_STALKER_ClearSky_NoPPE_Rifleman_Light_F",
+        "SIL_STALKER_ClearSky_NoPPE_Sharpshooter_F"
     ]],
     ["Mercenaries", [blufor,opfor,independent], [
         "B_Merc_Contractor_01","B_Merc_Exo_Merc_01","B_Merc_Merc_Assassin_01",
         "B_Merc_Merc_Scout_01","B_Merc_Merc_Seva_01","B_Merc_Old_Hand_01",
-        "B_Merc_Trained_Merc_01"
+        "B_Merc_Trained_Merc_01",
+        "SIL_STALKER_Merc_Autorifleman_F","SIL_STALKER_Merc_Medic_F",
+        "SIL_STALKER_Merc_Rifleman_1_F","SIL_STALKER_Merc_Rifleman_2_F",
+        "SIL_STALKER_Merc_Rifleman_Light_F","SIL_STALKER_Merc_Sharpshooter_F",
+        "SIL_STALKER_Merc_Night_Medic_F","SIL_STALKER_Merc_Night_Rifleman_1_F",
+        "SIL_STALKER_Merc_Night_Rifleman_2_F","SIL_STALKER_Merc_Night_Rifleman_Light_F",
+        "SIL_STALKER_Merc_Night_Sharpshooter_F","SIL_STALKER_Merc_NoPPE_Autorifleman_F",
+        "SIL_STALKER_Merc_NoPPE_Medic_F","SIL_STALKER_Merc_NoPPE_Rifleman_1_F",
+        "SIL_STALKER_Merc_NoPPE_Rifleman_2_F","SIL_STALKER_Merc_NoPPE_Rifleman_Light_F",
+        "SIL_STALKER_Merc_NoPPE_Sharpshooter_F"
     ]],
     ["Freedom",    [blufor,opfor,independent,civilian], [
         "B_FD_Anomaly_Splunker_01","B_FD_Defender_01","B_FD_Exo_01",
         "B_FD_Guardian_01","B_FD_Seedy_01","B_FD_Seedy_Sniper_01",
-        "B_FD_Wardog_01"
+        "B_FD_Wardog_01",
+        "SIL_STALKER_Freedom_Engineer_F","SIL_STALKER_Freedom_Medic_F",
+        "SIL_STALKER_Freedom_Rifleman_1_F","SIL_STALKER_Freedom_Rifleman_2_F",
+        "SIL_STALKER_Freedom_Rifleman_Light_F","SIL_STALKER_Freedom_Sharpshooter_F",
+        "SIL_STALKER_Freedom_Exo_Rifleman_1_F","SIL_STALKER_Freedom_Exo_Rifleman_2_F",
+        "SIL_STALKER_Freedom_NoPPE_Engineer_F","SIL_STALKER_Freedom_NoPPE_Medic_F",
+        "SIL_STALKER_Freedom_NoPPE_Rifleman_1_F","SIL_STALKER_Freedom_NoPPE_Rifleman_2_F",
+        "SIL_STALKER_Freedom_NoPPE_Rifleman_Light_F","SIL_STALKER_Freedom_NoPPE_Sharpshooter_F",
+        "SIL_STALKER_Freedom_SEVA_Medic_F","SIL_STALKER_Freedom_SEVA_Rifleman_1_F",
+        "SIL_STALKER_Freedom_SEVA_Rifleman_2_F","SIL_STALKER_Freedom_SEVA_Rifleman_Light_F"
     ]],
     ["Bandits",    [blufor,opfor,independent,civilian], [
         "O_Bdz_Assaulter_01","O_Bdz_Conman_01","O_Bdz_Criminal_01",
         "O_Bdz_Exo_01","O_Bdz_Raider_01","O_Bdz_Robber_01",
-        "O_Bdz_Thug_01","O_Bdz_Waster_01"
+        "O_Bdz_Thug_01","O_Bdz_Waster_01",
+        "SIL_STALKER_Bandit_Autorifleman_F","SIL_STALKER_Bandit_Rifleman_1_F",
+        "SIL_STALKER_Bandit_Rifleman_2_F","SIL_STALKER_Bandit_Rifleman_Light_F",
+        "SIL_STALKER_Bandit_Sharpshooter_F"
     ]],
     ["Duty",       [blufor,opfor], [
         "O_ODty_Artifact_Specialist_01","O_ODty_Duty_Hunter_01","O_ODty_Duty_Patrolman_01",
         "O_ODty_Duty_Officer_01","O_ODty_Duty_Private_01","O_ODty_Duty_Sniper_01",
-        "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01"
+        "O_ODty_Duty_Specialist_01","O_ODty_Duty_Trooper_01",
+        "SIL_STALKER_Duty_Autorifleman_F","SIL_STALKER_Duty_Engineer_F",
+        "SIL_STALKER_Duty_Medic_F","SIL_STALKER_Duty_Rifleman_1_F",
+        "SIL_STALKER_Duty_Rifleman_2_F","SIL_STALKER_Duty_Rifleman_Light_F",
+        "SIL_STALKER_Duty_Sharpshooter_F","SIL_STALKER_Duty_Exo_Rifleman_1_F",
+        "SIL_STALKER_Duty_Exo_Rifleman_2_F","SIL_STALKER_Duty_SEVA_Medic_F",
+        "SIL_STALKER_Duty_SEVA_Rifleman_1_F","SIL_STALKER_Duty_SEVA_Rifleman_2_F",
+        "SIL_STALKER_Duty_SEVA_Rifleman_Light_F"
     ]],
     ["Monolith",   [opfor], [
         "O_mn_Monolith_Cultist_01","O_mn_Monolith_Disciple_01","O_mn_Monolith_Exo_01",
         "O_mn_Monolith_Fanatic_01","O_mn_Monolith_Preacher_01",
-        "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01"
+        "O_mn_Monolith_Predecessor_01","O_mn_Monolith_Scientist_01",
+        "SIL_STALKER_Monolith_Autorifleman_F","SIL_STALKER_Monolith_Engineer_F",
+        "SIL_STALKER_Monolith_Medic_F","SIL_STALKER_Monolith_Rifleman_1_F",
+        "SIL_STALKER_Monolith_Rifleman_2_F","SIL_STALKER_Monolith_Rifleman_Light_F",
+        "SIL_STALKER_Monolith_Sharpshooter_F","SIL_STALKER_Monolith_Exo_Rifleman_1_F",
+        "SIL_STALKER_Monolith_Exo_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Engineer_F",
+        "SIL_STALKER_Monolith_SEVA_Medic_F","SIL_STALKER_Monolith_SEVA_Rifleman_1_F",
+        "SIL_STALKER_Monolith_SEVA_Rifleman_2_F","SIL_STALKER_Monolith_SEVA_Rifleman_Light_F"
     ]],
     ["Military",   [blufor], [
         "I_UA_Military_autorifleman_01","I_UA_Military_Officer_01","I_UA_Military_Private_01",
-        "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01"
+        "I_UA_Military_Sergeant_01","I_UA_Military_Stalker_01",
+        "SIL_STALKER_Military_Autorifleman_F","SIL_STALKER_Military_Engineer_F",
+        "SIL_STALKER_Military_Medic_F","SIL_STALKER_Military_Rifleman_1_F",
+        "SIL_STALKER_Military_Rifleman_2_F","SIL_STALKER_Military_Rifleman_Light_F",
+        "SIL_STALKER_Military_Sharpshooter_F","SIL_STALKER_Military_NoPPE_Engineer_F",
+        "SIL_STALKER_Military_NoPPE_Medic_F","SIL_STALKER_Military_NoPPE_Rifleman_1_F",
+        "SIL_STALKER_Military_NoPPE_Rifleman_2_F","SIL_STALKER_Military_NoPPE_Rifleman_Light_F",
+        "SIL_STALKER_Military_NoPPE_Sharpshooter_F","SIL_STALKER_Military_SEVA_Engineer_F",
+        "SIL_STALKER_Military_SEVA_Medic_F","SIL_STALKER_Military_SEVA_Rifleman_1_F",
+        "SIL_STALKER_Military_SEVA_Rifleman_2_F","SIL_STALKER_Military_SEVA_Rifleman_Light_F",
+        "SIL_STALKER_Military_SEVA_Sharpshooter_F"
     ]],
     ["Spetznaz",   [blufor], [
         "I_UA_Spetznaz_Officer_01","I_UA_Spetznaz_Operator_01",
@@ -58,12 +111,32 @@ private _factionInfo = [
     ]],
     ["Ecologists", [blufor,opfor,independent,civilian], [
         "I_Eco_Eco_Guard_01","I_Eco_Eco_Stalker_01","I_Eco_Field_Ecologist_01",
-        "I_Eco_Lab_Scientist_01","I_Eco_Protector_01"
+        "I_Eco_Lab_Scientist_01","I_Eco_Protector_01",
+        "SIL_STALKER_Ecologist_Scientist_1_F","SIL_STALKER_Ecologist_Scientist_2_F"
     ]],
     ["Loners",     [independent], [
         "I_LNR_Artifact_Huner_01","I_LNR_Explorer_01","I_LNR_Loner_01",
         "I_LNR_Loner_Rookie_01","I_LNR_Mutant_Hunter_01",
-        "I_LNR_Tourist_01","I_LNR_Veteran_01"
+        "I_LNR_Tourist_01","I_LNR_Veteran_01",
+        "SIL_STALKER_Loner_Autorifleman_F","SIL_STALKER_Loner_Engineer_F",
+        "SIL_STALKER_Loner_Medic_F","SIL_STALKER_Loner_Rifleman_1_F",
+        "SIL_STALKER_Loner_Rifleman_2_F","SIL_STALKER_Loner_Rifleman_Light_F",
+        "SIL_STALKER_Loner_Sharpshooter_F","SIL_STALKER_Loner_NoPPE_Autorifleman_F",
+        "SIL_STALKER_Loner_NoPPE_Medic_F","SIL_STALKER_Loner_NoPPE_Rifleman_1_F",
+        "SIL_STALKER_Loner_NoPPE_Rifleman_2_F","SIL_STALKER_Loner_NoPPE_Rifleman_Light_F",
+        "SIL_STALKER_Loner_NoPPE_Sharpshooter_F","SIL_STALKER_Loner_SEVA_Suit_Medic_F",
+        "SIL_STALKER_Loner_SEVA_Suit_Rifleman_1_F","SIL_STALKER_Loner_SEVA_Suit_Rifleman_2_F",
+        "SIL_STALKER_Loner_SEVA_Suit_Rifleman_Light_F"
+    ]],
+    ["Ward", [blufor], [
+        "SIL_STALKER_Ward_Engineer_F","SIL_STALKER_Ward_Medic_F",
+        "SIL_STALKER_Ward_Rifleman_1_F","SIL_STALKER_Ward_Rifleman_2_F",
+        "SIL_STALKER_Ward_Rifleman_Light_F"
+    ]],
+    ["IPSF", [blufor], [
+        "SIL_STALKER_IPSF_Medic_F","SIL_STALKER_IPSF_Rifleman_1_F",
+        "SIL_STALKER_IPSF_Rifleman_2_F","SIL_STALKER_IPSF_Rifleman_Light_F",
+        "SIL_STALKER_IPSF_Sharpshooter_F"
     ]]
 ];
 
@@ -128,6 +201,8 @@ if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         case "Freedom": {"ColorBlue"};
         case "Loners": {"ColorWhite"};
         case "Mercs": {"ColorPink"};
+        case "Ward": {"ColorBlue"};
+        case "IPSF": {"ColorBlue"};
         default {"ColorWhite"};
     };
     [_marker, _pos, "ICON", "mil_box", _color, 0.2, _faction] call VIC_fnc_createGlobalMarker;


### PR DESCRIPTION
## Summary
- integrate expanded soldier type lists for all factions
- add Ward and IPSF factions
- colourise Ward and IPSF camp markers
- extend Duty camp roster with all soldier types

## Testing
- `bash scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6861f29ce640832f866fa99925b36153