### PR TITLE
Fix minefield/boobytrap proximity

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf
@@ -4,9 +4,9 @@
     are beyond the activation range plus 200 meters.
 
     Params:
-        0: OBJECT   - proximity anchor for the site
-        1: NUMBER   - activation range in meters
-        2: BOOL     - current active state
+        0: OBJECT or POSITION - anchor object or site position
+        1: NUMBER            - activation range in meters
+        2: BOOL              - current active state
 
     Returns: BOOL - updated active state
 */

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf
@@ -1,6 +1,8 @@
 /*
     Activates or deactivates booby traps based on player proximity.
     STALKER_boobyTraps entries: [position, anchor, objects, marker, active]
+    Proximity checks use the stored position so anchors are not required
+    after initial placement.
 */
 // ["manageBoobyTraps"] call VIC_fnc_debugLog;
 
@@ -11,7 +13,9 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 {
     _x params ["_pos","_anchor","_objs","_marker",["_active",false]];
-    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
+    // Rely on the stored position instead of the anchor object so traps remain
+    // functional if the anchor is removed
+    private _newActive = [_pos,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (!_active) then {
             // Spawn tripwire or fallback APERS mine vehicles

--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf
@@ -1,6 +1,8 @@
 /*
     Activates or deactivates minefields based on player proximity.
     STALKER_minefields entries: [center, anchor, type, size, objects, marker, active]
+    The stored position is used for proximity checks so the anchor object is
+    optional and only kept for debugging purposes.
 */
 // ["manageMinefields"] call VIC_fnc_debugLog;
 
@@ -11,7 +13,9 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 
 {
     _x params ["_center","_anchor","_type","_size","_objs","_marker",["_active",false]];
-    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
+    // Use the stored position rather than the anchor object so proximity works
+    // even if the logic was deleted
+    private _newActive = [_center,_dist,_active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (!_active) then {
             _objs = switch (_type) do {


### PR DESCRIPTION
## Summary
- clarify that `fn_evalSiteProximity` accepts either a position or an object
- make minefields and booby traps evaluate proximity using the stored position

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/core/fn_evalSiteProximity.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageBoobyTraps.sqf addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageMinefields.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6862dc1deca0832fa1be816e970b5122