### PR TITLE
Disable all auto marker placement

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -87,36 +87,7 @@ if (isNil {_habData} || {_habData isEqualTo []}) then {
 
 // Automatically display cached points when debug mode is active
 if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
-    [] remoteExec ["VIC_fnc_markRockClusters", 0];
-    [format ["initMap: placed %1 rock cluster markers", count STALKER_rockClusterMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markSniperSpots", 0];
-    [format ["initMap: placed %1 sniper spot markers", count STALKER_sniperSpotMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markSwamps", 0];
-    [format ["initMap: placed %1 swamp markers", count STALKER_swampMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markBeaches", 0];
-    [format ["initMap: placed %1 beach markers", count STALKER_beachMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markValleys", 0];
-    [format ["initMap: placed %1 valley markers", count STALKER_valleyMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markLandZones", 0];
-    [format ["initMap: placed %1 land zone markers", count STALKER_landZoneMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markBuildingClusters", 0];
-    [format ["initMap: placed %1 building cluster markers", count STALKER_buildingClusterMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markBridges", 0];
-    [format ["initMap: placed %1 bridge markers", count STALKER_bridgeMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markRoads", 0];
-    [format ["initMap: placed %1 road markers", count STALKER_roadMarkers]] call VIC_fnc_debugLog;
-    [format ["initMap: placed %1 crossroad markers", count STALKER_crossroadMarkers]] call VIC_fnc_debugLog;
-
-    [] remoteExec ["VIC_fnc_markWrecks", 0];
-    [format ["initMap: placed %1 wreck markers", count STALKER_wreckMarkers]] call VIC_fnc_debugLog;
+    // Marker autogeneration disabled in production. Use placeCachedMarkers for debugging.
 };
 
 "STALKER ALife initialization complete" remoteExec ["hint", 0];


### PR DESCRIPTION
## Summary
- remove automatic marker placement for every cached map node
- restore the `placeCachedMarkers` function so all marker types can be spawned manually for debugging

## Testing
- `bash scripts/sqflint-hook.sh $(git ls-files '*.sqf')`


------
https://chatgpt.com/codex/tasks/task_e_6862708e6608832fa9ffabeb549fa779