### PR TITLE
Add per-mutant disable settings

### DIFF
--- a/addons/Viceroys-STALKER-ALife/cba_settings.sqf
+++ b/addons/Viceroys-STALKER-ALife/cba_settings.sqf
@@ -282,6 +282,30 @@
     false
 ] call CBA_fnc_addSetting;
 
+// Individual mutant enable toggles
+["VSA_enableBloodsucker","CHECKBOX",["Enable Bloodsuckers","Allow bloodsucker spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableBoar","CHECKBOX",["Enable Boars","Allow boar spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableCat","CHECKBOX",["Enable Cats","Allow cat spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableFlesh","CHECKBOX",["Enable Flesh","Allow flesh spawns"],"Viceroy's STALKER ALife - Mutants",false] call CBA_fnc_addSetting;
+["VSA_enableBlindDog","CHECKBOX",["Enable Blind Dogs","Allow blind dog spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enablePseudodog","CHECKBOX",["Enable Pseudodogs","Allow pseudodog spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableSnork","CHECKBOX",["Enable Snorks","Allow snork spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableController","CHECKBOX",["Enable Controllers","Allow controller spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enablePseudogiant","CHECKBOX",["Enable Pseudogiants","Allow pseudogiant spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableIzlom","CHECKBOX",["Enable Izlom","Allow izlom spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableCorruptor","CHECKBOX",["Enable Corruptors","Allow corruptor spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableSmasher","CHECKBOX",["Enable Smashers","Allow smasher spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableAcidSmasher","CHECKBOX",["Enable Acid Smashers","Allow acid smasher spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableBehemoth","CHECKBOX",["Enable Behemoths","Allow behemoth spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableParasite","CHECKBOX",["Enable Parasites","Allow parasite spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableJumper","CHECKBOX",["Enable Jumpers","Allow jumper spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableSpitter","CHECKBOX",["Enable Spitters","Allow spitter spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableStalker","CHECKBOX",["Enable Stalkers","Allow stalker mutant spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableBully","CHECKBOX",["Enable Bullies","Allow bully spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableHivemind","CHECKBOX",["Enable Hiveminds","Allow hivemind spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableZombie","CHECKBOX",["Enable Zombies","Allow zombie spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+["VSA_enableChimera","CHECKBOX",["Enable Chimeras","Allow chimera spawns"],"Viceroy's STALKER ALife - Mutants",true] call CBA_fnc_addSetting;
+
 // -----------------------------------------------------------------------------
 // Stalkers
 // -----------------------------------------------------------------------------

--- a/addons/Viceroys-STALKER-ALife/config.cpp
+++ b/addons/Viceroys-STALKER-ALife/config.cpp
@@ -76,6 +76,7 @@ class CfgFunctions
             class spawnSmasherNest{};
             class spawnAcidSmasherNest{};
             class spawnBehemothNest{};
+            class isMutantEnabled{};
             class manageHerds{};
             class manageHostiles{};
             class manageNests{};

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_isMutantEnabled.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_isMutantEnabled.sqf
@@ -1,0 +1,38 @@
+/*
+    Returns true if the specified mutant type is enabled via CBA settings.
+
+    Params:
+        0: STRING - mutant type name (e.g. "Bloodsucker")
+
+    Returns:
+        BOOL - whether the mutant is enabled
+*/
+params ["_type"];
+
+private _setting = switch (_type) do {
+    case "Bloodsucker": {"VSA_enableBloodsucker"};
+    case "Boar": {"VSA_enableBoar"};
+    case "Cat": {"VSA_enableCat"};
+    case "Flesh": {"VSA_enableFlesh"};
+    case "Blind Dog": {"VSA_enableBlindDog"};
+    case "Pseudodog": {"VSA_enablePseudodog"};
+    case "Snork": {"VSA_enableSnork"};
+    case "Controller": {"VSA_enableController"};
+    case "Pseudogiant": {"VSA_enablePseudogiant"};
+    case "Izlom": {"VSA_enableIzlom"};
+    case "Corruptor": {"VSA_enableCorruptor"};
+    case "Smasher": {"VSA_enableSmasher"};
+    case "Acid Smasher": {"VSA_enableAcidSmasher"};
+    case "Behemoth": {"VSA_enableBehemoth"};
+    case "Parasite": {"VSA_enableParasite"};
+    case "Jumper": {"VSA_enableJumper"};
+    case "Spitter": {"VSA_enableSpitter"};
+    case "Stalker": {"VSA_enableStalker"};
+    case "Bully": {"VSA_enableBully"};
+    case "Hivemind": {"VSA_enableHivemind"};
+    case "Zombie": {"VSA_enableZombie"};
+    case "Chimera": {"VSA_enableChimera"};
+    default {""};
+};
+if (_setting isEqualTo "") exitWith { true };
+[_setting, true] call VIC_fnc_getSetting;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_manageHabitats.sqf
@@ -43,6 +43,10 @@ private _getClass = {
 
     _x params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
 
+    if !( [_type] call VIC_fnc_isMutantEnabled ) then {
+        _max = 0; _count = 0;
+    };
+
     if (_near) then {
         if (isNull _grp && {_count > 0}) then {
             private _class = [_type] call _getClass;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_setupMutantHabitats.sqf
@@ -13,6 +13,8 @@ STALKER_mutantHabitatData = [];
 private _createMarker = {
     params ["_type", "_pos"];
 
+    if !( [_type] call VIC_fnc_isMutantEnabled ) exitWith { false };
+
     // Skip this location if it overlaps an existing habitat or anomaly field
     private _overlap = false;
     {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAcidSmasherNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnAcidSmasherNest.sqf
@@ -7,4 +7,8 @@ params ["_pos"];
 
 ["spawnAcidSmasherNest"] call VIC_fnc_debugLog;
 
+if !( ["Acid Smasher"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnAcidSmasherNest exit: Acid Smashers disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "WBK_SpecialZombie_Smasher_Acid_3"] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBehemothNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBehemothNest.sqf
@@ -6,4 +6,9 @@
 params ["_pos"];
 
 ["spawnBehemothNest"] call VIC_fnc_debugLog;
+
+if !( ["Behemoth"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnBehemothNest exit: Behemoths disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "WBK_Goliaph_3"] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBlindDogNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBlindDogNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnBlindDogNest"] call VIC_fnc_debugLog;
 
+if !( ["Blind Dog"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnBlindDogNest exit: Blind Dogs disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_blinddog1", "armst_blinddog2", "armst_blinddog3"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBloodsuckerNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBloodsuckerNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnBloodsuckerNest"] call VIC_fnc_debugLog;
 
+if !( ["Bloodsucker"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnBloodsuckerNest exit: Bloodsuckers disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_krovosos", "armst_krovosos2"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBoarNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnBoarNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnBoarNest"] call VIC_fnc_debugLog;
 
+if !( ["Boar"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnBoarNest exit: Boars disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_boar", "armst_boar2"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCachedHabitats.sqf
@@ -14,6 +14,8 @@ if (isNil "STALKER_mutantHabitats") then { STALKER_mutantHabitats = []; };
 
 private _createMarker = {
     params ["_type", "_pos", "_max"];
+
+    if !( [_type] call VIC_fnc_isMutantEnabled ) exitWith { false };
     private _overlap = false;
     {
         if (_pos distance2D (_x#3) < 300) exitWith { _overlap = true };

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCatNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCatNest.sqf
@@ -7,4 +7,8 @@ params ["_pos"];
 
 ["spawnCatNest"] call VIC_fnc_debugLog;
 
+if !( ["Cat"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnCatNest exit: Cats disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "armst_cat"] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnControllerNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnControllerNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnControllerNest"] call VIC_fnc_debugLog;
 
+if !( ["Controller"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnControllerNest exit: Controllers disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_controller_new", "armst_controller_new2", "armst_controller_new3"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCorruptorNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnCorruptorNest.sqf
@@ -7,4 +7,8 @@ params ["_pos"];
 
 ["spawnCorruptorNest"] call VIC_fnc_debugLog;
 
+if !( ["Corruptor"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnCorruptorNest exit: Corruptors disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "WBK_SpecialZombie_Corrupted_3"] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnFleshNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnFleshNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnFleshNest"] call VIC_fnc_debugLog;
 
+if !( ["Flesh"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnFleshNest exit: Flesh disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_PLOT", "armst_PLOT2"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnHabitatHunters.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnHabitatHunters.sqf
@@ -10,12 +10,13 @@ params ["_player"];
 if (!isServer) exitWith {};
 if (isNil "STALKER_mutantHabitats") exitWith {};
 
-private _habitats = STALKER_mutantHabitats apply {
-    _x params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
-    [_player distance2D _pos, _pos, _type]
-};
-_habitats sort true;
-_habitats = _habitats select [0,5];
+    private _habitats = STALKER_mutantHabitats apply {
+        _x params ["_area","_label","_grp","_pos","_anchor","_type","_max","_count","_near"];
+        [_player distance2D _pos, _pos, _type]
+    };
+    _habitats sort true;
+    _habitats = _habitats select { ([_x#2] call VIC_fnc_isMutantEnabled) };
+    _habitats = _habitats select [0,5];
 
 private _getClass = {
     params ["_type"];

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnIzlomNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnIzlomNest.sqf
@@ -7,4 +7,8 @@ params ["_pos"];
 
 ["spawnIzlomNest"] call VIC_fnc_debugLog;
 
+if !( ["Izlom"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnIzlomNest exit: Izloms disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "armst_izlom"] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPredatorAttack.sqf
@@ -51,6 +51,22 @@ private _rareTypes  = ["goliath","crusher"];
 private _type = if (random 100 < 3) then { selectRandom _rareTypes } else {
     if (_isNight) then { selectRandom _nightTypes } else { selectRandom _dayTypes }
 };
+
+private _mapType = switch (_type) do {
+    case "dog": {"Blind Dog"};
+    case "boar": {"Boar"};
+    case "snork": {"Snork"};
+    case "pseudodog": {"Pseudodog"};
+    case "cat": {"Cat"};
+    case "chimera": {"Chimera"};
+    case "bloodsucker": {"Bloodsucker"};
+    case "goliath": {"Behemoth"};
+    case "crusher": {"Smasher"};
+    default {""};
+};
+if (_mapType != "" && { !( [_mapType] call VIC_fnc_isMutantEnabled ) }) exitWith {
+    [format ["spawnPredatorAttack exit: %1 disabled", _mapType]] call VIC_fnc_debugLog;
+};
 private _grp = createGroup east;
 
 switch (_type) do {

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPseudodogNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPseudodogNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnPseudodogNest"] call VIC_fnc_debugLog;
 
+if !( ["Pseudodog"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnPseudodogNest exit: Pseudodogs disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_pseudodog", "armst_pseudodog2"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPseudogiantNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnPseudogiantNest.sqf
@@ -7,5 +7,9 @@ params ["_pos"];
 
 ["spawnPseudogiantNest"] call VIC_fnc_debugLog;
 
+if !( ["Pseudogiant"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnPseudogiantNest exit: Pseudogiants disabled"] call VIC_fnc_debugLog;
+};
+
 private _classes = ["armst_giant", "armst_giant2"];
 [_pos, selectRandom _classes] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnSmasherNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnSmasherNest.sqf
@@ -7,4 +7,8 @@ params ["_pos"];
 
 ["spawnSmasherNest"] call VIC_fnc_debugLog;
 
+if !( ["Smasher"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnSmasherNest exit: Smashers disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "WBK_SpecialZombie_Smasher_3"] call VIC_fnc_spawnMutantNest;

--- a/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnSnorkNest.sqf
+++ b/addons/Viceroys-STALKER-ALife/functions/mutants/fn_spawnSnorkNest.sqf
@@ -7,4 +7,8 @@ params ["_pos"];
 
 ["spawnSnorkNest"] call VIC_fnc_debugLog;
 
+if !( ["Snork"] call VIC_fnc_isMutantEnabled ) exitWith {
+    ["spawnSnorkNest exit: Snorks disabled"] call VIC_fnc_debugLog;
+};
+
 [_pos, "armst_snork"] call VIC_fnc_spawnMutantNest;


### PR DESCRIPTION
## Summary
- add CBA checkboxes to individually enable or disable specific mutants
- create helper `fn_isMutantEnabled` to read these settings
- skip habitat generation, hunting parties and nests when mutants are disabled
- update predator attack and habitat management logic to honour settings
- disable Flesh spawns by default and fix boolean checks

## Testing
- `./scripts/sqflint-hook.sh $(git diff --name-only HEAD~1 | grep '.sqf$')`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68643d7670e8832fa08ed86cc5104256