### PR TITLE
Improve proximity checks using anchors

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalies.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalies.sqf
@@ -26,7 +26,7 @@ private _range  = ["VSA_aiAnomalyAvoidRange", 20] call VIC_fnc_getSetting;
 
 private _anoms = [];
 {
-    private _objs = _x select 4;
+    private _objs = _x select 5;
     _anoms append _objs;
 } forEach STALKER_anomalyFields;
 if (_anoms isEqualTo []) exitWith {};

--- a/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ai/fn_avoidAnomalyFields.sqf
@@ -28,7 +28,7 @@ if (isNil "STALKER_anomalyFields") exitWith {
 private _chance = ["VSA_aiAnomalyAvoidChance", 50] call VIC_fnc_getSetting;
 private _buffer = ["VSA_aiAnomalyAvoidRange", 20] call VIC_fnc_getSetting;
 
-private _fields = STALKER_anomalyFields apply { [ _x select 0, _x select 1 ] };
+private _fields = STALKER_anomalyFields apply { [ _x select 0, _x select 2 ] };
 if (_fields isEqualTo []) exitWith {
     ["fn_avoidAnomalyFields exit: no valid fields"] call VIC_fnc_debugLog;
 };

--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -45,7 +45,7 @@ for "_i" from 1 to _count do {
     };
     if (isNil {_pos}) then { continue; };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
@@ -53,7 +53,7 @@ for "_i" from 1 to _count do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorBlack", 0.2, "Ambush"] call VIC_fnc_createGlobalMarker;
     };
 
-    STALKER_ambushes pushBack [_pos, objNull, [], [], false, _marker, false];
+    STALKER_ambushes pushBack [_pos, _anchor, objNull, [], [], false, _marker, false];
 };
 
 true;

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_activateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_activateSite.sqf
@@ -11,7 +11,7 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 if (_index < 0 || {_index >= count STALKER_anomalyFields}) exitWith {};
 
 private _entry = STALKER_anomalyFields select _index;
