### PR TITLE
Add dedicated bridge anomaly spawner

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ All functions are contained under the `functions` directory and follow the `TAG_
 * **VIC_fnc_spawnAllAnomalyFields** – Spawns anomaly fields at random positions
   across the map, marks them and tracks their lifetime. Missions must call this
   function (or use the provided `initServer.sqf`) to populate the world.
+* **VIC_fnc_spawnBridgeAnomalyFields** – Places bridge-specific anomaly fields on
+  every detected bridge object.
 * **VIC_fnc_cycleAnomalyFields** – Reshuffles stable fields and relocates unstable ones. Useful for testing without a full emission.
 * **VIC_fnc_generateFieldName** – Produces themed names for stable anomaly field markers using local town names when possible.
 

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -149,6 +149,13 @@
     [0, 2000, 200, 0]
 ] call CBA_fnc_addSetting;
 
+["VSA_bridgeFieldRadius",
+ "SLIDER",
+ ["Bridge Field Radius", "Radius of bridge anomaly fields"],
+ "Viceroy's STALKER ALife - Anomalies",
+ [0, 2000, 200, 0]
+] call CBA_fnc_addSetting;
+
 [
     "VSA_anomaliesPerField",
     "SLIDER",

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -186,6 +186,7 @@ class CfgFunctions
         {
             file = "Viceroys-STALKER-ALife\functions\anomalies";
             class spawnAllAnomalyFields{};
+            class spawnBridgeAnomalyFields{};
             class cleanupAnomalyMarkers{};
             class manageAnomalyFields{};
             class startAnomalyManager{};
@@ -261,6 +262,7 @@ class CfgRemoteExec
         class VIC_fnc_spawnValleyChemicalZones { allowedTargets = 2; };
         class VIC_fnc_spawnValleyChemicalFields { allowedTargets = 2; };
         class VIC_fnc_spawnAllAnomalyFields    { allowedTargets = 2; };
+        class VIC_fnc_spawnBridgeAnomalyFields { allowedTargets = 2; };
         class VIC_fnc_cycleAnomalyFields  { allowedTargets = 2; };
         class VIC_fnc_spawnMutantGroup    { allowedTargets = 2; };
         class VIC_fnc_spawnSpookZone      { allowedTargets = 2; };

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf
@@ -33,7 +33,7 @@ if (_count < 0) then {
     _count = round (_count * (_dens / 100));
 };
 
-private _size = ["VSA_anomalyFieldRadius", 200] call VIC_fnc_getSetting;
+private _size = ["VSA_bridgeFieldRadius", 200] call VIC_fnc_getSetting;
 
 if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
 private _markerName = format ["anom_bridge_%1", diag_tickTime];

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf
@@ -109,36 +109,7 @@ for "_i" from 1 to _fieldCount do {
     [format ["spawnAllAnomalyFields: spawned %1 %2", count _spawned, _typeName]] call VIC_fnc_debugLog;
 }; 
 
-// Always place a bridge field on every detected bridge zone
-private _bridges = missionNamespace getVariable ["VIC_cachedBridges", []];
-if (_bridges isEqualTo []) then {
-    _bridges = [] call VIC_fnc_findBridges;
-    missionNamespace setVariable ["VIC_cachedBridges", _bridges];
-};
-{
-    private _pos = getPosATL _x;
-    // skip if field already exists at this bridge
-    private _exists = count (STALKER_anomalyFields select {
-        (_x select 2) == VIC_fnc_createField_bridgeElectra && { (_x select 6) distance2D _pos < 10 }
-    }) > 0;
-    if (_exists) then { continue };
-
-    private _stable = if (_type == -1) then { (random 100) < _stableChance } else { _type == 1 };
-    private _spawned = [_pos, 75, -1, _pos] call VIC_fnc_createField_bridgeElectra;
-    if (_spawned isEqualTo []) then { continue };
-
-    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
-    private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
-    private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
-    if (_marker != "") then {
-        _marker setMarkerBrush "Border";
-        _marker setMarkerAlpha 1;
-        if (_stable) then { _marker setMarkerText (["bridge", _site] call VIC_fnc_generateFieldName); };
-    };
-    private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
-    private _exp = diag_tickTime + (_dur * 60);
-    STALKER_anomalyFields pushBack [_pos,_anchor,75,VIC_fnc_createField_bridgeElectra,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
-    [format ["spawnAllAnomalyFields: spawned %1 bridge", count _spawned]] call VIC_fnc_debugLog;
-} forEach _bridges;
+// Bridges are now spawned via separate helper
+[_type] call VIC_fnc_spawnBridgeAnomalyFields;
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnBridgeAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnBridgeAnomalyFields.sqf
@@ -1,0 +1,47 @@
+/*
+    Spawns bridge electra anomaly fields on every detected bridge.
+    Params:
+        0: NUMBER - forces stable (1) or unstable (0) fields (optional, -1 uses setting)
+*/
+params [["_type", -1]];
+["spawnBridgeAnomalyFields"] call VIC_fnc_debugLog;
+
+// Gather known bridges
+private _bridges = missionNamespace getVariable ["VIC_cachedBridges", []];
+if (_bridges isEqualTo []) then {
+    _bridges = [] call VIC_fnc_findBridges;
+    missionNamespace setVariable ["VIC_cachedBridges", _bridges];
+};
+
+if (isNil "STALKER_anomalyFields") then { STALKER_anomalyFields = [] };
+if (isNil "STALKER_anomalyMarkers") then { STALKER_anomalyMarkers = [] };
+
+private _stableChance = ["VSA_stableFieldChance", 50] call VIC_fnc_getSetting;
+
+{
+    private _pos = getPosATL _x;
+    // Skip if a field already exists for this bridge
+    private _exists = count (STALKER_anomalyFields select {
+        (_x select 3) == VIC_fnc_createField_bridgeElectra && { (_x select 7) distance2D _pos < 10 }
+    }) > 0;
+    if (_exists) then { continue };
+
+    private _stable = if (_type == -1) then { (random 100) < _stableChance } else { _type == 1 };
+    private _spawned = [_pos, 75, -1, _pos] call VIC_fnc_createField_bridgeElectra;
+    if (_spawned isEqualTo []) then { continue };
+
+    private _anchor = [_pos] call VIC_fnc_createProximityAnchor;
+    private _marker = (_spawned select 0) getVariable ["zoneMarker", ""];
+    private _site   = if (_marker isEqualTo "") then { getPosATL (_spawned select 0) } else { getMarkerPos _marker };
+    if (_marker != "") then {
+        _marker setMarkerBrush "Border";
+        _marker setMarkerAlpha 1;
+        if (_stable) then { _marker setMarkerText (["bridge", _site] call VIC_fnc_generateFieldName); };
+    };
+    private _dur = missionNamespace getVariable ["STALKER_AnomalyFieldDuration", 30];
+    private _exp = diag_tickTime + (_dur * 60);
+    STALKER_anomalyFields pushBack [_pos,_anchor,75,VIC_fnc_createField_bridgeElectra,count _spawned,_spawned,_marker,_site,_exp,_stable,false];
+    [format ["spawnBridgeAnomalyFields: spawned %1 bridge", count _spawned]] call VIC_fnc_debugLog;
+} forEach _bridges;
+
+true

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -116,6 +116,7 @@ VIC_fnc_manageChemicalZones     = compile preprocessFileLineNumbers (_root + "\f
 VIC_fnc_spawnZombiesFromQueue    = compile preprocessFileLineNumbers (_root + "\functions\zombification\fn_spawnZombiesFromQueue.sqf");
 VIC_fnc_trackDeadForZombify      = compile preprocessFileLineNumbers (_root + "\functions\zombification\fn_trackDeadForZombify.sqf");
 VIC_fnc_spawnAllAnomalyFields    = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_spawnAllAnomalyFields.sqf");
+VIC_fnc_spawnBridgeAnomalyFields = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_spawnBridgeAnomalyFields.sqf");
 VIC_fnc_cycleAnomalyFields       = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_cycleAnomalyFields.sqf");
 VIC_fnc_cleanupAnomalyMarkers    = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_cleanupAnomalyMarkers.sqf");
 VIC_fnc_manageAnomalyFields     = compile preprocessFileLineNumbers (_root + "\functions\anomalies\fn_manageAnomalyFields.sqf");


### PR DESCRIPTION
## Summary
- add new function `spawnBridgeAnomalyFields` to spawn bridge electra fields
- use new `VSA_bridgeFieldRadius` setting for bridge field size
- expose new setting in `cba_settings.sqf`
- register bridge spawner in config and master init
- update README
- call bridge spawner from `spawnAllAnomalyFields`

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/cba_settings.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fields/fn_createField_bridgeElectra.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnAllAnomalyFields.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnBridgeAnomalyFields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_686214c931ac832fa2dcad0d7914ebaa