### PR TITLE
Make IEDs use real mines

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -21,7 +21,7 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
                 "APERSMine"
             };
             private _type = selectRandom [_tripMine, "IEDUrbanSmall_F"];
-            private _mine = createVehicle [_type, _pos, [], 0, "CAN_COLLIDE"];
+            private _mine = createMine [_type, _pos, [], 0];
             _objs = [_mine];
         };
         if (_marker != "") then { _marker setMarkerAlpha 1; };

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf
@@ -14,7 +14,7 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
     private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (isNull _obj) then {
-            _obj = createVehicle ["IEDUrbanSmall_F", _pos, [], 0, "CAN_COLLIDE"];
+            _obj = createMine ["IEDUrbanSmall_F", _pos, [], 0];
             _obj setVariable ["VIC_iedIndex", _forEachIndex];
             _obj addEventHandler ["Deleted", {
                 params ["_mine"];
@@ -51,7 +51,7 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 // Maintain site count
 private _target = ["VSA_IEDSiteCount",10] call VIC_fnc_getSetting;
 while { count STALKER_iedSites < _target } do {
-    private _c = [ [worldSize/2, worldSize/2, 0], worldSize, 1 ] call VIC_fnc_spawnIEDSites;
+    [ [worldSize/2, worldSize/2, 0], worldSize, 1 ] call VIC_fnc_spawnIEDSites;
 };
 
 true


### PR DESCRIPTION
## Summary
- spawn real IED mines in site manager
- spawn real mines for booby traps

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68629842437c832f993bb365e77ada71