### PR TITLE
Add site anchors for proximity tracking

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -45,6 +45,8 @@ for "_i" from 1 to _count do {
     };
     if (isNil {_pos}) then { continue; };
 
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["amb_%1", diag_tickTime + _i];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
@@ -23,6 +23,8 @@ private _createField = {
     private _spawned = [_pos, 75] call _fn;
     if (_spawned isEqualTo []) exitWith { false };
 
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     if (_marker != "") then {
         _marker setMarkerBrush "Border";

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -91,6 +91,8 @@ for "_i" from 1 to _fieldCount do {
         continue;
     };
 
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
     if (_marker != "") then {
@@ -124,6 +126,8 @@ if (_bridges isEqualTo []) then {
     private _stable = if (_type == -1) then { (random 100) < _stableChance } else { _type == 1 };
     private _spawned = [_pos, 75, -1, _pos] call VIC_fnc_createField_bridgeElectra;
     if (_spawned isEqualTo []) then { continue };
+
+    [_pos] call VIC_fnc_createProximityAnchor;
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
     if (_marker != "") then {

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
@@ -43,6 +43,8 @@ for "_i" from 1 to _count do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorOrange", 0.2, "Trap"] call VIC_fnc_createGlobalMarker;
     };
 
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     STALKER_boobyTraps pushBack [_pos, [], _marker, false];
     _spawned = _spawned + 1;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIED.sqf
@@ -13,6 +13,8 @@ if (!isServer) exitWith { [] };
 
 private _pos = [_center, 200, 20] call VIC_fnc_findRoadPosition;
 if (isNil {_pos}) exitWith { [] };
+
+[_pos] call VIC_fnc_createProximityAnchor;
 private _ied = createMine ["IEDLandSmall_F", _pos, [], 0];
 
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf
@@ -37,6 +37,8 @@ for "_i" from 1 to _count do {
     };
     if (isNil {_pos}) then { continue };
 
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["ied_%1_%2", count STALKER_iedSites, diag_tickTime];

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -46,6 +46,8 @@ for "_i" from 1 to _fieldCount do {
         _pos = [_pos] call VIC_fnc_findLandPos;
     };
     if (isNil {_pos} || { _pos isEqualTo [] }) then { continue; };
+
+    [_pos] call VIC_fnc_createProximityAnchor;
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["mf_%1", diag_tickTime];
@@ -67,6 +69,8 @@ for "_i" from 1 to _iedCount do {
         _pos = [_tPos, 200, 10] call VIC_fnc_findRoadPosition;
     };
     if (isNil {_pos}) then { continue; };
+
+    [_pos] call VIC_fnc_createProximityAnchor;
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["ied_%1", diag_tickTime];

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -58,6 +58,9 @@ private _createMarker = {
     };
 
     _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
+
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
     STALKER_mutantHabitatData pushBack [_type, _pos, _max];
 };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
@@ -31,6 +31,9 @@ private _createMarker = {
     private _label = _base + "_label";
     [_label, _pos, "ICON", "mil_dot", "ColorGreen", 1] call VIC_fnc_createGlobalMarker;
     _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
+
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnMutantNest.sqf
@@ -39,6 +39,8 @@ for "_i" from 1 to 3 do {
 };
 private _nestObj = "Land_Campfire_F" createVehicle _pos;
 
+[_pos] call VIC_fnc_createProximityAnchor;
+
 STALKER_mutantNests pushBack [_nestObj, _grp, _pos, _class];
 
 [_grp, _pos] call BIS_fnc_taskDefend;

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -174,6 +174,8 @@ for "_i" from 1 to _groupCount do {
         [_marker, _pos, "ICON", "mil_dot", "ColorGreen", 0.2] call VIC_fnc_createGlobalMarker;
     };
 
+    [_pos] call VIC_fnc_createProximityAnchor;
+
     STALKER_stalkerGroups pushBack [_grp, _marker];
     STALKER_wanderers pushBack [_grp, _pos, _marker, true];
 }; 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -9,6 +9,8 @@ params ["_pos"];
 
 ["spawnStalkerCamp"] call VIC_fnc_debugLog;
 
+[_pos] call VIC_fnc_createProximityAnchor;
+
 if (!isServer) exitWith {};
 
 if (isNil "STALKER_camps") then { STALKER_camps = []; };


### PR DESCRIPTION
## Summary
- create proximity anchors when spawning ambushes, minefields, IED sites, and other point-of-interest locations
- ensure mutant habitats, nests, stalker camps and ambient groups also place an anchor

## Testing
- `./scripts/sqflint-hook.sh $(git diff --name-only --diff-filter=AM)`

------
https://chatgpt.com/codex/tasks/task_e_6861f77587b8832fba5aa2e29c0c0022