### PR TITLE
Fix camp spawning and add cooldown

### DIFF
--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf
@@ -16,6 +16,9 @@ if (_minPos < 0) then {
 
 ["findCampBuilding"] call VIC_fnc_debugLog;
 
+if (isNil "STALKER_campCooldowns") then { STALKER_campCooldowns = [] };
+STALKER_campCooldowns = STALKER_campCooldowns select { diag_tickTime - (_x select 1) < 300 };
+
 private _clusters = missionNamespace getVariable ["STALKER_buildingClusters", []];
 if (_clusters isEqualTo []) exitWith { objNull };
 
@@ -24,7 +27,12 @@ private _candidates = [];
     {
         private _building = nearestObject [_x, "House"];
         if (!isNull _building && {count (_building buildingPos -1) >= _minPos}) then {
-            _candidates pushBack _building;
+            private _onCooldown = false;
+            {
+                _x params ["_p","_t"];
+                if (_p distance _building < 5 && {diag_tickTime - _t < 300}) exitWith { _onCooldown = true };
+            } forEach STALKER_campCooldowns;
+            if (!_onCooldown) then { _candidates pushBack _building; };
         };
     } forEach _x;
 } forEach _clusters;

--- a/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf
@@ -11,6 +11,7 @@ if (missionNamespace getVariable ["VIC_campManagerRunning", false]) exitWith {};
 missionNamespace setVariable ["VIC_campManagerRunning", true];
 
 [] spawn {
+    missionNamespace setVariable ["VIC_lastCampSpawnAttempt", 0];
     while { missionNamespace getVariable ["VIC_campManagerRunning", false] } do {
         // Update existing camps based on player proximity
         [] call VIC_fnc_manageStalkerCamps;
@@ -34,14 +35,18 @@ missionNamespace setVariable ["VIC_campManagerRunning", true];
             };
         };
 
-        if ((count STALKER_camps) < _min) then {
-            private _needed = _min - (count STALKER_camps);
-            for "_i" from 1 to _needed do {
-                private _building = [] call VIC_fnc_findCampBuilding;
-                if (isNull _building) exitWith {};
-                private _pos = getPosATL _building;
-                [_pos] call VIC_fnc_spawnStalkerCamp;
+        private _last = missionNamespace getVariable ["VIC_lastCampSpawnAttempt", 0];
+        if (diag_tickTime - _last > 120) then {
+            if ((count STALKER_camps) < _min) then {
+                private _needed = _min - (count STALKER_camps);
+                for "_i" from 1 to _needed do {
+                    private _building = [] call VIC_fnc_findCampBuilding;
+                    if (isNull _building) exitWith {};
+                    private _pos = getPosATL _building;
+                    [_pos] call VIC_fnc_spawnStalkerCamp;
+                };
             };
+            missionNamespace setVariable ["VIC_lastCampSpawnAttempt", diag_tickTime];
         };
 
         sleep 6;


### PR DESCRIPTION
## Summary
- randomize each unit class when spawning stalker camps
- silence camp spawn failure logs
- introduce camp site cooldown logic
- throttle camp spawn attempts to every two minutes

## Testing
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/stalkers/fn_spawnStalkerCamp.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/stalkers/fn_findCampBuilding.sqf`
- `sqflint -e w addons/Viceroys-STALKER-ALife/functions/stalkers/fn_startCampManager.sqf`

------
https://chatgpt.com/codex/tasks/task_e_68643e15604c832f8853621d1ce7109d