### PR TITLE
Enable all managers at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    * [Chemical Warfare Plus](https://steamcommunity.com/sharedfiles/filedetails/?id=3295358796)
    * [Necroplague](https://steamcommunity.com/workshop/filedetails/?id=2616555444)
 3. Review `cba_settings.sqf` for adjustable options such as the player nearby range and activity zone depth used by many systems.
-4. **VSA_autoInit** is enabled by default so the world populates automatically on mission start. All managers (minefields, IEDs, ambushes, snipers, anomaly fields and camps) start on their own. Disable this option if you prefer to spawn systems manually via debug actions.
+4. **VSA_autoInit** is enabled by default so the world populates automatically on mission start. All managers (minefields, IEDs, ambushes, snipers, anomaly fields, camps, chemical zones and mutants) start on their own. Disable this option if you prefer to spawn systems manually via debug actions.
 5. Enable **VSA_debugMode** to show on-screen debug messages and access testing actions.
    The activity grid overlay now refreshes automatically while this mode is active.
    This option can now be toggled while a mission is running and the debug

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf
@@ -36,6 +36,22 @@ if !( ["VSA_autoInit", false] call VIC_fnc_getSetting ) exitWith {
     };
 };
 [] spawn {
+    while { true } do {
+        [] call VIC_fnc_manageChemicalZones;
+        sleep 6;
+    };
+};
+[] spawn {
+    while { true } do {
+        [] call VIC_fnc_manageHabitats;
+        [] call VIC_fnc_manageHerds;
+        [] call VIC_fnc_manageHostiles;
+        [] call VIC_fnc_manageNests;
+        [] call VIC_fnc_managePredators;
+        sleep 6;
+    };
+};
+[] spawn {
     sleep 8;
     while { true } do {
         [] call VIC_fnc_updateProximity;


### PR DESCRIPTION
## Summary
- run chemical and mutant management loops when auto init is enabled
- note new managers in README

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_initManagers.sqf README.md`

------
https://chatgpt.com/codex/tasks/task_e_6862a7815020832f869b87b3e302c106