### PR TITLE
Fix bridge anomaly comparison

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnBridgeAnomalyFields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnBridgeAnomalyFields.sqf
@@ -22,7 +22,7 @@ private _stableChance = ["VSA_stableFieldChance", 50] call VIC_fnc_getSetting;
     private _pos = getPosATL _x;
     // Skip if a field already exists for this bridge
     private _exists = count (STALKER_anomalyFields select {
-        (_x select 3) == VIC_fnc_createField_bridgeElectra && { (_x select 7) distance2D _pos < 10 }
+        (_x select 3) isEqualTo VIC_fnc_createField_bridgeElectra && { (_x select 7) distance2D _pos < 10 }
     }) > 0;
     if (_exists) then { continue };
 


### PR DESCRIPTION
## Summary
- fix equality check when searching for bridge anomaly fields

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/anomalies/fn_spawnBridgeAnomalyFields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68626da37e3c832f81ba593f95557b66