### PR TITLE
Cache building cluster positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Camps are distributed across building clusters all over the map and only activate when players come close.
 * Camps may belong to BLUFOR, OPFOR or Independent factions based on configurable chances.
 * Group counts and sizes are fully adjustable through CBA settings.
+* Cached building clusters now store positions so camp searches survive across sessions.
 
 ### Chemical Zones
 * Randomly creates chemical gas zones that damage unprotected units.

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf
@@ -8,7 +8,7 @@
         3: SCALAR - Grid step for scanning (default: 500m)
 
     Returns:
-        ARRAY of ARRAYs - Each subarray is a cluster of building OBJECTS
+        ARRAY of ARRAYs - Each subarray is a cluster of building POSITIONS
 */
 
 params [["_minBuildings", 3], ["_clusterRadius", 40], ["_townClearDist", 1000], ["_step", 500]];
@@ -42,7 +42,7 @@ for "_px" from 0 to worldSize step _step do {
         };
 
         if ((count _realBuildings) >= _minBuildings) then {
-            _clusters pushBack _realBuildings;
+            _clusters pushBack (_realBuildings apply { getPosATL _x });
         };
     };
 };

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -63,11 +63,12 @@ if (isNil {_crossroads} || {_crossroads isEqualTo []}) then {
     ["STALKER_crossroads", _crossroads] call VIC_fnc_saveCache;
 };
 
-private _bClusters = ["STALKER_buildingClusters"] call VIC_fnc_loadCache;
-if (isNil {_bClusters} || {_bClusters isEqualTo []}) then {
-    _bClusters = [] call VIC_fnc_findBuildingClusters;
-    ["STALKER_buildingClusters", _bClusters] call VIC_fnc_saveCache;
-};
+// Building clusters are cached as arrays of positions
+private _bClusterPositions = ["STALKER_buildingClusters"] call VIC_fnc_loadCache;
+if (isNil {_bClusterPositions} || {_bClusterPositions isEqualTo []}) then {
+    _bClusterPositions = [] call VIC_fnc_findBuildingClusters;
+    ["STALKER_buildingClusters", _bClusterPositions] call VIC_fnc_saveCache;
+}; 
 
 private _wrecks = ["STALKER_wrecks"] call VIC_fnc_loadCache;
 if (isNil {_wrecks} || {_wrecks isEqualTo []}) then {

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf
@@ -23,7 +23,7 @@ private _clusters = STALKER_buildingClusters;
 
 {
     {
-        private _pos = getPosATL _x;
+        private _pos = _x;
         private _name = format ["bcl_%1", diag_tickTime + random 1000];
         private _marker = [_name, _pos, "ICON", "mil_objective", "#(0,0,1,1)", 1, "", [1,1], _global] call VIC_fnc_createGlobalMarker;
         STALKER_buildingClusterMarkers pushBack _marker;

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
@@ -22,8 +22,9 @@ if (_clusters isEqualTo []) exitWith { objNull };
 private _candidates = [];
 {
     {
-        if (count (_x buildingPos -1) >= _minPos) then {
-            _candidates pushBack _x;
+        private _building = nearestObject [_x, "House"];
+        if (!isNull _building && {count (_building buildingPos -1) >= _minPos}) then {
+            _candidates pushBack _building;
         };
     } forEach _x;
 } forEach _clusters;


### PR DESCRIPTION
## Summary
- save building cluster positions instead of objects
- load clusters as positions during map init
- convert camp building search to use position data
- mark clusters by position for debugging
- document persistent building clusters

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_findBuildingClusters.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_markBuildingClusters.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6862870fa584832fa46ecaa07fb70424