### PR TITLE
Fix flare tripwire creation

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnFlareTripwires.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnFlareTripwires.sqf
@@ -27,7 +27,8 @@ for "_i" from 0 to (_count - 1) do {
     } else {
         "APERSMine"
     };
-    private _mine = createVehicle [_mineType, _pos, [], 0, "CAN_COLLIDE"];
+    // Use createMine so the Explosion event handler registers correctly
+    private _mine = createMine [_mineType, _pos, [], 0];
     _mine setDir ([_pos, _center] call BIS_fnc_dirTo);
     _mine addEventHandler ["Explosion", { "F_40mm_White" createVehicle getPosATL (_this select 0); }];
     _objs pushBack _mine;


### PR DESCRIPTION
## Summary
- make flare tripwire use `createMine`

## Testing
- `scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnFlareTripwires.sqf`


------
https://chatgpt.com/codex/tasks/task_e_6862ff8a48c8832fa0dc793058deb8ee