### PR TITLE
Fix IED site cleanup handler

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf
@@ -21,7 +21,7 @@ private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
                 private _idx = _mine getVariable ["VIC_iedIndex", -1];
                 if (_idx > -1 && {!isNil "STALKER_iedSites"}) then { STALKER_iedSites deleteAt _idx; };
             }];
-            _obj addEventHandler ["Killed", {
+            _obj addEventHandler ["Explosion", {
                 params ["_mine"];
                 private _idx = _mine getVariable ["VIC_iedIndex", -1];
                 if (_idx > -1 && {!isNil "STALKER_iedSites"}) then { STALKER_iedSites deleteAt _idx; };


### PR DESCRIPTION
## Summary
- fix IED cleanup when mines explode

## Testing
- `sqflint addons/Viceroys-STALKER-ALife/functions/minefields/fn_manageIEDSites.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6862fb4a4f1c832fa53748c835c212e6