### PR TITLE
Enforce minimum distance between stalker camps

### DIFF
--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -92,6 +92,7 @@ class CfgFunctions
             class spawnStalkerCamp{};
             class spawnStalkerCamps{};
             class findCampBuilding{};
+            class isCampLocationValid{};
             class spawnFlareTripwires{};
             class spawnSniper{};
             class manageSnipers{};

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -206,6 +206,7 @@ VIC_fnc_spawnAmbientStalkers   = compile preprocessFileLineNumbers (_root + "\fu
 VIC_fnc_spawnStalkerCamp       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamp.sqf");
 VIC_fnc_spawnStalkerCamps      = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnStalkerCamps.sqf");
 VIC_fnc_findCampBuilding       = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_findCampBuilding.sqf");
+VIC_fnc_isCampLocationValid    = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_isCampLocationValid.sqf");
 VIC_fnc_spawnFlareTripwires    = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnFlareTripwires.sqf");
 VIC_fnc_spawnSniper           = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnSniper.sqf");
 VIC_fnc_manageSnipers         = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_manageSnipers.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_isCampLocationValid.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_isCampLocationValid.sqf
@@ -1,0 +1,20 @@
+/*
+    Checks if a candidate stalker camp position is far enough from existing camps.
+
+    Params:
+        0: POSITION - position to test
+        1: NUMBER   - minimum separation distance (default 300m)
+
+    Returns:
+        BOOL - true if no existing camp is within the distance
+*/
+
+params ["_pos", ["_dist", 300]];
+
+if (isNil "STALKER_camps") exitWith { true };
+
+{
+    if (_pos distance2D (_x select 2) < _dist) exitWith { false };
+} forEach STALKER_camps;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -15,6 +15,11 @@ if (!isServer) exitWith {};
 
 if (isNil "STALKER_camps") then { STALKER_camps = []; };
 
+if (!([_pos, 300] call VIC_fnc_isCampLocationValid)) exitWith {
+    ["spawnStalkerCamp: position too close to existing camp"] call VIC_fnc_debugLog;
+    false
+};
+
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
 
 // Available factions and their unit classes

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamps.sqf
@@ -16,9 +16,16 @@ if (["VSA_enableStalkerCamps", true] call VIC_fnc_getSetting isEqualTo false) ex
 
 if (_count < 0) then { _count = ["VSA_stalkerCampCount",1] call VIC_fnc_getSetting; };
 
+private _minDist = 300;
+
 for "_i" from 1 to _count do {
-    private _building = [] call VIC_fnc_findCampBuilding;
-    if (isNull _building) exitWith {};
-    private _campPos = getPosATL _building;
+    private _campPos = nil;
+    for "_j" from 1 to 30 do {
+        private _building = [] call VIC_fnc_findCampBuilding;
+        if (isNull _building) exitWith {};
+        private _pos = getPosATL _building;
+        if ([ _pos, _minDist ] call VIC_fnc_isCampLocationValid) exitWith { _campPos = _pos };
+    };
+    if (isNil {_campPos}) exitWith {};
     [_campPos] call VIC_fnc_spawnStalkerCamp;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
@@ -36,11 +36,17 @@ missionNamespace setVariable ["VIC_campManagerRunning", true];
 
         if ((count STALKER_camps) < _min) then {
             private _needed = _min - (count STALKER_camps);
+            private _minDist = 300;
             for "_i" from 1 to _needed do {
-                private _building = [] call VIC_fnc_findCampBuilding;
-                if (isNull _building) exitWith {};
-                private _pos = getPosATL _building;
-                [_pos] call VIC_fnc_spawnStalkerCamp;
+                private _campPos = nil;
+                for "_j" from 1 to 30 do {
+                    private _building = [] call VIC_fnc_findCampBuilding;
+                    if (isNull _building) exitWith {};
+                    private _pos = getPosATL _building;
+                    if ([ _pos, _minDist ] call VIC_fnc_isCampLocationValid) exitWith { _campPos = _pos };
+                };
+                if (isNil {_campPos}) exitWith {};
+                [_campPos] call VIC_fnc_spawnStalkerCamp;
             };
         };
 


### PR DESCRIPTION
## Summary
- add `isCampLocationValid` helper to check camp separation
- register the new function in `config.cpp` and `fn_masterInit.sqf`
- ensure new camps are at least 300m apart when spawned
- prevent spawning camps too close together in `spawnStalkerCamp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861fdd74210832fb468b40ca942d234