-_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
+_entry params ["_center","_anchor","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
 
 if (_objs isEqualTo [] || {{isNull _x} count _objs == count _objs}) then {
     private _spawned = [_center,_radius,_count,_site] call _fn;
@@ -31,6 +31,6 @@ if (_marker != "") then {
 };
 
 _active = true;
-STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_active]];
+STALKER_anomalyFields set [_index, [_center,_anchor,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_active]];
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf
@@ -7,9 +7,9 @@
 
 if (isServer && !isNil "STALKER_anomalyFields") then {
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
-    for [{_i = 0}, {_i < count STALKER_anomalyFields}, {_i = _i + 1}] do {
+    for "_i" from 0 to ((count STALKER_anomalyFields) - 1) do {
         private _entry = STALKER_anomalyFields select _i;
-        _entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
+        _entry params ["_center","_anchor","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable"];
         { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
         if (_marker != "") then {
             deleteMarker _marker;
@@ -49,7 +49,7 @@ if (isServer && !isNil "STALKER_anomalyFields") then {
             };
         };
         _exp = diag_tickTime + (_dur * 60);
-        STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
+        STALKER_anomalyFields set [_i, [_center,_anchor,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable]];
     };
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_deactivateSite.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_deactivateSite.sqf
@@ -11,7 +11,7 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 if (_index < 0 || {_index >= count STALKER_anomalyFields}) exitWith {};
 
 private _entry = STALKER_anomalyFields select _index;
-_entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
+_entry params ["_center","_anchor","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
 
 if ((count _objs) > 0) then {
     { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
@@ -23,6 +23,6 @@ if (_marker != "") then {
 };
 
 _active = false;
-STALKER_anomalyFields set [_index, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_active]];
+STALKER_anomalyFields set [_index, [_center,_anchor,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_active]];
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_manageAnomalyFields.sqf
@@ -2,7 +2,7 @@
     Activates or deactivates anomaly fields based on player proximity and
     removes expired entries.
     STALKER_anomalyFields entries:
-        [center, radius, fn, count, objects, marker, site, expires, stable, active]
+        [center, anchor, radius, fn, count, objects, marker, site, expires, stable, active]
 */
 // ["manageAnomalyFields"] call VIC_fnc_debugLog;
 
@@ -11,7 +11,7 @@ if (isNil "STALKER_anomalyFields") exitWith {};
 
 for "_i" from ((count STALKER_anomalyFields) - 1) to 0 step -1 do {
     private _entry = STALKER_anomalyFields select _i;
-    _entry params ["_center","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
+    _entry params ["_center","_anchor","_radius","_fn","_count","_objs","_marker","_site","_exp","_stable",["_active",false]];
 
     if (_exp >= 0 && {diag_tickTime > _exp}) then {
         { if (!isNull _x) then { deleteVehicle _x; } } forEach _objs;
@@ -26,9 +26,8 @@ for "_i" from ((count STALKER_anomalyFields) - 1) to 0 step -1 do {
         continue;
     };
 
-    private _pos = if (_site isEqualTo []) then {_center} else {_site};
     private _dist = 400;
-    private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
+    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
 
     if (_newActive) then {
         if (!_active || {_objs isEqualTo [] || {{isNull _x} count _objs == count _objs}}) then {
@@ -57,7 +56,7 @@ for "_i" from ((count STALKER_anomalyFields) - 1) to 0 step -1 do {
             _marker setMarkerAlpha 0.2;
         };
     };
-    STALKER_anomalyFields set [_i, [_center,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_newActive]];
+    STALKER_anomalyFields set [_i, [_center,_anchor,_radius,_fn,_count,_objs,_marker,_site,_exp,_stable,_newActive]];
 };
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf
@@ -15,15 +15,16 @@ private _createField = {
 
     // Skip this location if it overlaps an existing field
     private _overlap = false;
-    {
-        if (_pos distance2D (_x#6) < 300) exitWith { _overlap = true };
-    } forEach STALKER_anomalyFields;
+        {
+            private _site = _x select 7;
+            if (_pos distance2D _site < 300) exitWith { _overlap = true };
+        } forEach STALKER_anomalyFields;
     if (_overlap) exitWith { false };
 
     private _spawned = [_pos, 75] call _fn;
     if (_spawned isEqualTo []) exitWith { false };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     if (_marker != "") then {
@@ -50,7 +51,7 @@ private _createField = {
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
 
-    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_pos,_exp,true,false];
+    STALKER_anomalyFields pushBack [_pos,_anchor,75,_fn,count _spawned,_spawned,_marker,_pos,_exp,true,false];
     true
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -91,7 +91,7 @@ for "_i" from 1 to _fieldCount do {
         continue;
     };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
@@ -105,7 +105,7 @@ for "_i" from 1 to _fieldCount do {
 
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
-    STALKER_anomalyFields pushBack [_pos,75,_fn,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
+    STALKER_anomalyFields pushBack [_pos,_anchor,75,_fn,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
     [format ["spawnAllAnomalyFields: spawned %1 %2", count _spawned, _typeName]] call VIC_fnc_debugLog;
 }; 
 
@@ -127,7 +127,7 @@ if (_bridges isEqualTo []) then {
     private _spawned = [_pos, 75, -1, _pos] call VIC_fnc_createField_bridgeElectra;
     if (_spawned isEqualTo []) then { continue };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
     private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
     private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
     if (_marker != "") then {
@@ -137,7 +137,7 @@ if (_bridges isEqualTo []) then {
     };
     private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
     private _exp = diag_tickTime + (_dur * 60);
-    STALKER_anomalyFields pushBack [_pos,75,VIC_fnc_createField_bridgeElectra,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
+    STALKER_anomalyFields pushBack [_pos,_anchor,75,VIC_fnc_createField_bridgeElectra,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
     [format ["spawnAllAnomalyFields: spawned %1 bridge", count _spawned]] call VIC_fnc_debugLog;
 } forEach _bridges;
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf
@@ -4,20 +4,20 @@
     are beyond the activation range plus 200 meters.
 
     Params:
-        0: POSITION - position of the site
+        0: OBJECT   - proximity anchor for the site
         1: NUMBER   - activation range in meters
         2: BOOL     - current active state
 
     Returns: BOOL - updated active state
 */
 
-params ["_pos", "_range", "_active"];
+params ["_anchor", "_range", "_active"];
 
-private _near = [_pos, _range] call VIC_fnc_hasPlayersNearby;
+private _near = [_anchor, _range] call VIC_fnc_hasPlayersNearby;
 
 if (_active) then {
     if (!_near) then {
-        if !([_pos, _range + 200] call VIC_fnc_hasPlayersNearby) then {
+        if !([_anchor, _range + 200] call VIC_fnc_hasPlayersNearby) then {
             _active = false;
         } else {
             _active = true;

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -1,6 +1,6 @@
 /*
     Activates or deactivates booby traps based on player proximity.
-    STALKER_boobyTraps entries: [position, objects, marker, active]
+    STALKER_boobyTraps entries: [position, anchor, objects, marker, active]
 */
 // ["manageBoobyTraps"] call VIC_fnc_debugLog;
 
@@ -10,8 +10,8 @@ if (isNil "STALKER_boobyTraps") exitWith {};
 private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 {
-    _x params ["_pos","_objs","_marker",["_active",false]];
-    private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
+    _x params ["_pos","_anchor","_objs","_marker",["_active",false]];
+    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (!_active) then {
             // Spawn tripwire or fallback APERS mine vehicles
@@ -32,7 +32,7 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
         };
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
-    STALKER_boobyTraps set [_forEachIndex, [_pos,_objs,_marker,_newActive]];
+    STALKER_boobyTraps set [_forEachIndex, [_pos,_anchor,_objs,_marker,_newActive]];
 } forEach STALKER_boobyTraps;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf
@@ -1,6 +1,6 @@
 /*
     Activates or deactivates minefields based on player proximity.
-    STALKER_minefields entries: [center, type, size, objects, marker, active]
+    STALKER_minefields entries: [center, anchor, type, size, objects, marker, active]
 */
 // ["manageMinefields"] call VIC_fnc_debugLog;
 
@@ -10,8 +10,8 @@ if (isNil "STALKER_minefields") exitWith {};
 private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 {
-    _x params ["_center","_type","_size","_objs","_marker",["_active",false]];
-    private _newActive = [_center,_dist,_active] call VIC_fnc_evalSiteProximity;
+    _x params ["_center","_anchor","_type","_size","_objs","_marker",["_active",false]];
+    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (!_active) then {
             _objs = switch (_type) do {
@@ -28,7 +28,7 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
         };
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
-    STALKER_minefields set [_forEachIndex, [_center,_type,_size,_objs,_marker,_newActive]];
+    STALKER_minefields set [_forEachIndex, [_center,_anchor,_type,_size,_objs,_marker,_newActive]];
 } forEach STALKER_minefields;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnBoobyTraps.sqf
@@ -43,9 +43,9 @@ for "_i" from 1 to _count do {
         [_marker, _pos, "ICON", "mil_triangle", "ColorOrange", 0.2, "Trap"] call VIC_fnc_createGlobalMarker;
     };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
-    STALKER_boobyTraps pushBack [_pos, [], _marker, false];
+    STALKER_boobyTraps pushBack [_pos, _anchor, [], _marker, false];
     _spawned = _spawned + 1;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -47,14 +47,14 @@ for "_i" from 1 to _fieldCount do {
     };
     if (isNil {_pos} || { _pos isEqualTo [] }) then { continue; };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["mf_%1", diag_tickTime];
         [_marker, _pos, "RECTANGLE", "", "ColorYellow", 0.2, "APERS Field"] call VIC_fnc_createGlobalMarker;
         _marker setMarkerSize [_size/2, _size/2];
     };
-    STALKER_minefields pushBack [_pos,"APERS",_size,[],_marker,false];
+    STALKER_minefields pushBack [_pos,_anchor,"APERS",_size,[],_marker,false];
     _fieldsSpawned = _fieldsSpawned + 1;
 };
 
@@ -70,13 +70,13 @@ for "_i" from 1 to _iedCount do {
     };
     if (isNil {_pos}) then { continue; };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["ied_%1", diag_tickTime];
         [_marker, _pos, "ICON", "mil_triangle", "ColorRed", 0.2, "IED"] call VIC_fnc_createGlobalMarker;
     };
-    STALKER_minefields pushBack [_pos,"IED",0,[],_marker,false];
+    STALKER_minefields pushBack [_pos,_anchor,"IED",0,[],_marker,false];
     _iedsSpawned = _iedsSpawned + 1;
 };
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -2,7 +2,7 @@
     Manages mutant habitats. Spawns units when players approach and
     replenishes cleared habitats over time.
 
-    STALKER_mutantHabitats entries: [areaMarker, labelMarker, group, position, type, max, count, near]
+    STALKER_mutantHabitats entries: [areaMarker, labelMarker, group, position, anchor, type, max, count, near]
 */
 
 // ["manageHabitats"] call VIC_fnc_debugLog;
@@ -41,7 +41,7 @@ private _getClass = {
 
 {
 
-    _x params ["_area","_label","_grp","_pos","_type","_max","_count","_near"];
+    _x params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
 
     if (_near) then {
         if (isNull _grp && {_count > 0}) then {
@@ -86,6 +86,6 @@ private _getClass = {
     _area setMarkerAlpha _alpha;
     _label setMarkerAlpha _alpha;
 
-    STALKER_mutantHabitats set [_forEachIndex, [_area,_label,_grp,_pos,_type,_max,_count,_near]];
+    STALKER_mutantHabitats set [_forEachIndex, [_area,_label,_grp,_pos,_anchor,_type,_max,_count,_near]];
 } forEach STALKER_mutantHabitats;
 

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_onMutantKilled.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_onMutantKilled.sqf
@@ -21,13 +21,13 @@ if (_herdIndex > -1 && {!isNil "STALKER_activeHerds"}) then {
 private _habIndex = _unit getVariable ["VSA_habitatIndex", -1];
 if (_habIndex > -1 && {!isNil "STALKER_mutantHabitats"}) then {
     private _entry = STALKER_mutantHabitats select _habIndex;
-    _entry params ["_area","_label","_grp","_pos","_type","_max","_count","_near"];
+    _entry params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
     _count = _count - 1;
     if (_count < 0) then {_count = 0;};
     _area setMarkerColor (if (_count > 0) then {"ColorRed"} else {"ColorGreen"});
     _label setMarkerColor (if (_count > 0) then {"ColorRed"} else {"ColorGreen"});
     _label setMarkerText format ["%1 Habitat: %2/%3", _type, _count, _max];
-    STALKER_mutantHabitats set [_habIndex, [_area,_label,_grp,_pos,_type,_max,_count,_near]];
+    STALKER_mutantHabitats set [_habIndex, [_area,_label,_grp,_pos,_anchor,_type,_max,_count,_near]];
 };
 
 if (missionNamespace getVariable ["STALKER_mutantHunt_active", false]) then {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -20,7 +20,7 @@ private _createMarker = {
     } forEach STALKER_mutantHabitats;
     if (!_overlap && {!isNil "STALKER_anomalyFields"}) then {
         {
-            if (_pos distance2D (_x#6) < 300) exitWith { _overlap = true };
+            if (_pos distance2D (_x#7) < 300) exitWith { _overlap = true };
         } forEach STALKER_anomalyFields;
     };
     if (_overlap) exitWith { false };
@@ -59,9 +59,9 @@ private _createMarker = {
 
     _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
-    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
+    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _anchor, _type, _max, 0, false];
     STALKER_mutantHabitatData pushBack [_type, _pos, _max];
 };
 
@@ -179,7 +179,7 @@ private _swampSites = selectBestPlaces [_center, worldSize, "meadow", 1, 50];
 } forEach (_swampSites select [0,10]);
 
 private _allTypes = _weightsGeneric apply { _x#0 };
-private _existing = STALKER_mutantHabitats apply { _x#4 };
+private _existing = STALKER_mutantHabitats apply { _x#5 };
 {
     if (!(_x in _existing)) then {
         if !(_buildings isEqualTo []) then {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
@@ -20,7 +20,7 @@ private _createMarker = {
     } forEach STALKER_mutantHabitats;
     if (!_overlap && {!isNil "STALKER_anomalyFields"}) then {
         {
-            if (_pos distance2D (_x#6) < 300) exitWith { _overlap = true };
+            if (_pos distance2D (_x#7) < 300) exitWith { _overlap = true };
         } forEach STALKER_anomalyFields;
     };
     if (_overlap) exitWith { false };
@@ -32,9 +32,9 @@ private _createMarker = {
     [_label, _pos, "ICON", "mil_dot", "ColorGreen", 1] call VIC_fnc_createGlobalMarker;
     _label setMarkerText format ["%1 Habitat: 0/%2", _type, _max];
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
-    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _type, _max, 0, false];
+    STALKER_mutantHabitats pushBack [_area, _label, grpNull, _pos, _anchor, _type, _max, 0, false];
 };
 
 {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnHabitatHunters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnHabitatHunters.sqf
@@ -11,7 +11,7 @@ if (!isServer) exitWith {};
 if (isNil "STALKER_mutantHabitats") exitWith {};
 
 private _habitats = STALKER_mutantHabitats apply {
-    _x params ["_area","_label","_grp","_pos","_type","_max","_count","_near"];
+    _x params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
     [_player distance2D _pos, _pos, _type]
 };
 _habitats sort true;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_updateProximity.sqf
@@ -11,18 +11,18 @@ private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 if (!isNil "STALKER_mutantHabitats") then {
     {
-        _x params ["_area","_label","_grp","_pos","_type","_max","_count","_near"];
-        _near = [_pos,_range] call VIC_fnc_hasPlayersNearby;
-        STALKER_mutantHabitats set [_forEachIndex, [_area,_label,_grp,_pos,_type,_max,_count,_near]];
+        _x params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
+        _near = [_anchor, _range] call VIC_fnc_hasPlayersNearby;
+        STALKER_mutantHabitats set [_forEachIndex, [_area,_label,_grp,_pos,_anchor,_type,_max,_count,_near]];
     } forEach STALKER_mutantHabitats;
 };
 
 if (!isNil "STALKER_activeHerds") then {
     {
         _x params ["_leader","_grp","_max","_count","_near","_marker"];
-        _near = [getPos _leader,_range] call VIC_fnc_hasPlayersNearby;
+        _near = [_leader, _range] call VIC_fnc_hasPlayersNearby;
         STALKER_activeHerds set [_forEachIndex, [_leader,_grp,_max,_count,_near,_marker]];
     } forEach STALKER_activeHerds;
-}; 
+};
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageSnipers.sqf
@@ -1,7 +1,7 @@
 /*
     Handles spawned sniper units. Snipers are removed when their
     spawns when players are nearby and despawns when they leave.
-    STALKER_snipers entries: [group, position, marker, active]
+    STALKER_snipers entries: [group, position, anchor, marker, active]
 */
 
 // ["manageSnipers"] call VIC_fnc_debugLog;
@@ -12,9 +12,9 @@ if (isNil "STALKER_snipers") exitWith {};
 private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 {
-    _x params ["_grp","_pos","_marker","_active"];
+    _x params ["_grp","_pos","_anchor","_marker","_active"];
 
-    private _newActive = [_pos,_range,_active] call VIC_fnc_evalSiteProximity;
+    private _newActive = [_anchor,_range,_active] call VIC_fnc_evalSiteProximity;
 
     if (_newActive) then {
         if (isNull _grp || { count units _grp == 0 }) then {
@@ -33,7 +33,7 @@ private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
 
-    STALKER_snipers set [_forEachIndex, [_grp, _pos, _marker, _newActive]];
+    STALKER_snipers set [_forEachIndex, [_grp, _pos, _anchor, _marker, _newActive]];
 } forEach STALKER_snipers;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -1,6 +1,6 @@
 /*
     Activates or deactivates stalker camps based on player proximity.
-    STALKER_camps entries: [campfire, group, position, marker, side, faction, active]
+    STALKER_camps entries: [campfire, group, position, anchor, marker, side, faction, active]
 */
 
 // ["manageStalkerCamps"] call VIC_fnc_debugLog;
@@ -12,8 +12,8 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
 
 {
-    _x params ["_camp", "_grp", "_pos", "_marker", "_side", "_faction",["_active",false]];
-    private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
+    _x params ["_camp", "_grp", "_pos", "_anchor", "_marker", "_side", "_faction",["_active",false]];
+    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (isNull _camp) then {
             // Spawn the campfire a few meters away from the building
@@ -198,7 +198,7 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
     if (_marker != "") then {
         [_marker, (if (_newActive) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
     };
-    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _marker, _side, _faction, _newActive]];
+    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _anchor, _marker, _side, _faction, _newActive]];
 } forEach STALKER_camps;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageWanderers.sqf
@@ -1,7 +1,7 @@
 /*
     Handles ambient stalker wanderer groups. Groups are removed when their
     patrol grid cell becomes inactive and respawned when the cell is active.
-    STALKER_wanderers entries: [group, position, marker, active]
+    STALKER_wanderers entries: [group, position, anchor, marker, active]
 */
 
 // ["manageWanderers"] call VIC_fnc_debugLog;
@@ -13,9 +13,9 @@ private _groupSize = ["VSA_ambientStalkerSize", 4] call VIC_fnc_getSetting;
 private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 {
-    _x params ["_grp","_pos","_marker","_active"];
+    _x params ["_grp","_pos","_anchor","_marker","_active"];
 
-    private _newActive = [_pos,_range,_active] call VIC_fnc_evalSiteProximity;
+    private _newActive = [_anchor,_range,_active] call VIC_fnc_evalSiteProximity;
 
     if (_newActive) then {
         if (isNull _grp || { count units _grp == 0 }) then {
@@ -162,7 +162,7 @@ private _range = missionNamespace getVariable ["STALKER_activityRadius", 1500];
         if (_marker != "") then { _marker setMarkerAlpha 0.2; };
     };
 
-    STALKER_wanderers set [_forEachIndex, [_grp, _pos, _marker, _newActive]];
+    STALKER_wanderers set [_forEachIndex, [_grp, _pos, _anchor, _marker, _newActive]];
 } forEach STALKER_wanderers;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnAmbientStalkers.sqf
@@ -174,8 +174,8 @@ for "_i" from 1 to _groupCount do {
         [_marker, _pos, "ICON", "mil_dot", "ColorGreen", 0.2] call VIC_fnc_createGlobalMarker;
     };
 
-    [_pos] call VIC_fnc_createProximityAnchor;
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
     STALKER_stalkerGroups pushBack [_grp, _marker];
-    STALKER_wanderers pushBack [_grp, _pos, _marker, true];
+    STALKER_wanderers pushBack [_grp, _pos, _anchor, _marker, true];
 }; 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnSniper.sqf
@@ -39,11 +39,13 @@ _grp createUnit ["O_sniper_F", _spotAGL, [], 0, "FORM"];
 [_grp, _spotAGL, 100, [], true, true, 0, true] call lambs_wp_fnc_taskGarrison;
 [_spotAGL, 6, 0, 4] call VIC_fnc_spawnTripwirePerimeter;
 
+private _anchor = [_spotAGL] call VIC_fnc_createProximityAnchor;
+
 private _marker = "";
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     _marker = format ["snp_%1", diag_tickTime];
     [_marker, _spotAGL, "ICON", "mil_triangle", "ColorRed", 0.6, "Sniper"] call VIC_fnc_createGlobalMarker;
 };
 
-STALKER_snipers pushBack [_grp, _spotAGL, _marker, true];
+STALKER_snipers pushBack [_grp, _spotAGL, _anchor, _marker, true];
 

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -9,7 +9,7 @@ params ["_pos"];
 
 ["spawnStalkerCamp"] call VIC_fnc_debugLog;
 
-[_pos] call VIC_fnc_createProximityAnchor;
+private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
 
 if (!isServer) exitWith {};
 
@@ -210,4 +210,4 @@ if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
     [_marker, _pos, "ICON", "mil_box", _color, 0.2, _faction] call VIC_fnc_createGlobalMarker;
 };
 
-STALKER_camps pushBack [_campfire, _grp, _pos, _marker, _side, _faction, false];
+STALKER_camps pushBack [_campfire, _grp, _pos, _anchor, _marker, _side, _faction, false];

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
@@ -26,7 +26,7 @@ missionNamespace setVariable ["VIC_campManagerRunning", true];
                 if ((count STALKER_camps) == 0) exitWith {};
                 private _idx = floor random (count STALKER_camps);
                 private _camp = STALKER_camps select _idx;
-                _camp params ["_fire","_grp","_pos","_marker"];
+                _camp params ["_fire","_grp","_pos","_anchor","_marker"];
                 if (!isNull _grp) then { { deleteVehicle _x } forEach units _grp; deleteGroup _grp; };
                 if (!isNull _fire) then { deleteVehicle _fire; };
                 if (_marker != "") then { deleteMarker _marker; };

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_manageWrecks.sqf
@@ -29,6 +29,11 @@ for [{_i = (count STALKER_wrecks) - 1}, {_i >= 0}, {_i = _i - 1}] do {
 
     private _site = _veh getVariable ["VIC_wreckSite", getPosATL _veh];
     _veh setVariable ["VIC_wreckSite", _site];
+    private _anchor = _veh getVariable ["VIC_anchor", objNull];
+    if (isNull _anchor) then {
+        _anchor = [_site] call VIC_fnc_createProximityAnchor;
+        _veh setVariable ["VIC_anchor", _anchor];
+    };
 
     if (_veh distance2D _site > 200) then {
         if (!isNil "STALKER_wreckMarkers") then {
@@ -40,7 +45,7 @@ for [{_i = (count STALKER_wrecks) - 1}, {_i >= 0}, {_i = _i - 1}] do {
         continue;
     };
 
-    private _near = [_site, _dist] call VIC_fnc_hasPlayersNearby;
+    private _near = [_anchor, _dist] call VIC_fnc_hasPlayersNearby;
     if (!_near) then {
         deleteVehicle _veh;
         if (!isNil "STALKER_wreckMarkers") then {

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -39,6 +39,8 @@ for "_i" from 1 to _count do {
             _veh setFuel 0;
             _veh lock 2;
             _veh setVariable ["VIC_wreckSite", ASLtoATL _pos];
+            private _anchor = [ASLtoATL _pos] call VIC_fnc_createProximityAnchor;
+            _veh setVariable ["VIC_anchor", _anchor];
             STALKER_wrecks pushBack _veh;
         };
     };


### PR DESCRIPTION
## Summary
- update core proximity eval to accept anchor objects
- store anchors for camps, wanderers, snipers, minefields, traps, ambushes, wrecks and anomaly fields
- use anchors when managing these sites

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/anomalies/fn_setupAnomalyFields.sqf` *(passed)*
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/ambushes/fn_manageAmbushes.sqf` *(passed)*
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/anomalies/fn_cycleAnomalyFields.sqf` *(passed)*
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf` *(passed)*
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf` *(failed: sqflint warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6861fd93bf00832f9b4156cf228c6175