### PR TITLE
Enable camp removal in camp manager

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -11,9 +11,10 @@ if (isNil "STALKER_camps") exitWith {};
 private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
 
-{
-    _x params ["_camp", "_grp", "_pos", "_anchor", "_marker", "_side", "_faction",["_active",false]];
-    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
+for [{_i = (count STALKER_camps) - 1}, {_i >= 0}, {_i = _i - 1}] do {
+    private _entry = STALKER_camps select _i;
+    _entry params ["_camp", "_grp", "_pos", "_anchor", "_marker", "_side", "_faction", ["_active", false]];
+    private _newActive = [_anchor, _dist, _active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (isNull _camp) then {
             // Spawn the campfire a few meters away from the building
@@ -201,7 +202,13 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
     if (_marker != "") then {
         [_marker, (if (_newActive) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
     };
-    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _anchor, _marker, _side, _faction, _newActive]];
-} forEach STALKER_camps;
+
+    if (!_newActive && {isNull _grp && {isNull _camp}}) then {
+        if (_marker != "") then { deleteMarker _marker; };
+        STALKER_camps deleteAt _i;
+    } else {
+        STALKER_camps set [_i, [_camp, _grp, _pos, _anchor, _marker, _side, _faction, _newActive]];
+    };
+};
 
 true


### PR DESCRIPTION
## Summary
- allow deletion of camps by looping in reverse
- drop cleared camps when nothing is left

## Testing
- `./scripts/sqflint-hook.sh addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf`

------
https://chatgpt.com/codex/tasks/task_e_6864332e3f14832fb3a01adce12385bb