### PR TITLE
Fix debug camp markers and remove stale entries

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf
@@ -11,9 +11,9 @@ if (isNil "STALKER_camps") exitWith {};
 private _dist = missionNamespace getVariable ["STALKER_activityRadius", 1500];
 private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
 
-{
-    _x params ["_camp", "_grp", "_pos", "_anchor", "_marker", "_side", "_faction",["_active",false]];
-    private _newActive = [_anchor,_dist,_active] call VIC_fnc_evalSiteProximity;
+for "_i" from ((count STALKER_camps) - 1) to 0 step -1 do {
+    STALKER_camps select _i params ["_camp", "_grp", "_pos", "_anchor", "_marker", "_side", "_faction", ["_active", false]];
+    private _newActive = [_anchor, _dist, _active] call VIC_fnc_evalSiteProximity;
     if (_newActive) then {
         if (isNull _camp) then {
             // Spawn the campfire a few meters away from the building
@@ -201,7 +201,13 @@ private _size = ["VSA_stalkerCampSize", 4] call VIC_fnc_getSetting;
     if (_marker != "") then {
         [_marker, (if (_newActive) then {1} else {0.2})] remoteExec ["setMarkerAlpha", 0];
     };
-    STALKER_camps set [_forEachIndex, [_camp, _grp, _pos, _anchor, _marker, _side, _faction, _newActive]];
-} forEach STALKER_camps;
+
+    if (!_newActive && { isNull _grp && { isNull _camp } }) then {
+        if (_marker != "") then { [_marker] remoteExec ["deleteMarker", 0]; };
+        STALKER_camps deleteAt _i;
+    } else {
+        STALKER_camps set [_i, [_camp, _grp, _pos, _anchor, _marker, _side, _faction, _newActive]];
+    };
+};
 
 true

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf
@@ -220,7 +220,7 @@ if (["VSA_debugMode", false] call VIC_fnc_getSetting) then {
         case "Monolith": {VIC_colorMonolith};
         default {"#(1,1,1,1)"};
     };
-    [_marker, _pos, "ICON", "mil_box", _color, 0.2, _faction] call VIC_fnc_createGlobalMarker;
+    [_marker, _pos, "ICON", "mil_box", _color, 0.2, _faction, [1,1], true] call VIC_fnc_createGlobalMarker;
 };
 
 STALKER_camps pushBack [_campfire, _grp, _pos, _anchor, _marker, _side, _faction, false];


### PR DESCRIPTION
## Summary
- purge inactive camp entries when no group or camp exists
- create camp debug markers on all clients when debug mode is active

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/stalkers/fn_manageStalkerCamps.sqf addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68642b8f57c4832fbdb41ab898b6659f