### PR TITLE
Enable autoinit by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    * [Chemical Warfare Plus](https://steamcommunity.com/sharedfiles/filedetails/?id=3295358796)
    * [Necroplague](https://steamcommunity.com/workshop/filedetails/?id=2616555444)
 3. Review `cba_settings.sqf` for adjustable options such as the player nearby range and activity zone depth used by many systems.
-4. Enable **VSA_autoInit** if you want the world to populate automatically on mission start. When enabled, all managers (minefields, IEDs, ambushes, snipers, anomaly fields and camps) start on their own. When disabled, use the debug actions to spawn systems manually.
+4. **VSA_autoInit** is enabled by default so the world populates automatically on mission start. All managers (minefields, IEDs, ambushes, snipers, anomaly fields and camps) start on their own. Disable this option if you prefer to spawn systems manually via debug actions.
 5. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    The activity grid overlay now refreshes automatically while this mode is active.
    This option can now be toggled while a mission is running and the debug

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -37,7 +37,7 @@
     "CHECKBOX",
     ["Automatically Initialize", "Populate the world and start managers on mission start"],
     "Viceroy's STALKER ALife - Core",
-    false
+    true
 ] call CBA_fnc_addSetting;
 
 [


### PR DESCRIPTION
## Summary
- default `VSA_autoInit` CBA setting to `true`
- update README to reflect auto initialization is now enabled by default

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6862838d7934832fa092ba73ef5223fe