### PR TITLE
Cache wreck positions only

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Drongo’s system adds creepy events such as ghostly whispers or sudden darkenin
    actions will appear automatically.
 6. When debug mode is active, your scroll menu includes options to trigger storms, spawn stable or unstable anomaly fields, cycle existing fields, spawn spook zones, spawn ambient herds, place booby traps in town buildings, summon predator attacks, trigger AI panic or reset their behaviour, and other test helpers. All spawn actions run on the server so they work correctly in multiplayer. Stable fields will show a randomly generated name on their marker for easy reference.
 7. Use the **Mark All Buildings**, **Mark Bridges** and **Mark Roads** actions from this menu if you need to visualize these objects. Road markers now highlight crossroads as well. Buildings are no longer marked automatically when debug mode is enabled.
-8. **Cache Map Wrecks** to collect all wreck objects placed on the map, including models whose path contains "wrecks". This action populates `STALKER_wrecks` for other functions.
+8. **Cache Map Wrecks** to record the positions of all map wrecks. These
+   positions are stored in `STALKER_wreckPositions` so wreck objects can be
+   located again on future missions.
 9. Additional **Cache** actions can store sniper spots, roads, crossroads, bridges, valleys, beach sites and swamps for quick access by other scripts.
 10. **Regenerate Map Points** to forcibly rescan the entire map and update caches, ignoring any previously saved data.
 

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf
@@ -70,11 +70,22 @@ if (isNil {_bClusterPositions} || {_bClusterPositions isEqualTo []}) then {
     ["STALKER_buildingClusters", _bClusterPositions] call VIC_fnc_saveCache;
 }; 
 
-private _wrecks = ["STALKER_wrecks"] call VIC_fnc_loadCache;
-if (isNil {_wrecks} || {_wrecks isEqualTo []}) then {
-    _wrecks = [] call VIC_fnc_findWrecks;
-    ["STALKER_wrecks", _wrecks] call VIC_fnc_saveCache;
+private _wreckPositions = ["STALKER_wreckPositions"] call VIC_fnc_loadCache;
+if (isNil {_wreckPositions} || {_wreckPositions isEqualTo []}) then {
+    _wreckPositions = [] call VIC_fnc_findWrecks;
+    ["STALKER_wreckPositions", _wreckPositions] call VIC_fnc_saveCache;
 };
+if (isNil "STALKER_wrecks") then { STALKER_wrecks = []; };
+{
+    private _near = nearestObjects [_x, ["AllVehicles","Static"], 5];
+    {
+        private _type = toLower typeOf _x;
+        private _model = toLower ((getModelInfo _x) select 0);
+        if ((_type find "wreck" > -1) || { _model find "wrecks" > -1 }) exitWith {
+            STALKER_wrecks pushBackUnique _x;
+        };
+    } forEach _near;
+} forEach _wreckPositions;
 
 // Load or generate mutant habitats
 private _habData = ["STALKER_mutantHabitatData"] call VIC_fnc_loadCache;

--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf
@@ -36,8 +36,8 @@ private _crossroads = [] call VIC_fnc_findCrossroads;
 private _bClusters = [] call VIC_fnc_findBuildingClusters;
 ["STALKER_buildingClusters", _bClusters] call VIC_fnc_saveCache;
 
-private _wrecks = [] call VIC_fnc_findWrecks;
-["STALKER_wrecks", _wrecks] call VIC_fnc_saveCache;
+private _wreckPositions = [] call VIC_fnc_findWrecks;
+["STALKER_wreckPositions", _wreckPositions] call VIC_fnc_saveCache;
 
 "Map points regenerated" remoteExec ["hint", 0];
 

--- a/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf
@@ -1,7 +1,8 @@
 /*
-    Scans the map for wreck objects and stores them in STALKER_wrecks
-    for use by other functions.
-    Returns: ARRAY of wreck objects found
+    Scans the map for wreck objects. Object references are stored in
+    STALKER_wrecks for runtime use while their positions are returned and
+    cached for persistence.
+    Returns: ARRAY of POSITIONs
 */
 
 ["findWrecks"] call VIC_fnc_debugLog;
@@ -18,8 +19,16 @@ private _found = _objs select {
 };
 
 if (isNil "STALKER_wrecks") then { STALKER_wrecks = [] };
-{ STALKER_wrecks pushBackUnique _x } forEach _found;
+if (isNil "STALKER_wreckPositions") then { STALKER_wreckPositions = [] };
 
-[format ["findWrecks: %1 wrecks cached", count _found]] call VIC_fnc_debugLog;
+private _positions = [];
+{
+    STALKER_wrecks pushBackUnique _x;
+    private _pos = getPosATL _x;
+    _positions pushBackUnique _pos;
+    STALKER_wreckPositions pushBackUnique _pos;
+} forEach _found;
 
-_found
+[format ["findWrecks: %1 wrecks cached", count _positions]] call VIC_fnc_debugLog;
+
+_positions


### PR DESCRIPTION
## Summary
- avoid persisting object references to profileNamespace
- store wreck positions instead of vehicles
- rebuild wreck objects from saved positions on init
- fix to keep abandoned vehicles out of cached wreck positions

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/functions/wrecks/fn_spawnAbandonedVehicles.sqf addons/Viceroys-STALKER-ALife/functions/wrecks/fn_findWrecks.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_initMap.sqf addons/Viceroys-STALKER-ALife/functions/core/fn_regenMapPoints.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6862aa51bd68832f92c5030d703c4e7d