### PR TITLE
Add debug log for mutant spawns

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_initMutantUnit.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_initMutantUnit.sqf
@@ -16,4 +16,7 @@ if (isClass (configFile >> "CfgPatches" >> "lambs_danger")) then {
     _unit setVariable ["lambs_danger_disableAI", true];
 };
 
+// Log the spawn for troubleshooting
+[format ["initMutantUnit: spawned %1 at %2", typeOf _unit, getPosWorld _unit]] call VIC_fnc_debugLog;
+
 true


### PR DESCRIPTION
## Summary
- log when each mutant unit is initialized to help debug spawn crashes

## Testing
- `pre-commit run --files addons/Viceroys-STALKER-ALife/functions/mutants/fn_initMutantUnit.sqf`

------
https://chatgpt.com/codex/tasks/task_e_686434f0ab5c832f9b77e2e8039f0fa7