### PR TITLE
Ensure roads used for site and wreck spawns

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/ambushes/fn_spawnAmbushes.sqf
@@ -30,7 +30,6 @@ for "_i" from 1 to _count do {
 
     for "_j" from 1 to 30 do {
         private _candidate = [_center, _radius, 5] call VIC_fnc_findRoadPosition;
-        if (isNil {_candidate}) then { continue; };
 
         private _locations = nearestLocations [
             _candidate,

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoadPosition.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_findRoadPosition.sqf
@@ -10,22 +10,15 @@
         POSITION - Road position [x, y, z], or nil if none found
 */
 params ["_centerPos", ["_radius", 300], ["_maxTries", 20]];
+_maxTries; // parameter kept for backward compatibility
 
 if (isNil "STALKER_roads" || { STALKER_roads isEqualTo [] }) then {
     STALKER_roads = [] call VIC_fnc_findRoads;
 };
 
-private _attempt = 0;
+private _roads = STALKER_roads select { _x distance2D _centerPos <= _radius };
+if (!(_roads isEqualTo [])) exitWith { selectRandom _roads };
 
-while { _attempt < _maxTries } do {
-    private _angle = random 360;
-    private _dist  = random _radius;
+[] call VIC_fnc_getRandomRoad
 
-    private _candidatePos = _centerPos getPos [_dist, _angle];
-    private _roads = STALKER_roads select { _x distance2D _candidatePos < 50 };
-    if (!(_roads isEqualTo [])) exitWith { selectRandom _roads };
 
-    _attempt = _attempt + 1;
-};
-
-nil

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_getRandomRoad.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_getRandomRoad.sqf
@@ -1,0 +1,12 @@
+/*
+    Returns a random cached road position, populating the cache if required.
+
+    Returns:
+        POSITION - road position [x, y, z]
+*/
+
+if (isNil "STALKER_roads" || { STALKER_roads isEqualTo [] }) then {
+    STALKER_roads = [] call VIC_fnc_findRoads;
+};
+
+selectRandom STALKER_roads

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_masterInit.sqf
@@ -230,6 +230,7 @@ VIC_fnc_findLandPos = compile preprocessFileLineNumbers (_root + "\functions\cor
 VIC_fnc_getLandSurfacePosition  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_getLandSurfacePosition.sqf");
 VIC_fnc_findRoadPosition        = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRoadPosition.sqf");
 VIC_fnc_findRandomRoadPosition  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_findRandomRoadPosition.sqf");
+VIC_fnc_getRandomRoad           = compile preprocessFileLineNumbers (_root + "\functions\core\fn_getRandomRoad.sqf");
 VIC_fnc_evalSiteProximity      = compile preprocessFileLineNumbers (_root + "\functions\core\fn_evalSiteProximity.sqf");
 VIC_fnc_createProximityAnchor  = compile preprocessFileLineNumbers (_root + "\functions\core\fn_createProximityAnchor.sqf");
 VIC_fnc_spawnAmbientStalkers   = compile preprocessFileLineNumbers (_root + "\functions\stalkers\fn_spawnAmbientStalkers.sqf");

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnIEDSites.sqf
@@ -29,7 +29,6 @@ for "_i" from 1 to _count do {
     private _pos = [];
     if (_useFallback) then {
         _pos = [_center, _radius, 20] call VIC_fnc_findRoadPosition;
-        if (isNil {_pos}) then { _pos = [_radius,20] call VIC_fnc_findRandomRoadPosition; };
     } else {
         private _town = selectRandom _towns;
         private _tPos = locationPosition _town;

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf
@@ -20,28 +20,19 @@ private _classes = [
 ];
 
 for "_i" from 1 to _count do {
-    private _base = [random worldSize, random worldSize, 0];
-    private _road = roadAt _base;
-    if (isNull _road) then {
-        private _roads = _base nearRoads 50;
-        if ((count _roads) > 0) then { _road = _roads select 0; };
-    };
-
-    if (!isNull _road) then {
-        private _pos = getPos _road;
-        _pos = _pos getPos [2 + random 3, random 360];
-        _pos = [_pos] call VIC_fnc_getLandSurfacePosition;
-        if !(_pos isEqualTo []) then {
-            private _veh = createVehicle [selectRandom _classes, ASLtoATL _pos, [], 0, "CAN_COLLIDE"];
-            _veh setPosATL (ASLtoATL _pos);
-            _veh setVectorUp surfaceNormal (ASLtoATL _pos);
-            _veh setDamage (0.3 + random 0.7);
-            _veh setFuel 0;
-            _veh lock 2;
-            _veh setVariable ["VIC_wreckSite", ASLtoATL _pos];
-            private _anchor = [ASLtoATL _pos] call VIC_fnc_createProximityAnchor;
-            _veh setVariable ["VIC_anchor", _anchor];
-            STALKER_wrecks pushBack _veh;
-        };
+    private _roadPos = [] call VIC_fnc_getRandomRoad;
+    private _pos = _roadPos getPos [2 + random 3, random 360];
+    _pos = [_pos] call VIC_fnc_getLandSurfacePosition;
+    if !(_pos isEqualTo []) then {
+        private _veh = createVehicle [selectRandom _classes, ASLtoATL _pos, [], 0, "CAN_COLLIDE"];
+        _veh setPosATL (ASLtoATL _pos);
+        _veh setVectorUp surfaceNormal (ASLtoATL _pos);
+        _veh setDamage (0.3 + random 0.7);
+        _veh setFuel 0;
+        _veh lock 2;
+        _veh setVariable ["VIC_wreckSite", ASLtoATL _pos];
+        private _anchor = [ASLtoATL _pos] call VIC_fnc_createProximityAnchor;
+        _veh setVariable ["VIC_anchor", _anchor];
+        STALKER_wrecks pushBack _veh;
     };
 };


### PR DESCRIPTION
## Summary
- add `fn_getRandomRoad` helper to pull cached road spots
- simplify `fn_findRoadPosition` to use cached roads with fallback
- call the new road search logic from IED site, ambush, and wreck spawns
- register helper in `fn_masterInit`

## Testing
- `pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_68628727f5b4832fb84f660ee09f2984