### PR TITLE
Adjust minefields to circular radius

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The goal of this mod is to add atmosphere and unpredictable encounters to missio
 * Cleanup functions remove old zones to keep performance reasonable.
 
 ### Minefields
-* Generates APERS minefields on town outskirts and single IEDs on roads.
+* Generates APERS minefields on town outskirts and single IEDs on roads. Fields are now circular with a configurable radius.
 * Mines despawn when no players are nearby and respawn when someone approaches.
 * Enable debug mode to visualize fields and place test minefields via the action menu. Ambush sites can also be spawned this way.
 * When debug mode is enabled the activity grid overlay automatically refreshes on the map, filling each grid block with 20% opacity: yellow for active squares and red for inactive ones.

--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -808,9 +808,9 @@ true
 [
     "VSA_minefieldSize",
     "SLIDER",
-    ["APERS Field Size", "Side length in meters for APERS minefields"],
+    ["APERS Field Radius", "Radius in meters for APERS minefields"],
     "Viceroy's STALKER ALife - Minefields",
-    [10, 100, 30, 0]
+    [10, 200, 30, 0]
 ] call CBA_fnc_addSetting;
 
 [

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf
@@ -1,23 +1,23 @@
 /*
-    Spawns a square APERS minefield.
+    Spawns a circular APERS minefield.
     Params:
         0: POSITION - center position
-        1: NUMBER   - side length in meters (default 30)
+        1: NUMBER   - radius in meters (default 30)
     Returns:
         ARRAY - spawned mine objects
 */
-params ["_center", ["_size",30]];
+params ["_center", ["_radius",30]];
 
 ["spawnAPERSField"] call VIC_fnc_debugLog;
 
 if (!isServer) exitWith { [] };
 
 private _objs = [];
-private _half = _size / 2;
 private _spacing = 5;
 
-for "_xOff" from -_half to _half step _spacing do {
-    for "_yOff" from -_half to _half step _spacing do {
+for "_xOff" from -_radius to _radius step _spacing do {
+    for "_yOff" from -_radius to _radius step _spacing do {
+        if ((_xOff * _xOff + _yOff * _yOff) > (_radius * _radius)) then { continue; };
         private _pos = [(_center select 0) + _xOff, (_center select 1) + _yOff, 0];
         _pos = [_pos] call VIC_fnc_findLandPos;
         if (isNil {_pos} || {_pos isEqualTo []}) then { continue; };

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf
@@ -51,8 +51,8 @@ for "_i" from 1 to _fieldCount do {
     private _marker = "";
     if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         _marker = format ["mf_%1", diag_tickTime];
-        [_marker, _pos, "RECTANGLE", "", "#(1,1,0,1)", 0.2, "APERS Field"] call VIC_fnc_createGlobalMarker;
-        _marker setMarkerSize [_size/2, _size/2];
+        [_marker, _pos, "ELLIPSE", "", "#(1,1,0,1)", 0.2, "APERS Field"] call VIC_fnc_createGlobalMarker;
+        _marker setMarkerSize [_size, _size];
     };
     STALKER_minefields pushBack [_pos,_anchor,"APERS",_size,[],_marker,false];
     _fieldsSpawned = _fieldsSpawned + 1;


### PR DESCRIPTION
## Summary
- make APERS minefields circular instead of square
- show circular debug markers
- increase APERS field size slider maximum to 200 and rename to radius
- document circular radius in README

## Testing
- `pre-commit run --files README.md addons/Viceroys-STALKER-ALife/cba_settings.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnAPERSField.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_spawnMinefields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6862cfcb617c832fb618f5a7d8373272